### PR TITLE
Validator: added TransactionPreExecution.

### DIFF
--- a/openchain/crypto/validator/validator.go
+++ b/openchain/crypto/validator/validator.go
@@ -53,10 +53,7 @@ func (validator *Validator) Init() (error) {
 
 // TransactionPreValidation verifies that the transaction is
 // well formed with the respect to the security layer
-// prescriptions (i.e. signature verification)
-// In addition, the method verifies that the validator
-// is allowed to validate the transaction and if this is the case
-// the method decrypts all the relevant fields.
+// prescriptions (i.e. signature verification).
 func (validator *Validator) TransactionPreValidation(tx *pb.Transaction) (*pb.Transaction, error) {
 	if (!validator.isInitialized) {
 		return nil, ErrModuleNotInitialized
@@ -64,3 +61,16 @@ func (validator *Validator) TransactionPreValidation(tx *pb.Transaction) (*pb.Tr
 
 	return tx, nil
 }
+
+// TransactionPreValidation verifies that the transaction is
+// well formed with the respect to the security layer
+// prescriptions (i.e. signature verification). If this is the case,
+// the method prepares the transaction to be executed.
+func (validator *Validator) TransactionPreExecution(tx *pb.Transaction) (*pb.Transaction, error) {
+	if (!validator.isInitialized) {
+		return nil, ErrModuleNotInitialized
+	}
+
+	return tx, nil
+}
+

--- a/openchain/crypto/validator/validator_test.go
+++ b/openchain/crypto/validator/validator_test.go
@@ -43,6 +43,25 @@ func TestInvokeTransactionPreValidation(t *testing.T) {
 	}
 }
 
+func TestDeployTransactionPreExecution(t *testing.T) {
+	res, err := validator.TransactionPreExecution(mockDeployTransaction());
+	if (res == nil) {
+		t.Fatalf("TransactionPreExecution: result must be diffrent from nil")
+	}
+	if (err != nil) {
+		t.Fatalf("TransactionPreExecution: failed pre validing transaction: %s", err)
+	}
+}
+
+func TestInvokeTransactionPreExecution(t *testing.T) {
+	res, err := validator.TransactionPreExecution(mockInvokeTransaction());
+	if (res == nil) {
+		t.Fatalf("TransactionPreExecution: result must be diffrent from nil")
+	}
+	if (err != nil) {
+		t.Fatalf("TransactionPreExecution: failed pre validing transaction: %s", err)
+	}
+}
 
 
 func mockDeployTransaction() (*pb.Transaction) {


### PR DESCRIPTION
A validator is required to call TransactionPreValidation before adding a transaction to the total order.
Before executing a transaction, a validator is required to call TransactionPreExecution.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
