### PR TITLE
Fix transaction unmarshaling bug

### DIFF
--- a/openchain/consensus/pbft/pbft.go
+++ b/openchain/consensus/pbft/pbft.go
@@ -467,10 +467,10 @@ func (instance *Plugin) executeOutstanding() error {
 				instance.id, idx.v, idx.n, digest)
 			instance.lastExec = idx.n
 
-			txBlock := &pb.TransactionBlock{}
-			err := proto.Unmarshal(req.Payload, txBlock)
+			tx := &pb.Transaction{}
+			err := proto.Unmarshal(req.Payload, tx)
 			if err == nil {
-				instance.cpi.ExecTXs(txBlock.Transactions)
+				instance.cpi.ExecTXs([]*pb.Transaction{tx})
 			}
 
 			retry = true

--- a/openchain/consensus/pbft/pbft_test.go
+++ b/openchain/consensus/pbft/pbft_test.go
@@ -308,7 +308,13 @@ func TestNetwork(t *testing.T) {
 	for _, inst := range net.replicas {
 		if len(inst.executed) == 0 {
 			t.Errorf("Instance %d did not execute transaction", inst.id)
-		} else if !reflect.DeepEqual(inst.executed[0], tx) {
+			continue
+		}
+		if len(inst.executed[0]) != 1 {
+			t.Errorf("Instance %d executed more than one transaction", inst.id)
+			continue
+		}
+		if !reflect.DeepEqual(inst.executed[0][0], tx) {
 			t.Errorf("Instance %d executed wrong transaction, %s should be %s",
 				inst.id, inst.executed[0], tx)
 		}


### PR DESCRIPTION
We now need to unmarshal to `Transaction`, not `TransactionBlock`.
Leftover from 1e8fea4.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
