### PR TITLE
Added support for rolling back a tx if chaincode execution fails

### DIFF
--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -23,12 +23,11 @@ import (
 	"bytes"
 	"testing"
 
-	"google/protobuf"
-
 	"github.com/openblockchain/obc-peer/openchain/ledger"
 	"github.com/openblockchain/obc-peer/openchain/util"
 	"github.com/openblockchain/obc-peer/protos"
 	"golang.org/x/net/context"
+	"google/protobuf"
 )
 
 func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
@@ -240,7 +239,9 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	transaction1a := protos.NewTransaction(protos.ChainletID{Url: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
 	// VM runs transaction1a and updates the global state with the result
 	// In this case, the 'Contracts' contract stores 'MyContract1' in its state
+	ledger1.TxBegin(transaction1a.Uuid)
 	ledger1.SetState("MyContract1", "code", []byte("code example"))
+	ledger1.TxFinished(transaction1a.Uuid, true)
 	ledger1.CommitTxBatch(1, []*protos.Transaction{transaction1a}, []byte("dummy-proof"))
 	// -----------------------------</Block #1>-----------------------------------
 
@@ -251,8 +252,10 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	transaction2b := protos.NewTransaction(protos.ChainletID{Url: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 
 	// Run this transction in the VM. The VM updates the state
+	ledger1.TxBegin(transaction2a.Uuid)
 	ledger1.SetState("MyContract", "x", []byte("hello"))
 	ledger1.SetState("MyOtherContract", "y", []byte("goodbuy"))
+	ledger1.TxFinished(transaction2a.Uuid, true)
 
 	// Commit txbatch that creates the 2nd block on blockchain
 	ledger1.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, []byte("dummy-proof"))
@@ -281,7 +284,9 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	transaction1a := protos.NewTransaction(protos.ChainletID{Url: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
 	// VM runs transaction1a and updates the global state with the result
 	// In this case, the 'Contracts' contract stores 'MyContract1' in its state
+	ledger.TxBegin(transaction1a.Uuid)
 	ledger.SetState("MyContract1", "code", []byte("code example"))
+	ledger.TxFinished(transaction1a.Uuid, true)
 	ledger.CommitTxBatch(1, []*protos.Transaction{transaction1a}, []byte("dummy-proof"))
 
 	// -----------------------------</Block #1>-----------------------------------
@@ -293,8 +298,10 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	transaction2b := protos.NewTransaction(protos.ChainletID{Url: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 
 	// Run this transction in the VM. The VM updates the state
+	ledger.TxBegin(transaction2a.Uuid)
 	ledger.SetState("MyContract", "x", []byte("hello"))
 	ledger.SetState("MyOtherContract", "y", []byte("goodbuy"))
+	ledger.TxFinished(transaction2a.Uuid, true)
 
 	// Commit txbatch that creates the 2nd block on blockchain
 	ledger.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, []byte("dummy-proof"))
@@ -306,11 +313,11 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	transaction3a := protos.NewTransaction(protos.ChainletID{Url: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 	transaction3b := protos.NewTransaction(protos.ChainletID{Url: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 	transaction3c := protos.NewTransaction(protos.ChainletID{Url: "MyImportantContract"}, generateUUID(t), "setZ", []string{"{z: \"super\"}"})
-
+	ledger.TxBegin(transaction3a.Uuid)
 	ledger.SetState("MyContract", "x", []byte("hello"))
 	ledger.SetState("MyOtherContract", "y", []byte("goodbuy"))
 	ledger.SetState("MyImportantContract", "z", []byte("super"))
-
+	ledger.TxFinished(transaction3a.Uuid, true)
 	ledger.CommitTxBatch(3, []*protos.Transaction{transaction3a, transaction3b, transaction3c}, []byte("dummy-proof"))
 
 	// -----------------------------</Block #3>-----------------------------------
@@ -327,10 +334,12 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	transaction4d := protos.NewTransaction(protos.ChainletID{Url: "MyMEGAContract"}, generateUUID(t), "setMEGA", []string{"{mega: \"MEGA\"}"})
 
 	// Run this transction in the VM. The VM updates the state
+	ledger.TxBegin(transaction4a.Uuid)
 	ledger.SetState("MyContract", "x", []byte("hello"))
 	ledger.SetState("MyOtherContract", "y", []byte("goodbuy"))
 	ledger.SetState("MyImportantContract", "z", []byte("super"))
 	ledger.SetState("MyMEGAContract", "mega", []byte("MEGA"))
+	ledger.TxFinished(transaction4a.Uuid, true)
 
 	// Create the 4th block and add it to the chain
 	ledger.CommitTxBatch(4, []*protos.Transaction{transaction4a, transaction4b, transaction4c, transaction4d}, []byte("dummy-proof"))

--- a/openchain/chaincode/exectransaction.go
+++ b/openchain/chaincode/exectransaction.go
@@ -32,23 +32,33 @@ import (
 )
 
 //Execute - execute transaction or a query
-func  Execute(ctxt context.Context, chain *ChainletSupport, t *pb.Transaction) ([]byte, error) {
+func Execute(ctxt context.Context, chain *ChainletSupport, t *pb.Transaction) ([]byte, error) {
 	var err error
+
+	// get a handle to ledger to mark the begin/finish of a tx
+	ledger, ledgerErr := ledger.GetLedger()
+	if ledgerErr != nil {
+		return nil, fmt.Errorf("Failed to get handle to ledger (%s)", ledgerErr)
+	}
+
 	if t.Type == pb.Transaction_CHAINLET_NEW {
-		_,err := chain.DeployChaincode(ctxt, t)
+		_, err := chain.DeployChaincode(ctxt, t)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to deploy chaincode spec(%s)", err)
 		}
 
 		//launch and wait for ready
-		_,_,err = chain.LaunchChaincode(ctxt, t)
+		markTxBegin(ledger, t)
+		_, _, err = chain.LaunchChaincode(ctxt, t)
 		if err != nil {
 			//TODO rollback transaction as init might have set state
+			markTxFinish(ledger, t, false)
 			return nil, fmt.Errorf("Failed to launch chaincode spec(%s)", err)
 		}
+		markTxFinish(ledger, t, true)
 	} else if t.Type == pb.Transaction_CHAINLET_EXECUTE || t.Type == pb.Transaction_CHAINLET_QUERY {
 		//will launch if necessary (and wait for ready)
-		cID,cMsg,err := chain.LaunchChaincode(ctxt, t)
+		cID, cMsg, err := chain.LaunchChaincode(ctxt, t)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to launch chaincode spec(%s)", err)
 		}
@@ -56,63 +66,68 @@ func  Execute(ctxt context.Context, chain *ChainletSupport, t *pb.Transaction) (
 		//this should work because it worked above...
 		chaincode, _ := getChaincodeID(cID)
 
-		if(err != nil){
+		if err != nil {
 			return nil, fmt.Errorf("Failed to stablish stream to container %s", chaincode)
 		}
-	
-		// TODO: Need to comment next line and uncomment call to getTimeout, when transaction blocks are being created	
+
+		// TODO: Need to comment next line and uncomment call to getTimeout, when transaction blocks are being created
 		timeout := time.Duration(30000) * time.Millisecond
 		//timeout, err := getTimeout(cID)
-		
-		if(err != nil){
+
+		if err != nil {
 			return nil, fmt.Errorf("Failed to retrieve chaincode spec(%s)", err)
 		}
-		
+
 		var ccMsg *pb.ChaincodeMessage
 		if t.Type == pb.Transaction_CHAINLET_EXECUTE {
-			ccMsg,err = createTransactionMessage(t.Uuid, cMsg)
+			ccMsg, err = createTransactionMessage(t.Uuid, cMsg)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to transaction message(%s)", err)
 			}
 		} else {
-			ccMsg,err = createQueryMessage(t.Uuid, cMsg)
+			ccMsg, err = createQueryMessage(t.Uuid, cMsg)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to query message(%s)", err)
 			}
 		}
 
-		resp,err := chain.Execute(ctxt, chaincode, ccMsg, timeout)
+		markTxBegin(ledger, t)
+		resp, err := chain.Execute(ctxt, chaincode, ccMsg, timeout)
 		if err != nil {
 			//TODO rollback transaction....
+			markTxFinish(ledger, t, false)
 			return nil, fmt.Errorf("Failed to execute transaction(%s)", err)
 		} else if resp == nil {
 			//TODO rollback transaction....
+			markTxFinish(ledger, t, false)
 			return nil, fmt.Errorf("Failed to receive a response for (%s)", t.Uuid)
 		} else {
-			if resp.Type == pb.ChaincodeMessage_COMPLETED || resp.Type == pb.ChaincodeMessage_QUERY_COMPLETED || 
-			   resp.Type == pb.ChaincodeMessage_ERROR || resp.Type == pb.ChaincodeMessage_QUERY_ERROR {
-				return 	resp.Payload, nil
+			if resp.Type == pb.ChaincodeMessage_COMPLETED || resp.Type == pb.ChaincodeMessage_QUERY_COMPLETED ||
+				resp.Type == pb.ChaincodeMessage_ERROR || resp.Type == pb.ChaincodeMessage_QUERY_ERROR {
+				markTxFinish(ledger, t, true)
+				return resp.Payload, nil
 			}
+			markTxFinish(ledger, t, false)
 			return resp.Payload, fmt.Errorf("receive a response for (%s) but in invalid state(%d)", t.Uuid, resp.Type)
 		}
 
 	} else {
 		err = fmt.Errorf("Invalid transaction type %s", t.Type.String())
 	}
-	return  nil,err
+	return nil, err
 }
 
 //ExecuteTransactions - will execute transactions on the array one by one
 //will return an array of errors one for each transaction. If the execution
 //succeeded, array element will be nil. returns state hash
-func  ExecuteTransactions(ctxt context.Context, cname ChainName, xacts []*pb.Transaction) ([]byte, []error) {
+func ExecuteTransactions(ctxt context.Context, cname ChainName, xacts []*pb.Transaction) ([]byte, []error) {
 	var chain = GetChain(cname)
 	if chain == nil {
 		panic(fmt.Sprintf("[ExecuteTransactions]Chain %s not found\n", cname))
 	}
 	errs := make([]error, len(xacts)+1)
 	for i, t := range xacts {
-		_,errs[i] = Execute(ctxt,chain,t)
+		_, errs[i] = Execute(ctxt, chain, t)
 	}
 	ledger, hasherr := ledger.GetLedger()
 	var statehash []byte
@@ -141,6 +156,20 @@ func getTimeout(cID *pb.ChainletID) (time.Duration, error) {
 			}
 		}
 	}
-	
+
 	return -1, errFailedToGetChainCodeSpecForTransaction
+}
+
+func markTxBegin(ledger *ledger.Ledger, t *pb.Transaction) {
+	if t.Type == pb.Transaction_CHAINLET_QUERY {
+		return
+	}
+	ledger.TxBegin(t.Uuid)
+}
+
+func markTxFinish(ledger *ledger.Ledger, t *pb.Transaction, successful bool) {
+	if t.Type == pb.Transaction_CHAINLET_QUERY {
+		return
+	}
+	ledger.TxFinished(t.Uuid, successful)
 }

--- a/openchain/ledger/blockchain_test.go
+++ b/openchain/ledger/blockchain_test.go
@@ -131,8 +131,9 @@ func buildSimpleChain(t *testing.T) (blocks []*protos.Block, hashes [][]byte) {
 
 	// VM runs transaction2a and updates the global state with the result
 	// In this case, the 'Contracts' contract stores 'MyContract1' in its state
+	state.txBegin("transaction2a")
 	state.set("MyContract1", "code", []byte("code example"))
-
+	state.txFinish("transaction2a", true)
 	// Now we add the transaction to the block 2 and add the block to the chain
 	stateHash = getTestStateHash(t)
 	transactions2a := []*protos.Transaction{transaction2a}
@@ -152,7 +153,9 @@ func buildSimpleChain(t *testing.T) (blocks []*protos.Block, hashes [][]byte) {
 	transaction3a := protos.NewTransaction(protos.ChainletID{Url: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 
 	// Run this transction in the VM. The VM updates the state
+	state.txBegin("transaction3a")
 	state.set("MyContract", "x", []byte("hello"))
+	state.txFinish("transaction3a", true)
 
 	// Create the thrid block and add it to the chain
 	transactions3a := []*protos.Transaction{transaction3a}

--- a/openchain/ledger/ledger.go
+++ b/openchain/ledger/ledger.go
@@ -41,7 +41,7 @@ type Ledger struct {
 var ledger *Ledger
 var mutex sync.Mutex
 
-// GetLedger - gives a reference to a singleton ledger
+// GetLedger - gives a reference to a 'singleton' ledger
 func GetLedger() (*Ledger, error) {
 	if ledger == nil {
 		mutex.Lock()
@@ -97,6 +97,17 @@ func (ledger *Ledger) RollbackTxBatch(id interface{}) error {
 	return nil
 }
 
+// TxBegin - Marks the begin of a new transaction in the ongoing batch
+func (ledger *Ledger) TxBegin(txUuid string) {
+	ledger.state.txBegin(txUuid)
+}
+
+// TxFinished - Marks the finish of the on-going transaction.
+// If txSuccessful is false, the state changes made by the transaction are discarded
+func (ledger *Ledger) TxFinished(txUuid string, txSuccessful bool) {
+	ledger.state.txFinish(txUuid, txSuccessful)
+}
+
 /////////////////// world-state related methods /////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////
 
@@ -112,12 +123,12 @@ func (ledger *Ledger) GetState(chaincodeID string, key string, committed bool) (
 	return ledger.state.get(chaincodeID, key, committed)
 }
 
-// SetState sets state to given value for chaincodeID and key. Does not immideatly writes to memory
+// SetState sets state to given value for chaincodeID and key. Does not immideatly writes to DB
 func (ledger *Ledger) SetState(chaincodeID string, key string, value []byte) error {
 	return ledger.state.set(chaincodeID, key, value)
 }
 
-// DeleteState tracks the deletion of state for chaincodeID and key. Does not immideatly writes to memory
+// DeleteState tracks the deletion of state for chaincodeID and key. Does not immideatly writes to DB
 func (ledger *Ledger) DeleteState(chaincodeID string, key string) error {
 	return ledger.state.delete(chaincodeID, key)
 }

--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -37,9 +37,11 @@ func TestMain(m *testing.M) {
 func TestLedgerCommit(t *testing.T) {
 	ledger := InitTestLedger(t)
 	beginTxBatch(t, 1)
+	ledger.TxBegin("txUuid")
 	ledger.SetState("chaincode1", "key1", []byte("value1"))
 	ledger.SetState("chaincode2", "key2", []byte("value2"))
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx()
 	commitTxBatch(t, 1, []*protos.Transaction{transaction}, []byte("prrof"))
 	if !reflect.DeepEqual(getStateFromLedger(t, "chaincode1", "key1"), []byte("value1")) {
@@ -50,9 +52,11 @@ func TestLedgerCommit(t *testing.T) {
 func TestLedgerRollback(t *testing.T) {
 	ledger := InitTestLedger(t)
 	beginTxBatch(t, 1)
+	ledger.TxBegin("txUuid")
 	ledger.SetState("chaincode1", "key1", []byte("value1"))
 	ledger.SetState("chaincode2", "key2", []byte("value2"))
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
 	rollbackTxBatch(t, 1)
 
 	valueAfterRollback := getStateFromLedger(t, "chaincode1", "key1")
@@ -66,9 +70,11 @@ func TestLedgerRollback(t *testing.T) {
 func TestLedgerDifferentID(t *testing.T) {
 	ledger := InitTestLedger(t)
 	ledger.BeginTxBatch(1)
+	ledger.TxBegin("txUuid")
 	ledger.SetState("chaincode1", "key1", []byte("value1"))
 	ledger.SetState("chaincode2", "key2", []byte("value2"))
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx()
 	err := ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("prrof"))
 	if err == nil {
@@ -79,9 +85,11 @@ func TestLedgerDifferentID(t *testing.T) {
 func TestStateSnapshot(t *testing.T) {
 	ledger := InitTestLedger(t)
 	beginTxBatch(t, 1)
+	ledger.TxBegin("txUuid")
 	ledger.SetState("chaincode1", "key1", []byte("value1"))
 	ledger.SetState("chaincode2", "key2", []byte("value2"))
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx()
 	commitTxBatch(t, 1, []*protos.Transaction{transaction}, []byte("proof"))
 
@@ -95,10 +103,12 @@ func TestStateSnapshot(t *testing.T) {
 
 	// Modify keys to ensure they do not impact the snapshot
 	beginTxBatch(t, 2)
+	ledger.TxBegin("txUuid")
 	ledger.DeleteState("chaincode1", "key1")
 	ledger.SetState("chaincode4", "key4", []byte("value4"))
 	ledger.SetState("chaincode5", "key5", []byte("value5"))
 	ledger.SetState("chaincode6", "key6", []byte("value6"))
+	ledger.TxFinished("txUuid", true)
 	transaction, _ = buildTestTx()
 	commitTxBatch(t, 2, []*protos.Transaction{transaction}, []byte("proof"))
 

--- a/openchain/ledger/state_delta.go
+++ b/openchain/ledger/state_delta.go
@@ -56,6 +56,22 @@ func (stateDelta *stateDelta) delete(chaincodeID string, key string) {
 	return
 }
 
+func (stateDelta *stateDelta) applyChanges(anotherStateDelta *stateDelta) {
+	for chaincodeID, chaincodeStateDelta := range anotherStateDelta.chaincodeStateDeltas {
+		for key, valueHolder := range chaincodeStateDelta.updatedKVs {
+			if valueHolder.isDelete() {
+				stateDelta.delete(chaincodeID, key)
+			} else {
+				stateDelta.set(chaincodeID, key, valueHolder.value)
+			}
+		}
+	}
+}
+
+func (stateDelta *stateDelta) isEmpty() bool {
+	return len(stateDelta.chaincodeStateDeltas) == 0
+}
+
 func (stateDelta *stateDelta) getOrCreateChaincodeStateDelta(chaincodeID string) *chaincodeStateDelta {
 	chaincodeStateDelta, ok := stateDelta.chaincodeStateDeltas[chaincodeID]
 	if !ok {

--- a/openchain/ledger/state_delta_test.go
+++ b/openchain/ledger/state_delta_test.go
@@ -43,25 +43,32 @@ func TestStateDeltaPersistence(t *testing.T) {
 	initTestDB(t)
 	historyStateDeltaSize = 2
 	state := getState()
-
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key1", []byte("value1"))
 	state.set("chaincode2", "key2", []byte("value2"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 0)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key3", []byte("value3"))
 	state.set("chaincode2", "key4", []byte("value4"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 1)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key5", []byte("value5"))
 	state.set("chaincode2", "key6", []byte("value6"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 2)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key7", []byte("value7"))
 	state.set("chaincode2", "key8", []byte("value8"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 3)
 
 	// state delta for block# 3

--- a/openchain/ledger/state_snapshot_test.go
+++ b/openchain/ledger/state_snapshot_test.go
@@ -26,23 +26,31 @@ func TestSnapshot(t *testing.T) {
 	state := getState()
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key1", []byte("value1"))
 	state.set("chaincode2", "key2", []byte("value2"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 0)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key3", []byte("value3"))
 	state.set("chaincode2", "key4", []byte("value4"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 1)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key5", []byte("value5"))
 	state.set("chaincode2", "key6", []byte("value6"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 2)
 
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.set("chaincode1", "key7", []byte("value7"))
 	state.set("chaincode2", "key8", []byte("value8"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 3)
 
 	snapshot, err := state.getSnapshot()
@@ -55,9 +63,11 @@ func TestSnapshot(t *testing.T) {
 
 	// Modify keys to ensure they do not impact the snapshot
 	state.clearInMemoryChanges()
+	state.txBegin("txUuid")
 	state.delete("chaincode1", "key8")
 	state.set("chaincode1", "key9", []byte("value9"))
 	state.set("chaincode2", "key10", []byte("value10"))
+	state.txFinish("txUuid", true)
 	commitTestState(t, 3)
 
 	var count = 0


### PR DESCRIPTION
Introduced two methods in Ledger.go. 
TxBegin(txUuid string)  and TxFinished(txUuid string, txSuccessful bool). Any state changes API should be called after calling TxBegin(txUuid string) in order to associate changes with a tx. If txSuccessful flag in TxFinished method is true then only changes made by the tx are retained, otherwise - the changes are discarded.
@srderson Please see if the changes in ledger package looks fine.
@muralisrini Please review that the changes made in exectransaction.go are fine.
