### PR TITLE
Map incoming requests to digests, closes #88

### DIFF
--- a/openchain/consensus/pbft/pbft_test.go
+++ b/openchain/consensus/pbft/pbft_test.go
@@ -20,6 +20,7 @@ under the License.
 package pbft
 
 import (
+	"bytes"
 	gp "google/protobuf"
 	"testing"
 	"time"
@@ -121,5 +122,48 @@ func TestRecvMsg(t *testing.T) {
 	err = instance.RecvMsg(msg)
 	if err != nil {
 		t.Fatalf("Failed to handle message OpenchainMessage:%s message: %s", msg.Type, err)
+	}
+}
+
+func TestStoreRetrieve(t *testing.T) {
+
+	// Create new algorithm instance.
+	helperInstance := helper.New()
+	instance := New(helperInstance)
+	helperInstance.SetConsenter(instance)
+
+	// Create a `REQUEST` message.
+	reqMsg := &Request2{Payload: []byte("helloworld")}
+	// Marshal it.
+	reqMsgPacked, err := proto.Marshal(reqMsg)
+	if err != nil {
+		t.Fatalf("Error marshalling REQUEST message.")
+	}
+
+	// Get its hash.
+	digest := hashMsg(reqMsgPacked)
+
+	// Store it.
+	count := instance.storeRequest(digest, reqMsg)
+
+	if count != 1 {
+		t.Fatalf("Expected message count in map is 1, instead got: %d", count)
+	}
+
+	t.Logf("Map: %+v\n", instance.msgStore)
+
+	newMsg, err := instance.retrieveRequest(digest)
+	if err != nil {
+		t.Fatalf("Error retrieving REQUEST message from map.")
+	}
+	// Marshal it.
+	newMsgPacked, err := proto.Marshal(newMsg)
+	if err != nil {
+		t.Fatalf("Error marshalling retrieved REQUEST message.")
+	}
+
+	// Are the two messages the same?
+	if !bytes.Equal(reqMsgPacked, newMsgPacked) {
+		t.Logf("Retrieved REQUEST message is not identical to original one.")
 	}
 }


### PR DESCRIPTION
- Added `storeRequest()` and `retrieveRequest()` functions in preparation of #167.
- Added unit tests for said functions.
- Starting to break the body of `RecvMsg()` into smaller, tightly-scoped functions so as to make maintenance more manageable.

Passes all tests.

Signed-off-by: Kostas Christidis `<kchristidis@us.ibm.com>`
