### PR TITLE
Issue 65,66, and 68

### DIFF
--- a/openchain/blockchain.go
+++ b/openchain/blockchain.go
@@ -156,7 +156,7 @@ func (blockchain *Blockchain) GetTransactionByBlockHash(blockHash []byte, txInde
 func (blockchain *Blockchain) AddBlock(ctx context.Context, block *protos.Block) error {
 	block.SetPreviousBlockHash(blockchain.previousBlockHash)
 	state := GetState()
-	stateHash, err := state.GetHash()
+	stateHash, err := state.GetTempStateHash()
 	if err != nil {
 		return err
 	}

--- a/openchain/blockchain.go
+++ b/openchain/blockchain.go
@@ -156,7 +156,7 @@ func (blockchain *Blockchain) GetTransactionByBlockHash(blockHash []byte, txInde
 func (blockchain *Blockchain) AddBlock(ctx context.Context, block *protos.Block) error {
 	block.SetPreviousBlockHash(blockchain.previousBlockHash)
 	state := GetState()
-	stateHash, err := state.GetTempStateHash()
+	stateHash, err := state.GetHash()
 	if err != nil {
 		return err
 	}

--- a/openchain/blockchain_test.go
+++ b/openchain/blockchain_test.go
@@ -175,7 +175,7 @@ func buildTestBlock() *protos.Block {
 }
 
 func buildTestTx() *protos.Transaction {
-	return protos.NewTransaction(protos.ChainletID{"testUrl", "1.1"}, "anyfunction", []string{"param1, param2"})
+	return protos.NewTransaction(protos.ChainletID{Url: "testUrl", Version: "1.1"}, "anyfunction", []string{"param1, param2"})
 }
 
 func checkHash(t *testing.T, hash []byte, expectedHash []byte) {
@@ -187,7 +187,7 @@ func checkHash(t *testing.T, hash []byte, expectedHash []byte) {
 
 func getTestStateHash(t *testing.T) []byte {
 	state := GetState()
-	stateHash, err := state.GetHash()
+	stateHash, err := state.GetTempStateHash()
 	if err != nil {
 		t.Fatalf("Error while getting state hash. Error = [%s]", err)
 	}

--- a/openchain/blockchain_test.go
+++ b/openchain/blockchain_test.go
@@ -25,9 +25,8 @@ import (
 	"testing"
 
 	"github.com/openblockchain/obc-peer/openchain/db"
-	"github.com/spf13/viper"
-
 	"github.com/openblockchain/obc-peer/protos"
+	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
 
@@ -187,7 +186,7 @@ func checkHash(t *testing.T, hash []byte, expectedHash []byte) {
 
 func getTestStateHash(t *testing.T) []byte {
 	state := GetState()
-	stateHash, err := state.GetTempStateHash()
+	stateHash, err := state.GetHash()
 	if err != nil {
 		t.Fatalf("Error while getting state hash. Error = [%s]", err)
 	}

--- a/openchain/ledger.go
+++ b/openchain/ledger.go
@@ -91,7 +91,22 @@ func (ledger *Ledger) RollbackTxBatch(id interface{}) error {
 // GetTempStateHash - Computes state hash by taking into account the state changes that may have taken
 // place during the execution of current transaction-batch
 func (ledger *Ledger) GetTempStateHash() ([]byte, error) {
-	return ledger.state.GetTempStateHash()
+	return ledger.state.GetHash()
+}
+
+// GetState get state for chaincodeID and key. This first looks in memory and if missing, pulls from db
+func (ledger *Ledger) GetState(chaincodeID string, key string) ([]byte, error) {
+	return ledger.state.Get(chaincodeID, key)
+}
+
+// SetState sets state to given value for chaincodeID and key. Does not immideatly writes to memory
+func (ledger *Ledger) SetState(chaincodeID string, key string, value []byte) error {
+	return ledger.state.Set(chaincodeID, key, value)
+}
+
+// DeleteState tracks the deletion of state for chaincodeID and key. Does not immideatly writes to memory
+func (ledger *Ledger) DeleteState(chaincodeID string, key string) error {
+	return ledger.state.Delete(chaincodeID, key)
 }
 
 func (ledger *Ledger) checkValidID(id interface{}) error {

--- a/openchain/ledger.go
+++ b/openchain/ledger.go
@@ -1,0 +1,107 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package openchain
+
+import (
+	"fmt"
+	"github.com/openblockchain/obc-peer/protos"
+	"golang.org/x/net/context"
+	"sync"
+)
+
+// Ledger - the struct for openchain ledger
+type Ledger struct {
+	blockchain *Blockchain
+	state      *State
+	currentID  interface{}
+}
+
+var ledger *Ledger
+var mutex sync.Mutex
+
+// GetLedger - gives a reference to a singleton ledger
+func GetLedger() (*Ledger, error) {
+	if ledger == nil {
+		mutex.Lock()
+		defer mutex.Unlock()
+		if ledger == nil {
+			blockchain, err := GetBlockchain()
+			if err != nil {
+				return nil, err
+			}
+			state := GetState()
+			ledger = &Ledger{blockchain, state, nil}
+		}
+	}
+	return ledger, nil
+}
+
+// BeginTxBatch - gets invoked when next round of transaction-batch execution begins
+func (ledger *Ledger) BeginTxBatch(id interface{}) error {
+	err := ledger.checkValidID(id)
+	if err != nil {
+		return err
+	}
+	ledger.currentID = id
+	return nil
+}
+
+// CommitTxBatch - gets invoked when the current transaction-batch needs to be committed
+// This function returns successfully iff the transactions details and state changes (that
+// may have happened during execution of this transaction-batch) have been committed to permanent storage
+func (ledger *Ledger) CommitTxBatch(id interface{}, transactions []*protos.Transaction, proof []byte) error {
+	err := ledger.checkValidID(id)
+	if err != nil {
+		return err
+	}
+	block := protos.NewBlock("proposerID string", transactions)
+	ledger.blockchain.AddBlock(context.TODO(), block)
+	ledger.resetForNextTxGroup()
+	return nil
+}
+
+// RollbackTxBatch - Descards all the state changes that may have taken place during the execution of
+// current transaction-batch
+func (ledger *Ledger) RollbackTxBatch(id interface{}) error {
+	err := ledger.checkValidID(id)
+	if err != nil {
+		return err
+	}
+	ledger.resetForNextTxGroup()
+	return nil
+}
+
+// GetTempStateHash - Computes state hash by taking into account the state changes that may have taken
+// place during the execution of current transaction-batch
+func (ledger *Ledger) GetTempStateHash() ([]byte, error) {
+	return ledger.state.GetTempStateHash()
+}
+
+func (ledger *Ledger) checkValidID(id interface{}) error {
+	if ledger.currentID != nil {
+		return fmt.Errorf("Another TxGroup [%s] already in-progress", ledger.currentID)
+	}
+	return nil
+}
+
+func (ledger *Ledger) resetForNextTxGroup() {
+	ledger.currentID = nil
+	ledger.state.ClearInMemoryChanges()
+}

--- a/openchain/ledger_test.go
+++ b/openchain/ledger_test.go
@@ -1,0 +1,113 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package openchain
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openblockchain/obc-peer/protos"
+)
+
+func TestLedgerCommit(t *testing.T) {
+	ledger := initTestLedger(t)
+	beginTxBatch(t, 1)
+	ledger.SetState("chaincode1", "key1", []byte("value1"))
+	ledger.SetState("chaincode2", "key2", []byte("value2"))
+	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	transaction := buildTestTx()
+	commitTxBatch(t, 1, []*protos.Transaction{transaction}, []byte("prrof"))
+	if !reflect.DeepEqual(getStateFromLedger(t, "chaincode1", "key1"), []byte("value1")) {
+		t.Fatalf("state value not same after Tx commit")
+	}
+}
+
+func TestLedgerRollback(t *testing.T) {
+	ledger := initTestLedger(t)
+	beginTxBatch(t, 1)
+	ledger.SetState("chaincode1", "key1", []byte("value1"))
+	ledger.SetState("chaincode2", "key2", []byte("value2"))
+	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	rollbackTxBatch(t, 1)
+
+	valueAfterRollback := getStateFromLedger(t, "chaincode1", "key1")
+
+	if valueAfterRollback != nil {
+		t.Logf("Value after rollback = [%s]", valueAfterRollback)
+		t.Fatalf("state value not nil after Tx rollback")
+	}
+}
+
+func TestLedgerDifferentID(t *testing.T) {
+	ledger := initTestLedger(t)
+	ledger.BeginTxBatch(1)
+	ledger.SetState("chaincode1", "key1", []byte("value1"))
+	ledger.SetState("chaincode2", "key2", []byte("value2"))
+	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	transaction := buildTestTx()
+	err := ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("prrof"))
+	if err == nil {
+		t.Fatalf("ledger should throw error")
+	}
+}
+
+func initTestLedger(t *testing.T) *Ledger {
+	initTestBlockChain(t)
+	ledger := getLedger(t)
+	ledger.currentID = nil
+	return ledger
+}
+
+func getLedger(t *testing.T) *Ledger {
+	ledger, err := GetLedger()
+	if err != nil {
+		t.Fatalf("Error while creating a test ledger: %s", err)
+	}
+	return ledger
+}
+
+func getStateFromLedger(t *testing.T, chaincodeID string, key string) []byte {
+	value, err := getLedger(t).GetState(chaincodeID, key)
+	if err != nil {
+		t.Fatalf("Error while getting value from test ledger: %s", err)
+	}
+	return value
+}
+
+func beginTxBatch(t *testing.T, id interface{}) {
+	err := getLedger(t).BeginTxBatch(id)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+}
+
+func commitTxBatch(t *testing.T, id interface{}, transactions []*protos.Transaction, proof []byte) {
+	err := getLedger(t).CommitTxBatch(id, transactions, proof)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+}
+
+func rollbackTxBatch(t *testing.T, id interface{}) {
+	err := getLedger(t).RollbackTxBatch(id)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+}

--- a/openchain/state.go
+++ b/openchain/state.go
@@ -71,9 +71,9 @@ func (state *State) Delete(chaincodeID string, key string) error {
 	return nil
 }
 
-// GetTempStateHash computes new state hash if the stateDelta is to be applied.
+// GetHash computes new state hash if the stateDelta is to be applied.
 // Recomputes only if stateDelta has changed after most recent call to this function
-func (state *State) GetTempStateHash() ([]byte, error) {
+func (state *State) GetHash() ([]byte, error) {
 	if state.recomputeHash {
 		stateLogger.Debug("Recomputing state hash...")
 		hash, err := computeStateHash(state.stateDelta)

--- a/openchain/state.go
+++ b/openchain/state.go
@@ -71,8 +71,9 @@ func (state *State) Delete(chaincodeID string, key string) error {
 	return nil
 }
 
-// GetHash computes state hash, if called for first time or state has changed after most recent call to this function
-func (state *State) GetHash() ([]byte, error) {
+// GetTempStateHash computes new state hash if the stateDelta is to be applied.
+// Recomputes only if stateDelta has changed after most recent call to this function
+func (state *State) GetTempStateHash() ([]byte, error) {
 	if state.recomputeHash {
 		stateLogger.Debug("Recomputing state hash...")
 		hash, err := computeStateHash(state.stateDelta)

--- a/openchain/state_hash.go
+++ b/openchain/state_hash.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/op/go-logging"
 	"github.com/openblockchain/obc-peer/openchain/db"
+	"github.com/openblockchain/obc-peer/openchain/util"
 	"github.com/tecbot/gorocksdb"
-	"golang.org/x/crypto/sha3"
 )
 
 var stateHashLogger = logging.MustGetLogger("stateHash")
@@ -119,7 +119,7 @@ func computeStateHash(stateDelta *stateDelta) (*stateHash, error) {
 			itr.Next()
 		}
 	}
-	statehash.globalHash = computeSha3(buffer)
+	statehash.globalHash = util.ComputeCryptoHash(buffer.Bytes())
 	return statehash, nil
 }
 
@@ -218,7 +218,7 @@ func computeChaincodeHash(changedChaincode *chaincodeStateDelta) ([]byte, error)
 		}
 	}
 	stateHashLogger.Debug("Finished computing state hash for chaincodeID", changedChaincode.chaincodeID)
-	return computeSha3(buffer), nil
+	return util.ComputeCryptoHash(buffer.Bytes()), nil
 }
 
 func getSortedMapKeys1(dict map[string]*valueHolder) []string {
@@ -253,10 +253,4 @@ func decodeStateHashDBKey(dbKey []byte) string {
 
 func compareStrings(str1 string, str2 string) int {
 	return bytes.Compare([]byte(str1), []byte(str2))
-}
-
-func computeSha3(buffer bytes.Buffer) []byte {
-	hash := make([]byte, 64)
-	sha3.ShakeSum256(hash, buffer.Bytes())
-	return hash
 }

--- a/openchain/state_hash_test.go
+++ b/openchain/state_hash_test.go
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 package openchain
 
 import (

--- a/openchain/state_hash_test.go
+++ b/openchain/state_hash_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openblockchain/obc-peer/openchain/db"
+	"github.com/openblockchain/obc-peer/openchain/util"
 )
 
 func TestComputeHash_OnlyInMemoryChanges(t *testing.T) {
@@ -78,11 +79,9 @@ func computeExpectedGlobalHash(hashStr []string) []byte {
 	for i := range hashStr {
 		globalHashBuffer.Write(computeExpectedChaincodeHash(hashStr[i]))
 	}
-	return computeSha3(globalHashBuffer)
+	return util.ComputeCryptoHash(globalHashBuffer.Bytes())
 }
 
 func computeExpectedChaincodeHash(hashStr string) []byte {
-	var buffer bytes.Buffer
-	buffer.Write([]byte(hashStr))
-	return computeSha3(buffer)
+	return util.ComputeCryptoHash([]byte(hashStr))
 }

--- a/openchain/state_test.go
+++ b/openchain/state_test.go
@@ -1,3 +1,22 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
 package openchain
 
 import (

--- a/openchain/util/utils.go
+++ b/openchain/util/utils.go
@@ -1,0 +1,31 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package util
+
+import (
+	"golang.org/x/crypto/sha3"
+)
+
+// ComputeCryptoHash should be used in openchain code so that we can change the actual algo used for crypto-hash at one place
+func ComputeCryptoHash(data []byte) (hash []byte) {
+	hash = make([]byte, 64)
+	sha3.ShakeSum256(hash, data)
+	return
+}

--- a/protos/block.go
+++ b/protos/block.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/op/go-logging"
-
-	"golang.org/x/crypto/sha3"
+	"github.com/openblockchain/obc-peer/openchain/util"
 )
 
 // NewBlock creates a new block with the specified proposer ID, list of,
@@ -56,12 +55,11 @@ func NewBlock(proposerID string, transactions []*Transaction) *Block {
 
 // GetHash returns the hash of this block.
 func (block *Block) GetHash() ([]byte, error) {
-	hash := make([]byte, 64)
 	data, err := block.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("Could not calculate hash of block: %s", err)
 	}
-	sha3.ShakeSum256(hash, data)
+	hash := util.ComputeCryptoHash(data)
 	return hash, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Manish Sethi manishsethi@in.ibm.com
1) openchain/util/utils.go - ComputeCryptoHash() as a single place. So, we can change the actual hash method at one place
2) Transactions and State related functions in a separate interface 'ledger'. Other modules should call GetLedger() and work with this interface only.
closes #65 , closes #66 , and closes #68 
