### PR TITLE
Introducing REST APIs for Chaincode Build and Chaincode Deploy

### DIFF
--- a/main.go
+++ b/main.go
@@ -312,7 +312,8 @@ func serve() error {
 	pb.RegisterChainletSupportServer(grpcServer, openchain.NewChainletSupport())
 
 	// Register Devops server
-	pb.RegisterDevopsServer(grpcServer, openchain.NewDevopsServer())
+	serverDevops := openchain.NewDevopsServer()
+	pb.RegisterDevopsServer(grpcServer, serverDevops)
 
 	// Register the ServerOpenchain server
 	serverOpenchain, err := openchain.NewOpenchainServer()
@@ -324,7 +325,7 @@ func serve() error {
 	pb.RegisterOpenchainServer(grpcServer, serverOpenchain)
 
 	// Create and register the REST service
-	go rest.StartOpenchainRESTServer(serverOpenchain)
+	go rest.StartOpenchainRESTServer(serverOpenchain, serverDevops)
 
 	rootNode, err := openchain.GetRootNode()
 	if err != nil {

--- a/openchain/api.go
+++ b/openchain/api.go
@@ -31,20 +31,32 @@ import (
 )
 
 // ServerOpenchain defines the Openchain server object, which holds the
-// blockchain data structure.
+// Ledger data structure.
 type ServerOpenchain struct {
 	ledger *ledger.Ledger
 }
 
 // NewOpenchainServer creates a new instance of the ServerOpenchain.
 func NewOpenchainServer() (*ServerOpenchain, error) {
-	// Get a handle to the blockchain singleton.
+	// Get a handle to the Ledger singleton.
 	ledger, err := ledger.GetLedger()
 	if err != nil {
 		return nil, err
 	}
 	s := &ServerOpenchain{ledger: ledger}
-	log.Info("\nCreating new OpenchainServer: %s\n", s.ledger)
+
+	log.Info("\nCreating new OpenchainServer...\n")
+	/*
+		num := ledger.GetBlockchainSize()
+		for i := uint64(0); i < num; i++ {
+			block, err := ledger.GetBlockByNumber(i)
+			if err != nil {
+				log.Info("\nError retrieving block from blockchain: %s\n", err)
+				return nil, err
+			}
+			log.Info("\n\nBlock %d:\n\n%s\n\n", i, block)
+		}
+	*/
 	return s, nil
 }
 

--- a/openchain/devops.go
+++ b/openchain/devops.go
@@ -35,15 +35,15 @@ import (
 
 var devops_logger = logging.MustGetLogger("devops")
 
-func NewDevopsServer() *devops {
-	d := new(devops)
+func NewDevopsServer() *Devops {
+	d := new(Devops)
 	return d
 }
 
-type devops struct {
+type Devops struct {
 }
 
-func (*devops) Build(context context.Context, spec *pb.ChainletSpec) (*pb.ChainletDeploymentSpec, error) {
+func (*Devops) Build(context context.Context, spec *pb.ChainletSpec) (*pb.ChainletDeploymentSpec, error) {
 	devops_logger.Debug("Received build request for chainlet spec: %v", spec)
 	if err := checkSpec(spec); err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (*devops) Build(context context.Context, spec *pb.ChainletSpec) (*pb.Chainl
 	return chainletDeploymentSepc, nil
 }
 
-func (d *devops) Deploy(ctx context.Context, spec *pb.ChainletSpec) (*pb.ChainletDeploymentSpec, error) {
+func (d *Devops) Deploy(ctx context.Context, spec *pb.ChainletSpec) (*pb.ChainletDeploymentSpec, error) {
 	// First build and get the deployment spec
 	chainletDeploymentSepc, err := d.Build(ctx, spec)
 

--- a/openchain/rest/rest_api.go
+++ b/openchain/rest/rest_api.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/gocraft/web"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/spf13/viper"
 
 	oc "github.com/openblockchain/obc-peer/openchain"
@@ -37,20 +38,25 @@ import (
 )
 
 // serverOpenchain is a variable that will be holding the pointer to the
-// underlying ServerOpenchain object. This is necessary due to how gocraft/web
-// implements context initialization.
+// underlying ServerOpenchain object. serverDevops is a variable that will be
+// holding the pointer to the underlying Devops object. This is necessary due to
+// how the gocraft/web package implements context initialization.
 var serverOpenchain *oc.ServerOpenchain
+var serverDevops *oc.Devops
 
 // ServerOpenchainREST defines the Openchain REST service object. It exposes
-// the methods available on the ServerOpenchain service through a REST API.
+// the methods available on the ServerOpenchain service and the Devops service
+// through a REST API.
 type ServerOpenchainREST struct {
 	server *oc.ServerOpenchain
+	devops *oc.Devops
 }
 
 // SetOpenchainServer is a middleware function that sets the pointer to the
-// underlying ServerOpenchain object.
+// underlying ServerOpenchain object and the undeflying Devops object.
 func (s *ServerOpenchainREST) SetOpenchainServer(rw web.ResponseWriter, req *web.Request, next web.NextMiddlewareFunc) {
 	s.server = serverOpenchain
+	s.devops = serverDevops
 
 	next(rw, req)
 }
@@ -112,17 +118,14 @@ func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.R
 	}
 }
 
-// GetState returns the value for the specified chaincode ID and key.
+// GetState returns the value for the specified chaincodeID and key.
 func (s *ServerOpenchainREST) GetState(rw web.ResponseWriter, req *web.Request) {
-
-	// Parse out the chaincode id
+	// Parse out the chaincodeId and key.
 	chaincodeID := req.PathParams["chaincodeId"]
 	key := req.PathParams["key"]
 
-	// Retrieve Block from blockchain
-	val, err := s.server.GetState(context.Background(), chaincodeID, key)
-
-	encoder := json.NewEncoder(rw)
+	// Retrieve Chaincode state.
+	state, err := s.server.GetState(context.Background(), chaincodeID, key)
 
 	// Check for error
 	if err != nil {
@@ -131,9 +134,78 @@ func (s *ServerOpenchainREST) GetState(rw web.ResponseWriter, req *web.Request) 
 		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
 	} else {
 		// Success
-		rw.WriteHeader(200)
-		encoder.Encode(val)
+		if state == nil { // no match on ChaincodeID and key
+			rw.WriteHeader(200)
+			fmt.Fprintf(rw, "{\"State\": \"null\"}")
+		} else {
+			rw.WriteHeader(200)
+			fmt.Fprintf(rw, "{\"State\": \"%s\"}", state)
+		}
 	}
+}
+
+// Build creates the docker container that holds the Chaincode and all required
+// entities.
+func (s *ServerOpenchainREST) Build(rw web.ResponseWriter, req *web.Request) {
+	// Decode the incoming JSON payload
+	var spec pb.ChainletSpec
+	err := jsonpb.Unmarshal(req.Body, &spec)
+
+	// Check for proper JSON syntax
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+		return
+	}
+
+	// Check for nil ChainletSpec
+	if spec.ChainletID == nil {
+		fmt.Fprintf(rw, "{\"Error\": \"Must specify ChainletSpec.\"}")
+		return
+	}
+
+	// Build the ChainletSpec
+	buildResult, err := s.devops.Build(context.Background(), &spec)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+		return
+	}
+
+	encoder := json.NewEncoder(rw)
+	err = encoder.Encode(buildResult)
+}
+
+// Deploy first builds the docker container that holds the Chaincode
+// and then deploys that container to the blockchain.
+func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
+	// Decode the incoming JSON payload
+	var spec pb.ChainletSpec
+	err := jsonpb.Unmarshal(req.Body, &spec)
+
+	// Check for proper JSON syntax
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+		return
+	}
+
+	// Check for nil ChainletSpec
+	if spec.ChainletID == nil {
+		fmt.Fprintf(rw, "{\"Error\": \"Must specify ChainletSpec.\"}")
+		return
+	}
+
+	// Deploy the ChainletSpec
+	deployResult, err := s.devops.Deploy(context.Background(), &spec)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+		return
+	}
+
+	encoder := json.NewEncoder(rw)
+	err = encoder.Encode(deployResult)
 }
 
 // NotFound returns a custom landing page when a given openchain end point
@@ -145,12 +217,13 @@ func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
 
 // StartOpenchainRESTServer initializes the REST service and adds the required
 // middleware and routes.
-func StartOpenchainRESTServer(server *oc.ServerOpenchain) {
+func StartOpenchainRESTServer(server *oc.ServerOpenchain, devops *oc.Devops) {
 	// Initialize the REST service object
 	router := web.New(ServerOpenchainREST{})
 
-	// Record the pointer to the underlying ServerOpenchain object.
+	// Record the pointer to the underlying ServerOpenchain and Devops objects.
 	serverOpenchain = server
+	serverDevops = devops
 
 	// Add middleware
 	router.Middleware((*ServerOpenchainREST).SetOpenchainServer)
@@ -160,6 +233,8 @@ func StartOpenchainRESTServer(server *oc.ServerOpenchain) {
 	router.Get("/chain", (*ServerOpenchainREST).GetBlockchainInfo)
 	router.Get("/chain/blocks/:id", (*ServerOpenchainREST).GetBlockByNumber)
 	router.Get("/state/:chaincodeId/:key", (*ServerOpenchainREST).GetState)
+	router.Post("/devops/build", (*ServerOpenchainREST).Build)
+	router.Post("/devops/deploy", (*ServerOpenchainREST).Deploy)
 
 	// Add not found page
 	router.NotFound((*ServerOpenchainREST).NotFound)


### PR DESCRIPTION
Introducing the REST APIs required to build and deploy a chaincode at
the following service endpoints:

POST host:3000/devops/build
POST host:3000/devops/deploy

Closes #12.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
