### PR TITLE
deploy command should not be treated as a query

### DIFF
--- a/openchain/consensus/noops/noops.go
+++ b/openchain/consensus/noops/noops.go
@@ -89,8 +89,7 @@ func (i *Noops) RecvMsg(msg *pb.OpenchainMessage) error {
 		// WARNING: We might end up getting the same message sent back to us
 		// due to Byzantine. We ignore this case for the no-ops consensus
 	}
-	// We process the message if it is OpenchainMessage_CONSENSUS or QUERY. For
-	// QUERY, we need to return the result to the caller
+	// We process the message if it is OpenchainMessage_CONSENSUS. ie, all transactions
 	if msg.Type == pb.OpenchainMessage_CONSENSUS {
 		logger.Debug("Handling OpenchainMessage of type: %s ", msg.Type)
 		txs := &pb.TransactionBlock{}
@@ -99,6 +98,7 @@ func (i *Noops) RecvMsg(msg *pb.OpenchainMessage) error {
 			return err
 		}
 		txarr := txs.GetTransactions()
+		logger.Debug("Executing transactions")
 		hash, errs2 := i.cpi.ExecTXs(txarr)
 		//there are n+1 elements of errors in this array. On complete success
 		//they'll all be nil. In particular, the last err will be error in

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -300,7 +300,7 @@ func SendTransactionsToPeer(peerAddress string, transaction *pb.Transaction) *pb
 					return
 				}
 				var ttyp pb.OpenchainMessage_Type
-				if transaction.Type == pb.Transaction_CHAINCODE_EXECUTE {
+				if transaction.Type == pb.Transaction_CHAINCODE_EXECUTE || transaction.Type == pb.Transaction_CHAINCODE_NEW {
 					ttyp = pb.OpenchainMessage_CHAIN_TRANSACTION
 				} else {
 					ttyp = pb.OpenchainMessage_CHAIN_QUERY
@@ -343,7 +343,7 @@ func sendTransactionsToThisPeer(peerAddress string, transaction *pb.Transaction)
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transaction to local peer: %s", err))}
 	}
 	var ttyp pb.OpenchainMessage_Type
-	if transaction.Type == pb.Transaction_CHAINCODE_EXECUTE {
+	if transaction.Type == pb.Transaction_CHAINCODE_EXECUTE || transaction.Type == pb.Transaction_CHAINCODE_NEW {
 		ttyp = pb.OpenchainMessage_CHAIN_TRANSACTION
 	} else {
 		ttyp = pb.OpenchainMessage_CHAIN_QUERY


### PR DESCRIPTION
this completes the work needed for bring up validators with noops and doing transactions and queries with them
