### PR TITLE
Db create

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -82,7 +82,7 @@ peer:
         validator:
             enabled: false
         leader:
-            address: 
+            address:
 
     # TLS Settings for p2p communications
     tls:

--- a/openchain/db/db_test.go
+++ b/openchain/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
@@ -40,14 +41,14 @@ func TestWriteAndRead(t *testing.T) {
 func TestOpenDB_DirDoesNotExist(t *testing.T) {
 	deleteTestDBPath()
 	defer deleteTestDB()
-	GetDBHandle()
+	performBasicReadWrite(t)
 }
 
 func TestOpenDB_DirEmpty(t *testing.T) {
 	deleteTestDBPath()
 	createTestDBPath()
 	defer deleteTestDB()
-	GetDBHandle()
+	performBasicReadWrite(t)
 }
 
 // db helper functions
@@ -76,7 +77,13 @@ func deleteTestDB() {
 }
 
 func setupTestConfig() {
-	viper.Set("peer.db.path", os.TempDir()+"/openchain/db")
+	viper.SetConfigName("openchain") // name of config file (without extension)
+	viper.AddConfigPath("./../..")   // path to look for the config file in
+	err := viper.ReadInConfig()      // Find and read the config file
+	if err != nil {                  // Handle errors reading the config file
+		panic(fmt.Errorf("Fatal error config file: %s \n", err))
+	}
+
 	deleteTestDBPath()
 }
 


### PR DESCRIPTION
Signed-off-by: Manish Sethi manishsethi@in.ibm.com
db gets created if the db path does not exist on file system or the path is empty.
However, if a non-empty exists, we do not create a db and give control to rocks db. If the path happens to be a valid rocksdb, the db can be used else rocks db throws error (thought, strangely the error from rocks db says that path does not exist)
