### PR TITLE
blocknumber is retrieved from snapshot. Improve test cases. Issue #43

### DIFF
--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -93,6 +93,15 @@ func TestStateSnapshot(t *testing.T) {
 
 	defer snapshot.Release()
 
+	// Modify keys to ensure they do not impact the snapshot
+	beginTxBatch(t, 2)
+	ledger.DeleteState("chaincode1", "key1")
+	ledger.SetState("chaincode4", "key4", []byte("value4"))
+	ledger.SetState("chaincode5", "key5", []byte("value5"))
+	ledger.SetState("chaincode6", "key6", []byte("value6"))
+	transaction, _ = buildTestTx()
+	commitTxBatch(t, 2, []*protos.Transaction{transaction}, []byte("proof"))
+
 	var count = 0
 	for snapshot.Next() {
 		k, v := snapshot.GetRawKeyValue()

--- a/openchain/ledger/state_snapshot_test.go
+++ b/openchain/ledger/state_snapshot_test.go
@@ -23,7 +23,6 @@ import "testing"
 
 func TestSnapshot(t *testing.T) {
 	initTestDB(t)
-	historyStateDeltaSize = 2
 	state := getState()
 
 	state.clearInMemoryChanges()
@@ -53,6 +52,13 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	defer snapshot.Release()
+
+	// Modify keys to ensure they do not impact the snapshot
+	state.clearInMemoryChanges()
+	state.delete("chaincode1", "key8")
+	state.set("chaincode1", "key9", []byte("value9"))
+	state.set("chaincode2", "key10", []byte("value10"))
+	commitTestState(t, 3)
 
 	var count = 0
 	for snapshot.Next() {


### PR DESCRIPTION
Signed-off-by: Sheehan Anderson sheehan@us.ibm.com

Retrieve the block number for the state snapshot from the state snapshot. This ensures that both are in sync.

@manish-sethi - PR is based on your suggestions. Thanks
