### PR TITLE
Introducing the Openchain REST service

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/openblockchain/obc-peer/openchain"
+	"github.com/openblockchain/obc-peer/openchain/rest"
 	pb "github.com/openblockchain/obc-peer/protos"
 )
 
@@ -236,11 +237,23 @@ func serve() error {
 	// Register the Admin server
 	pb.RegisterAdminServer(grpcServer, openchain.NewAdminServer())
 
-	// Regist ChainletSupport server
+	// Register ChainletSupport server
 	pb.RegisterChainletSupportServer(grpcServer, openchain.NewChainletSupport())
 
-	// Regist Devops server
+	// Register Devops server
 	pb.RegisterDevopsServer(grpcServer, openchain.NewDevopsServer())
+
+	// Register the ServerOpenchain server
+	serverOpenchain, err := openchain.NewOpenchainServer()
+	if err != nil {
+		log.Error("Error creating OpenchainServer: %s", err)
+		return err
+	}
+
+	pb.RegisterOpenchainServer(grpcServer, serverOpenchain)
+
+	// Create and register the REST service
+	go rest.StartOpenchainRESTServer(serverOpenchain)
 
 	rootNode, err := openchain.GetRootNode()
 	if err != nil {

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -13,15 +13,27 @@ cli:
 
 ###############################################################################
 #
+#    REST section
+#
+###############################################################################
+rest:
+
+    # The address that the REST service will listen on for incoming requests.
+    address: 0.0.0.0:5000
+
+
+
+###############################################################################
+#
 #    Peer section
 #
 ###############################################################################
 peer:
-    
+
     # Peeer Version following version semantics as described here http://semver.org/
     # The Peer supplies this version in communications with other Peers
-    version:  0.1.0 
-    
+    version:  0.1.0
+
     # The Peer id is used for identifying this Peer instance.
     id: jdoe
 
@@ -79,7 +91,7 @@ peer:
     discovery:
 
         # The root nodes are used for bootstrapping purposes, and generally supplied through ENV variables
-        rootnode: 
+        rootnode:
 
         ## leaving this in for example of sub map entry
         # testNodes:

--- a/openchain/api.go
+++ b/openchain/api.go
@@ -36,9 +36,14 @@ type ServerOpenchain struct {
 }
 
 // NewOpenchainServer creates a new instance of the ServerOpenchain.
-func NewOpenchainServer() *ServerOpenchain {
-	s := new(ServerOpenchain)
-	return s
+func NewOpenchainServer() (*ServerOpenchain, error) {
+	// Get a handle to the blockchain singleton.
+	bc, err := GetBlockchain()
+	s := &ServerOpenchain{blockchain: bc}
+
+	log.Info("\nCreating new OpenchainServer: %s\n", s.blockchain)
+
+	return s, err
 }
 
 // GetBlockchainInfo returns information about the blockchain ledger such as
@@ -64,7 +69,7 @@ func (s *ServerOpenchain) GetBlockchainInfo(ctx context.Context, e *google_proto
 		return info, nil
 	}
 
-	return nil, fmt.Errorf("Error: No blocks in blockchain.")
+	return nil, fmt.Errorf("No blocks in blockchain.")
 }
 
 // GetBlockByNumber returns the data contained within a specific block in the
@@ -79,7 +84,7 @@ func (s *ServerOpenchain) GetBlockByNumber(ctx context.Context, num *pb.BlockNum
 	if size > 0 {
 		// If the block number requested is not in the blockchain, return error.
 		if num.Number > (size - 1) {
-			return nil, fmt.Errorf("Error: Requested block not in blockchain.")
+			return nil, fmt.Errorf("Requested block not in blockchain.")
 		}
 
 		block, blockErr := s.blockchain.GetBlock(num.Number)
@@ -90,7 +95,7 @@ func (s *ServerOpenchain) GetBlockByNumber(ctx context.Context, num *pb.BlockNum
 		return block, nil
 	}
 
-	return nil, fmt.Errorf("Error: No blocks in blockchain.")
+	return nil, fmt.Errorf("No blocks in blockchain.")
 }
 
 // GetBlockCount returns the current number of blocks in the blockchain data
@@ -107,5 +112,5 @@ func (s *ServerOpenchain) GetBlockCount(ctx context.Context, e *google_protobuf1
 		return count, nil
 	}
 
-	return nil, fmt.Errorf("Error: No blocks in blockchain.")
+	return nil, fmt.Errorf("No blocks in blockchain.")
 }

--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -28,13 +28,20 @@ import (
 )
 
 func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
-	server := NewOpenchainServer()
+	// Must initialize the Blockchain singleton before initializing the
+	// OpenchainServer, as it needs that pointer.
 
 	// Construct a blockchain with 0 blocks.
-	// buildTestChain0 builds a simple blockchain data structure that contains 0
-	// blocks. This chain is created only to verify error conditions, as a
-	// blockchain will always contain at least one block, the genesis block.
+
 	chain0 := initTestBlockChain(t)
+
+	// Initialize the OpenchainServer object.
+	server, err := NewOpenchainServer()
+	if err != nil {
+		t.Logf("Error creating OpenchainServer: %s", err)
+		t.Fail()
+	}
+
 	server.blockchain = chain0
 	t.Logf("Chain 0 => %s", server.blockchain)
 
@@ -51,6 +58,7 @@ func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
 	}
 
 	// Construct a blockchain with 3 blocks.
+
 	chain1 := initTestBlockChain(t)
 	chainErr1 := buildTestChain1(chain1)
 	if chainErr1 != nil {
@@ -71,6 +79,7 @@ func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
 	}
 
 	// Construct a blockchain with 5 blocks.
+
 	chain2 := initTestBlockChain(t)
 	chainErr2 := buildTestChain2(chain2)
 	if chainErr2 != nil {
@@ -93,11 +102,20 @@ func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
 }
 
 func TestServerOpenchain_API_GetBlockByNumber(t *testing.T) {
-	server := NewOpenchainServer()
+	// Must initialize the Blockchain singleton before initializing the
+	// OpenchainServer, as it needs that pointer.
 
 	// Construct a blockchain with 0 blocks.
 
 	chain0 := initTestBlockChain(t)
+
+	// Initialize the OpenchainServer object.
+	server, err := NewOpenchainServer()
+	if err != nil {
+		t.Logf("Error creating OpenchainServer: %s", err)
+		t.Fail()
+	}
+
 	server.blockchain = chain0
 	t.Logf("Chain 0 => %s", server.blockchain)
 
@@ -161,10 +179,20 @@ func TestServerOpenchain_API_GetBlockByNumber(t *testing.T) {
 }
 
 func TestServerOpenchain_API_GetBlockCount(t *testing.T) {
-	server := NewOpenchainServer()
+	// Must initialize the Blockchain singleton before initializing the
+	// OpenchainServer, as it needs that pointer.
 
 	// Construct a blockchain with 0 blocks.
+
 	chain0 := initTestBlockChain(t)
+
+	// Initialize the OpenchainServer object.
+	server, err := NewOpenchainServer()
+	if err != nil {
+		t.Logf("Error creating OpenchainServer: %s", err)
+		t.Fail()
+	}
+
 	server.blockchain = chain0
 	t.Logf("Chain 0 => %s", server.blockchain)
 

--- a/openchain/blockchain.go
+++ b/openchain/blockchain.go
@@ -22,6 +22,7 @@ package openchain
 import (
 	"bytes"
 	"encoding/binary"
+	"strconv"
 
 	"github.com/openblockchain/obc-peer/openchain/db"
 	"github.com/openblockchain/obc-peer/protos"
@@ -225,9 +226,13 @@ func (blockchain *Blockchain) String() string {
 		if blockErr != nil {
 			return ""
 		}
-		buffer.WriteString("\n----------<block>----------\n")
+		buffer.WriteString("\n----------<block #")
+		buffer.WriteString(strconv.FormatUint(i, 10))
+		buffer.WriteString(">----------\n")
 		buffer.WriteString(block.String())
-		buffer.WriteString("\n----------<\\block>----------\n")
+		buffer.WriteString("\n----------<\\block #")
+		buffer.WriteString(strconv.FormatUint(i, 10))
+		buffer.WriteString(">----------\n")
 	}
 	return buffer.String()
 }

--- a/openchain/rest/rest_api.go
+++ b/openchain/rest/rest_api.go
@@ -1,0 +1,137 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"google/protobuf"
+	"log"
+	"net/http"
+	"strconv"
+
+	"golang.org/x/net/context"
+
+	"github.com/gocraft/web"
+	"github.com/spf13/viper"
+
+	oc "github.com/openblockchain/obc-peer/openchain"
+	pb "github.com/openblockchain/obc-peer/protos"
+)
+
+// serverOpenchain is a variable that will be holding the pointer to the
+// underlying ServerOpenchain object. This is necessary due to how gocraft/web
+// implements context initialization.
+var serverOpenchain *oc.ServerOpenchain
+
+// ServerOpenchainREST defines the Openchain REST service object. It exposes
+// the methods available on the ServerOpenchain service through a REST API.
+type ServerOpenchainREST struct {
+	server *oc.ServerOpenchain
+}
+
+// SetOpenchainServer is a middleware function that sets the pointer to the
+// underlying ServerOpenchain object.
+func (s *ServerOpenchainREST) SetOpenchainServer(rw web.ResponseWriter, req *web.Request, next web.NextMiddlewareFunc) {
+	s.server = serverOpenchain
+
+	next(rw, req)
+}
+
+// SetResponseType is a middleware function that sets the appropriate response
+// header. Currently, it is set to "application/json".
+func (s *ServerOpenchainREST) SetResponseType(rw web.ResponseWriter, req *web.Request, next web.NextMiddlewareFunc) {
+	rw.Header().Set("Content-Type", "application/json")
+
+	next(rw, req)
+}
+
+// GetBlockchainInfo returns information about the blockchain ledger such as
+// height, current block hash, and previous block hash.
+func (s *ServerOpenchainREST) GetBlockchainInfo(rw web.ResponseWriter, req *web.Request) {
+	info, err := s.server.GetBlockchainInfo(context.Background(), &google_protobuf.Empty{})
+
+	encoder := json.NewEncoder(rw)
+
+	// Check for error
+	if err != nil {
+		// Failure
+		rw.WriteHeader(400)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+	} else {
+		// Success
+		rw.WriteHeader(200)
+		encoder.Encode(info)
+	}
+}
+
+// GetBlockByNumber returns the data contained within a specific block in the
+// blockchain. The genesis block is block zero.
+func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.Request) {
+	blockNumber, _ := strconv.ParseUint(req.PathParams["id"], 10, 64)
+	block, err := s.server.GetBlockByNumber(context.Background(), &pb.BlockNumber{Number: blockNumber})
+
+	encoder := json.NewEncoder(rw)
+
+	// Check for error
+	if err != nil {
+		// Failure
+		rw.WriteHeader(400)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+	} else {
+		// Success
+		rw.WriteHeader(200)
+		encoder.Encode(block)
+	}
+}
+
+// NotFound returns a custom landing page when a given openchain end point
+// had not been defined.
+func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
+    rw.WriteHeader(http.StatusNotFound)
+    fmt.Fprintf(rw, "{\"Error\": \"Openchain endpoint not found.\"}")
+}
+
+// StartOpenchainRESTServer initializes the REST service and adds the required
+// middleware and routes.
+func StartOpenchainRESTServer(server *oc.ServerOpenchain) {
+	// Initialize the REST service object
+	router := web.New(ServerOpenchainREST{})
+
+	// Record the pointer to the underlying ServerOpenchain object.
+	serverOpenchain = server
+
+	// Add middleware
+	router.Middleware((*ServerOpenchainREST).SetOpenchainServer)
+	router.Middleware((*ServerOpenchainREST).SetResponseType)
+
+	// Add routes
+	router.Get("/chain", (*ServerOpenchainREST).GetBlockchainInfo)
+	router.Get("/chain/blocks/:id", (*ServerOpenchainREST).GetBlockByNumber)
+
+	// Add not found page
+	router.NotFound((*ServerOpenchainREST).NotFound)
+
+	// Start server
+	err := http.ListenAndServe(viper.GetString("rest.address"), router)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}

--- a/openchain/rest/rest_api.json
+++ b/openchain/rest/rest_api.json
@@ -1,0 +1,185 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Openchain API",
+        "description": "Interact with the enterprise Blockchain through Openchain API",
+        "version": "1.0.0"
+    },
+    "host": "127.0.0.1:3000",
+    "schemes": [
+        "http"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/chain": {
+            "get": {
+                "summary": "Blockchain Information",
+                "description": "The Chain endpoint returns information about the current state of\n
+                                the blockchain such as the height, the current block hash, and the\n
+                                previous block hash.\n",
+                "tags": [
+                    "Blockchain"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Blockchain information",
+                        "schema": {
+                          "$ref": "#/definitions/BlockchainInfo"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/chain/blocks/{Block}": {
+            "parameters": [
+              {
+                "name": "Block",
+                "in": "path",
+                "description": "Block number to retrieve",
+                "type": "integer",
+                "required": true,
+              }
+            ],
+            "get": {
+                "summary": "Individual Block Information",
+                "description": "The {Block} endpoint returns information about a specific block\n
+                                within the Blockchain. Note that the genesis block is block zero.\n",
+                "tags": [
+                    "Block"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Individual Block contents",
+                        "schema": {
+                          "$ref": "#/definitions/Block"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "BlockchainInfo": {
+            "type": "object",
+            "properties": {
+                "height": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "description": "Current height of the blockchain."
+                },
+                "currentBlockHash": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Hash of the last block in the blockchain."
+                },
+                "previousBlockHash": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Hash of the previous block in the blockchain."
+                }
+            }
+        },
+        "Block": {
+            "type": "object",
+            "properties": {
+                "proposerID": {
+                    "type": "string",
+                    "description": "Creator/originator of the block."
+                },
+                "Timestamp": {
+                    "type": "string",
+                    "description": "Time of block creation."
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Transaction"
+                    }
+                },
+                "stateHash": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Global state hash after executing all transactions in the block."
+                },
+                "previousBlockHash": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Hash of the previous block in the blockchain."
+                }
+            }
+        },
+        "Transaction": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "UNDEFINED",
+                    "enum":[
+                        "UNDEFINED",
+                        "CHAINLET_NEW",
+                        "CHAINLET_UPDATE",
+                        "CHAINLET_EXECUTE",
+                        "CHAINLET_TERMINATE"
+                    ],
+                    "description": "Transaction type."
+                },
+                "chainletID": {
+                    "$ref": "#/definitions/chainletID",
+                    "description": "Unique Chaincode identifier."
+                },
+                "function": {
+                    "type": "string",
+                    "description": "Function to execute within a Chaincode."
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                   "description": "Arguments supplied to the Chaincode function."
+                },
+                "payload": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Payload supplied for Chaincode function execution."
+                }
+            }
+        },
+        "chainletID": {
+            "type": "object",
+            "properties": {
+                "Url": {
+                    "type": "string",
+                    "description": "URL uniquely identifying a Chaincode."
+                },
+                "Version": {
+                    "type": "string",
+                    "description": "Current version of a Chaincode."
+                }
+            }
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "A descriptive message explaining the cause of error."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
-- Introduce the Openchain REST service, ServerOpenchainREST.
-- Expose two service endpoints: /chain and /chain/blocks/{Block}.
-- Modify main.go and openchain.yaml to incorporate the new REST
service, listening on port 3000.
-- Begin compiling the REST interface documentation in rest_api.json
that will be readable through Swagger.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
