### PR TITLE
initial code for building indexes for block data

### DIFF
--- a/openchain/blockchain_indexes.go
+++ b/openchain/blockchain_indexes.go
@@ -1,0 +1,184 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package openchain
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/op/go-logging"
+	"github.com/openblockchain/obc-peer/openchain/db"
+	"github.com/openblockchain/obc-peer/protos"
+	"github.com/tecbot/gorocksdb"
+)
+
+var indexLogger = logging.MustGetLogger("indexes")
+
+var lastIndexedBlockKey = []byte{byte(0)}
+var prefixBlockHashKey = byte(1)
+var prefixTxGUIDKey = byte(2)
+var prefixAddressBlockNumCompositeKey = byte(3)
+
+var lastBlockIndexed uint64
+
+// createIndexes adds entries into db for creating indexes on various atributes
+func createIndexes(block *protos.Block, blockNumber uint64, blockHash []byte) error {
+	openchainDB := db.GetDBHandle()
+	writeBatch := gorocksdb.NewWriteBatch()
+	cf := openchainDB.IndexesCF
+
+	// add blockhash -> blockNumber
+	indexLogger.Debug("Indexing block number [%d] by hash = [%x]", blockNumber, blockHash)
+	writeBatch.PutCF(cf, encodeBlockHashKey(blockHash), encodeBlockNumber(blockNumber))
+
+	addressToTxIndexesMap := make(map[string][]uint64)
+	addressToChainletIDsMap := make(map[string][]*protos.ChainletID)
+
+	transactions := block.GetTransactions()
+	for txIndex, tx := range transactions {
+		// add TxGUID -> (blockNumber,indexWithinBlock)
+		writeBatch.PutCF(cf, encodeTxGUIDKey(getTxGUIDBytes(tx)), encodeBlockNumTxIndex(blockNumber, uint64(txIndex)))
+
+		txExecutingAddress := getTxExecutingAddress(tx)
+		addressToTxIndexesMap[txExecutingAddress] = append(addressToTxIndexesMap[txExecutingAddress], uint64(txIndex))
+
+		switch tx.Type {
+		case protos.Transaction_CHAINLET_NEW, protos.Transaction_CHAINLET_UPDATE:
+			authroizedAddresses, chainletID := getAuthorisedAddresses(tx)
+			for _, authroizedAddress := range authroizedAddresses {
+				addressToChainletIDsMap[authroizedAddress] = append(addressToChainletIDsMap[authroizedAddress], chainletID)
+			}
+		}
+	}
+
+	for address, txsIndexes := range addressToTxIndexesMap {
+		writeBatch.PutCF(cf, encodeAddressBlockNumCompositeKey(address, blockNumber), encodeListTxIndexes(txsIndexes))
+	}
+	writeBatch.PutCF(cf, lastIndexedBlockKey, encodeBlockNumber(blockNumber))
+	opt := gorocksdb.NewDefaultWriteOptions()
+	err := openchainDB.DB.Write(opt, writeBatch)
+	if err != nil {
+		return nil
+	}
+	return nil
+}
+
+func fetchBlockByHash(blockHash []byte) (*protos.Block, error) {
+	blockNumberBytes, err := db.GetDBHandle().GetFromIndexesCF(encodeBlockHashKey(blockHash))
+	if err != nil {
+		return nil, err
+	}
+	blockNumber := decodeBlockNumber(blockNumberBytes)
+	return fetchBlockFromDB(blockNumber)
+}
+
+func fetchTransactionByGUID(txGUID []byte) (*protos.Transaction, error) {
+	blockNumTxIndexBytes, err := db.GetDBHandle().GetFromIndexesCF(encodeTxGUIDKey(txGUID))
+	if err != nil {
+		return nil, err
+	}
+	blockNum, txIndex, err := decodeBlockNumTxIndex(blockNumTxIndexBytes)
+	if err != nil {
+		return nil, err
+	}
+	return fetchTransactionFromDB(blockNum, txIndex)
+}
+
+// fetch TxGUID
+func getTxGUIDBytes(tx *protos.Transaction) (guid []byte) {
+	guid = []byte("TODO:Fetch guid from Tx")
+	return
+}
+
+// encode / decode BlockNumber
+func encodeBlockNumber(blockNumber uint64) []byte {
+	return proto.EncodeVarint(blockNumber)
+}
+
+func decodeBlockNumber(blockNumberBytes []byte) (blockNumber uint64) {
+	blockNumber, _ = proto.DecodeVarint(blockNumberBytes)
+	return
+}
+
+// encode / decode BlockNumTxIndex
+func encodeBlockNumTxIndex(blockNumber uint64, txIndexInBlock uint64) []byte {
+	b := proto.NewBuffer([]byte{})
+	b.EncodeVarint(blockNumber)
+	b.EncodeVarint(txIndexInBlock)
+	return b.Bytes()
+}
+
+func decodeBlockNumTxIndex(bytes []byte) (blockNum uint64, txIndex uint64, err error) {
+	b := proto.NewBuffer(bytes)
+	blockNum, err = b.DecodeVarint()
+	if err != nil {
+		return
+	}
+	txIndex, err = b.DecodeVarint()
+	if err != nil {
+		return
+	}
+	return
+}
+
+// encode BlockHashKey
+func encodeBlockHashKey(blockHash []byte) []byte {
+	return prependKeyPrefix(prefixBlockHashKey, blockHash)
+}
+
+// encode TxGUIDKey
+func encodeTxGUIDKey(guidBytes []byte) []byte {
+	return prependKeyPrefix(prefixTxGUIDKey, guidBytes)
+}
+
+func encodeAddressBlockNumCompositeKey(address string, blockNumber uint64) []byte {
+	b := proto.NewBuffer([]byte{prefixAddressBlockNumCompositeKey})
+	b.EncodeRawBytes([]byte(address))
+	b.EncodeVarint(blockNumber)
+	return b.Bytes()
+}
+
+func encodeListTxIndexes(listTx []uint64) []byte {
+	b := proto.NewBuffer([]byte{})
+	for i := range listTx {
+		b.EncodeVarint(listTx[i])
+	}
+	return b.Bytes()
+}
+
+func encodeChainletID(c *protos.ChainletID) []byte {
+	// TODO serialize chainletID
+	return []byte{}
+}
+
+func getTxExecutingAddress(tx *protos.Transaction) string {
+	// TODO Fetch address form tx
+	return "address1"
+}
+
+func getAuthorisedAddresses(tx *protos.Transaction) ([]string, *protos.ChainletID) {
+	// TODO fetch address from chaincode deployment tx
+	return []string{"address1", "address2"}, tx.GetChainletID()
+}
+
+func prependKeyPrefix(prefix byte, key []byte) []byte {
+	modifiedKey := []byte{}
+	modifiedKey = append(modifiedKey, prefix)
+	modifiedKey = append(modifiedKey, key...)
+	return modifiedKey
+}

--- a/openchain/blockchain_indexes_test.go
+++ b/openchain/blockchain_indexes_test.go
@@ -1,0 +1,116 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package openchain
+
+import (
+	"bytes"
+	"github.com/golang/protobuf/proto"
+	"github.com/openblockchain/obc-peer/protos"
+	"github.com/spf13/viper"
+	"testing"
+)
+
+var chain *Blockchain
+var blocks []*protos.Block
+var setupDone bool
+
+func setup(t *testing.T) {
+	if setupDone {
+		return
+	}
+	viper.Set("peer.db.path", "/tmp/openchain/db")
+	chain = initTestBlockChain(t)
+	blocks, _ = buildSimpleChain(t)
+	setupDone = true
+}
+
+func TestIndexes_GetBlockByBlockNumber(t *testing.T) {
+	setup(t)
+	for i := range blocks {
+		compareProtoMessages(t, getBlock(t, i), blocks[i])
+	}
+}
+
+func TestIndexes_GetBlockByBlockHash(t *testing.T) {
+	setup(t)
+	for i := range blocks {
+		compareProtoMessages(t, getBlockByHash(t, getBlockHash(t, blocks[i])), blocks[i])
+	}
+}
+
+func TestIndexes_GetTransactionByBlockNumberAndIndex(t *testing.T) {
+	setup(t)
+	for i, block := range blocks {
+		for j, tx := range block.GetTransactions() {
+			compareProtoMessages(t, getTransactionByBlockNumberAndIndex(t, i, j), tx)
+		}
+	}
+}
+
+func TestIndexes_GetTransactionByBlockHashAndIndex(t *testing.T) {
+	setup(t)
+	for _, block := range blocks {
+		for j, tx := range block.GetTransactions() {
+			compareProtoMessages(t, getTransactionByBlockHashAndIndex(t, getBlockHash(t, block), j), tx)
+		}
+	}
+}
+
+func getBlockByHash(t *testing.T, blockHash []byte) *protos.Block {
+	chain := getBlockchain(t)
+	block, err := chain.GetBlockByHash(blockHash)
+	if err != nil {
+		t.Fatalf("Error while retrieving block from chain %s", err)
+	}
+	return block
+}
+
+func getTransactionByBlockNumberAndIndex(t *testing.T, blockNumber int, txIndex int) *protos.Transaction {
+	chain := getBlockchain(t)
+	tx, err := chain.GetTransaction(uint64(blockNumber), uint64(txIndex))
+	if err != nil {
+		t.Fatalf("Error in API blockchain.GetTransaction(): %s", err)
+	}
+	return tx
+}
+
+func getTransactionByBlockHashAndIndex(t *testing.T, blockHash []byte, txIndex int) *protos.Transaction {
+	chain := getBlockchain(t)
+	tx, err := chain.GetTransactionByBlockHash(blockHash, uint64(txIndex))
+	if err != nil {
+		t.Fatalf("Error in API blockchain.GetTransaction(): %s", err)
+	}
+	return tx
+}
+
+func compareProtoMessages(t *testing.T, found proto.Message, expected proto.Message) {
+	if bytes.Compare(serializeProtoMessage(t, found), serializeProtoMessage(t, expected)) != 0 {
+		t.Fatalf("Proto messages are not same. Expected = [%s], found = [%s]", expected, found)
+	}
+}
+
+func serializeProtoMessage(t *testing.T, msg proto.Message) []byte {
+	t.Logf("message = [%s]", msg)
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Error while serializing proto message: %s", err)
+	}
+	return data
+}

--- a/openchain/blockchain_test.go
+++ b/openchain/blockchain_test.go
@@ -153,9 +153,9 @@ func buildSimpleChain(t *testing.T) (blocks []*protos.Block, hashes [][]byte) {
 	return allBlocks, allHashes
 }
 
-func checkHash(t *testing.T, hash []byte, expectedStateHash []byte) {
-	if !bytes.Equal(hash, expectedStateHash) {
-		t.Fatalf("State hash in block not same as exepected. Expected=[%x], found=[%x]", expectedStateHash, hash)
+func checkHash(t *testing.T, hash []byte, expectedHash []byte) {
+	if !bytes.Equal(hash, expectedHash) {
+		t.Fatalf("hash is not same as exepected. Expected=[%x], found=[%x]", expectedHash, hash)
 	}
 	t.Logf("Hash value = [%x]", hash)
 }

--- a/openchain/db/db.go
+++ b/openchain/db/db.go
@@ -31,8 +31,9 @@ import (
 const blockchainCF = "blockchainCF"
 const stateCF = "stateCF"
 const statehashCF = "statehashCF"
+const indexesCF = "indexesCF"
 
-var columnfamilies = []string{blockchainCF, stateCF, statehashCF}
+var columnfamilies = []string{blockchainCF, stateCF, statehashCF, indexesCF}
 
 // OpenchainDB encapsulates rocksdb's structures
 type OpenchainDB struct {
@@ -40,6 +41,7 @@ type OpenchainDB struct {
 	BlockchainCF *gorocksdb.ColumnFamilyHandle
 	StateCF      *gorocksdb.ColumnFamilyHandle
 	StateHashCF  *gorocksdb.ColumnFamilyHandle
+	IndexesCF    *gorocksdb.ColumnFamilyHandle
 }
 
 var openchainDB *OpenchainDB
@@ -104,6 +106,10 @@ func (openchainDB *OpenchainDB) GetFromStateHashCF(key []byte) ([]byte, error) {
 	return openchainDB.get(openchainDB.StateHashCF, key)
 }
 
+func (openchainDB *OpenchainDB) GetFromIndexesCF(key []byte) ([]byte, error) {
+	return openchainDB.get(openchainDB.IndexesCF, key)
+}
+
 // GetBlockchainCFIterator get iterator for column family - blockchainCF
 func (openchainDB *OpenchainDB) GetBlockchainCFIterator() *gorocksdb.Iterator {
 	return openchainDB.getIterator(openchainDB.BlockchainCF)
@@ -135,15 +141,15 @@ func openDB() (*OpenchainDB, error) {
 	opts := gorocksdb.NewDefaultOptions()
 	opts.SetCreateIfMissing(false)
 	db, cfHandlers, err := gorocksdb.OpenDbColumnFamilies(opts, dbPath,
-		[]string{"default", blockchainCF, stateCF, statehashCF},
-		[]*gorocksdb.Options{opts, opts, opts, opts})
+		[]string{"default", blockchainCF, stateCF, statehashCF, indexesCF},
+		[]*gorocksdb.Options{opts, opts, opts, opts, opts})
 
 	if err != nil {
 		fmt.Println("Error opening DB", err)
 		return nil, err
 	}
 	isOpen = true
-	return &OpenchainDB{db, cfHandlers[1], cfHandlers[2], cfHandlers[3]}, nil
+	return &OpenchainDB{db, cfHandlers[1], cfHandlers[2], cfHandlers[3], cfHandlers[4]}, nil
 }
 
 // CloseDB releases all column family handles and closes rocksdb


### PR DESCRIPTION
Added code for indexing block information for client queries.
A list of queries is mentioned in issue#42. However, for some of the queries the required information is not yet available in the block/transaction proto structures. Hence, not closing the issue#42 as yet.
