### PR TITLE
Support for vendor folder in peer docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,11 @@ vagrant ssh
 
 From within the VM, follow these additional steps.
 
-### Go package dependencies
-You need to manually install some go packages that the peer project is dependent on. Simply view the [Gomfile](./Gomfile) in this directory and see the packages the project depends on. Then simply issue a `go get ...` command for each package listed, and example is shown below:
-
-    go get github.com/spf13/viper
-
 ### Go build
 ```
 cd $GOPATH/src/github.com/openblockchain/obc-peer
 go build
 ```
-
-
 
 ## Run
 

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -47,6 +47,7 @@ peer:
 
     Dockerfile:  |
         from golang:1.5.1
+        ENV GO15VENDOREXPERIMENT=1
         # Install RocksDB
         RUN cd /opt  && git clone --branch v3.13.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
         WORKDIR /opt/rocksdb
@@ -56,12 +57,11 @@ peer:
             libsnappy-dev      \
             zlib1g-dev         \
             libbz2-dev
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go get github.com/tecbot/gorocksdb
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
-        WORKDIR $GOPATH/bin
-        RUN go install github.com/openblockchain/obc-peer && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
+        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
 
     address: 0.0.0.0:30303
@@ -81,7 +81,7 @@ peer:
     consensus:
         validator:
             enabled: false
-        leader:            
+        leader:
             enabled: false
             address:
 
@@ -189,6 +189,7 @@ chainlet:
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chainlet specification.
         Dockerfile:  |
             from golang:1.5.1
+            ENV GO15VENDOREXPERIMENT=1
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 

--- a/openchain/vm.go
+++ b/openchain/vm.go
@@ -235,11 +235,6 @@ func (vm *VM) writeGopathSrc(tw *tar.Writer) error {
 			return nil
 		}
 
-		// Allow only go files and yaml
-		if !(strings.HasSuffix(path, ".go") || strings.HasSuffix(path, ".yaml")) {
-			return nil
-		}
-
 		fr, err := os.Open(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Sheehan Anderson sheehan@us.ibm.com

This PR is for @jeffgarratt 

This MUST be used in conjunction with the PR https://github.com/openblockchain/obc-dev-env/pull/25. 

@jeffgarratt Please test this PR and https://github.com/openblockchain/obc-dev-env/pull/25 before accepting this PR.

After accepting those two PRs, everyone will have to run `vagrant destroy` followed by `vagrant up`
