### PR TITLE
removed system wide chain properties into properties per chain. Also …

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,14 +20,14 @@ under the License.
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -335,8 +335,9 @@ func serve(args []string) error {
 	// Register the Admin server
 	pb.RegisterAdminServer(grpcServer, openchain.NewAdminServer())
 
-	// Register ChaincodeSupport server
-	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(peer.GetPeerEndpoint))
+	// Register ChaincodeSupport server...
+	// TODO : not the "DefaultChain" ... we have to revisit when we do multichain
+	registerChaincodeSupport(chaincode.DefaultChain, grpcServer)
 
 	// Register Devops server
 	serverDevops := openchain.NewDevopsServer()
@@ -364,9 +365,6 @@ func serve(args []string) error {
 		return err
 	}
 	logger.Info("Starting peer with id=%s, network id=%s, address=%s, discovery.rootnode=%s, validator=%v", peerEndpoint.ID, viper.GetString("peer.networkId"), peerEndpoint.Address, rootNode, viper.GetBool("peer.consensus.validator.enabled"))
-	if len(args) > 0 && args[0] == "cli" {
-		go doCLI()
-	}
 	grpcServer.Serve(lis)
 	return nil
 }
@@ -396,6 +394,24 @@ func stop() {
 	status, err := serverClient.StopServer(context.Background(), &google_protobuf.Empty{})
 	logger.Info("Current status: %s", status)
 
+}
+
+func registerChaincodeSupport(chainname chaincode.ChainName, grpcServer *grpc.Server) {
+	//get user mode
+	userRunsCC := false
+	if viper.GetString("chaincode.chaincoderunmode") == "user_mode" {
+		userRunsCC = true
+	}
+
+	//get chaincode startup timeout
+	tOut, err := strconv.Atoi(viper.GetString("chaincode.startuptimeout"))
+	if err != nil { //what went wrong ?
+		fmt.Printf("could not retrive timeout var...setting to 5secs\n")
+		tOut = 5000
+	}
+	ccStartupTimeout := time.Duration(tOut) * time.Millisecond
+
+	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chainname, peer.GetPeerEndpoint, userRunsCC, ccStartupTimeout))
 }
 
 func checkChaincodeCmdParams(cmd *cobra.Command) error {
@@ -558,50 +574,6 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) {
 		} else if resp != nil {
 			logger.Info("Trying to print as string: %s", string(resp.Msg))
 			logger.Info("Raw bytes %x", resp.Msg)
-		}
-	}
-}
-
-func doCLI() {
-	wio := bufio.NewWriter(os.Stdout)
-	rio := bufio.NewReader(os.Stdin)
-	help := "deploy <chaincodeid> <version> <funcname> <arg> <arg>...\n"
-	for {
-		wio.WriteString(">")
-		wio.Flush()
-		line, _ := rio.ReadString('\n')
-		if line == "q\n" {
-			break
-		}
-		toks := strings.Split(line, "\n") //get rid of /n
-		toks = strings.Split(toks[0], " ")
-		if toks == nil || len(toks) < 1 {
-			wio.WriteString("invalid input " + line + "\n")
-			continue
-		}
-		if toks[0] == "help" {
-			wio.WriteString(help)
-			continue
-		}
-		switch toks[0] {
-		case "deploy":
-			fallthrough
-		case "d":
-			if len(toks) < 5 {
-				wio.WriteString(help)
-				continue
-			}
-			chaincodeID := toks[1]
-			version := toks[2]
-			spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Url: chaincodeID, Version: version}, CtorMsg: &pb.ChaincodeInput{Function: toks[3], Args: toks[4:]}}
-			_, err := openchain.DeployLocal(context.Background(), spec)
-			if err != nil {
-				wio.WriteString("Error transacting : " + fmt.Sprintf("%s", err) + "\n")
-			} else {
-				wio.WriteString("Success\n")
-			}
-		default:
-			wio.WriteString(help)
 		}
 	}
 }

--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -20,6 +20,7 @@ under the License.
 package openchain
 
 import (
+	"fmt"
 	"bytes"
 	"testing"
 
@@ -28,8 +29,24 @@ import (
 	"github.com/openblockchain/obc-peer/openchain/ledger"
 	"github.com/openblockchain/obc-peer/openchain/util"
 	"github.com/openblockchain/obc-peer/protos"
+	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
+
+func TestMain(m *testing.M) {
+	setupTestConfig()
+}
+
+
+func setupTestConfig() {
+	viper.SetConfigName("openchain") // name of config file (without extension)
+	viper.AddConfigPath("./")   // path to look for the config file in
+	viper.AddConfigPath("./..")   // path to look for the config file in
+	err := viper.ReadInConfig()      // Find and read the config file
+	if err != nil {                  // Handle errors reading the config file
+		panic(fmt.Errorf("Fatal error config file: %s \n", err))
+	}
+}
 
 func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
 	// Construct a ledger with 0 blocks.

--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -48,59 +47,18 @@ const (
 	// DefaultChain is the name of the default chain.
 	DefaultChain ChainName = "default"
 	// DevModeUserRunsChaincode property allows user to run chaincode in development environment
-	DevModeUserRunsChaincode    string = "dev_mode"
-	chaincodeInstallPathDefault string = "/go/bin/"
-	peerAddressDefault          string = "0.0.0.0:30303"
+	DevModeUserRunsChaincode       string = "dev_mode"
+	chaincodeStartupTimeoutDefault int    = 5000
+	chaincodeInstallPathDefault    string = "/go/bin/"
+	peerAddressDefault             string = "0.0.0.0:30303"
 )
 
 // chains is a map between different blockchains and their ChaincodeSupport.
 //this needs to be a first class, top-level object... for now, lets just have a placeholder
 var chains map[ChainName]*ChaincodeSupport
 
-// ccStartupTimeout is the timeout after which deploy will fail.
-var ccStartupTimeout time.Duration
-var chaincodeInstallPath string
-
-// UserRunsCC is true when user is running the chaincode in dev mode and no container is launched.
-var UserRunsCC bool
-
-var peerAddress string
-
 func init() {
-	viper.SetEnvPrefix("OPENCHAIN")
-	viper.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	viper.SetEnvKeyReplacer(replacer)
-	viper.SetConfigName("openchain") // name of config file (without extension)
-	viper.AddConfigPath("./")        // path to look for the config file in
-	viper.AddConfigPath("./../")     // path to look for the config file in
-	viper.AddConfigPath("./../../")  // path to look for the config file in
-	err := viper.ReadInConfig()      // Find and read the config file
-	if err != nil {
-		fmt.Printf("Error reading viper :%s\n", err)
-	}
-
 	chains = make(map[ChainName]*ChaincodeSupport)
-	to, err := strconv.Atoi(viper.GetString("chaincode.startuptimeout"))
-	if err != nil { //what went wrong ?
-		fmt.Printf("could not retrive timeout var...setting to 5secs\n")
-		to = 5000
-	}
-	ccStartupTimeout = time.Duration(to) * time.Millisecond
-
-	mode := viper.GetString("chaincode.chaincoderunmode")
-	if mode == DevModeUserRunsChaincode {
-		UserRunsCC = true
-	} else {
-		UserRunsCC = false
-	}
-
-	chaincodeInstallPath = viper.GetString("chaincode.chaincodeinstallpath")
-	if chaincodeInstallPath == "" {
-		chaincodeInstallPath = chaincodeInstallPathDefault
-	}
-
-	fmt.Printf("chaincode env using [startuptimeout-%d, chaincode run mode-%s]\n", to, mode)
 }
 
 // handlerMap maps chaincodeIDs to their handlers, and maps Uuids to bool
@@ -116,9 +74,9 @@ func GetChain(name ChainName) *ChaincodeSupport {
 }
 
 // NewChaincodeSupport creates a new ChaincodeSupport instance
-func NewChaincodeSupport(getPeerEndpoint func() (*pb.PeerEndpoint, error)) *ChaincodeSupport {
+func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEndpoint, error), userrunsCC bool, ccstartuptimeout time.Duration) *ChaincodeSupport {
 	//we need to pass chainname when we do multiple chains...till then use DefaultChain
-	s := &ChaincodeSupport{name: DefaultChain, handlerMap: &handlerMap{chaincodeMap: make(map[string]*Handler)}}
+	s := &ChaincodeSupport{name: chainname, handlerMap: &handlerMap{chaincodeMap: make(map[string]*Handler)}}
 
 	//initialize global chain
 	chains[DefaultChain] = s
@@ -126,16 +84,23 @@ func NewChaincodeSupport(getPeerEndpoint func() (*pb.PeerEndpoint, error)) *Chai
 	peerEndpoint, err := getPeerEndpoint()
 	if err != nil {
 		chaincodeLog.Error(fmt.Sprintf("Error getting PeerEndpoint, using peer.address: %s", err))
-		peerAddress = viper.GetString("peer.address")
+		s.peerAddress = viper.GetString("peer.address")
 	} else {
-		peerAddress = peerEndpoint.Address
+		s.peerAddress = peerEndpoint.Address
 	}
-	chaincodeLog.Info("Chaincode support using peerAddress: %s\n", peerAddress)
+	chaincodeLog.Info("Chaincode support using peerAddress: %s\n", s.peerAddress)
 	//peerAddress = viper.GetString("peer.address")
 	// peerAddress = viper.GetString("peer.address")
-	if peerAddress == "" {
-		peerAddress = peerAddressDefault
+	if s.peerAddress == "" {
+		s.peerAddress = peerAddressDefault
 	}
+
+	s.userRunsCC = userrunsCC
+
+	s.ccStartupTimeout = ccstartuptimeout
+
+	//TODO I'm not sure if this needs to be on a per chain basis... too lowel and just needs to be a global default ?
+	s.chaincodeInstallPath = chaincodeInstallPathDefault
 
 	return s
 }
@@ -148,8 +113,12 @@ func NewChaincodeSupport(getPeerEndpoint func() (*pb.PeerEndpoint, error)) *Chai
 
 // ChaincodeSupport responsible for providing interfacing with chaincodes from the Peer.
 type ChaincodeSupport struct {
-	name       ChainName
-	handlerMap *handlerMap
+	name                 ChainName
+	handlerMap           *handlerMap
+	peerAddress          string
+	ccStartupTimeout     time.Duration
+	chaincodeInstallPath string
+	userRunsCC           bool
 }
 
 // DuplicateChaincodeHandlerError returned if attempt to register same chaincodeID while a stream already exists.
@@ -310,7 +279,7 @@ func (chaincodeSupport *ChaincodeSupport) launchAndWaitForRegister(context conte
 		if !ok {
 			err = fmt.Errorf("registration failed for %s(tx:%s)", vmname, uuid)
 		}
-	case <-time.After(ccStartupTimeout):
+	case <-time.After(chaincodeSupport.ccStartupTimeout):
 		err = fmt.Errorf("Timeout expired while starting chaincode %s(tx:%s)", vmname, uuid)
 		chaincodeSupport.handlerMap.Lock()
 		delete(chaincodeSupport.handlerMap.chaincodeMap, chaincode)
@@ -403,7 +372,7 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 	chaincodeSupport.handlerMap.Unlock()
 
 	//from here on : if we launch the container and get an error, we need to stop the container
-	if !UserRunsCC {
+	if !chaincodeSupport.userRunsCC {
 		_, err = chaincodeSupport.launchAndWaitForRegister(context, cID, t.Uuid)
 		if err != nil {
 			chaincodeLog.Debug("launchAndWaitForRegister failed %s", err)
@@ -413,7 +382,7 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 
 	if err == nil {
 		//send init (if (f,args)) and wait for ready state
-		err = chaincodeSupport.sendInitOrReady(context, t.Uuid, chaincode, f, initargs, ccStartupTimeout)
+		err = chaincodeSupport.sendInitOrReady(context, t.Uuid, chaincode, f, initargs, chaincodeSupport.ccStartupTimeout)
 		if err != nil {
 			chaincodeLog.Debug("sending init failed(%s)", err)
 			err = fmt.Errorf("Failed to init chaincode(%s)", err)
@@ -432,7 +401,7 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 
 // DeployChaincode deploys the chaincode if not in development mode where user is running the chaincode.
 func (chaincodeSupport *ChaincodeSupport) DeployChaincode(context context.Context, t *pb.Transaction) (*pb.ChaincodeDeploymentSpec, error) {
-	if UserRunsCC {
+	if chaincodeSupport.userRunsCC {
 		chaincodeLog.Debug("command line, not deploying chaincode")
 		return nil, nil
 	}
@@ -463,7 +432,7 @@ func (chaincodeSupport *ChaincodeSupport) DeployChaincode(context context.Contex
 	//openchain.yaml in the container likely will not have the right url:version. We know the right
 	//values, lets construct and pass as envs
 	var targz io.Reader = bytes.NewBuffer(cds.CodePackage)
-	envs := []string{"OPENCHAIN_CHAINCODE_ID_URL=" + cID.Url, "OPENCHAIN_CHAINCODE_ID_VERSION=" + cID.Version, "OPENCHAIN_PEER_ADDRESS=" + peerAddress}
+	envs := []string{"OPENCHAIN_CHAINCODE_ID_URL=" + cID.Url, "OPENCHAIN_CHAINCODE_ID_VERSION=" + cID.Version, "OPENCHAIN_PEER_ADDRESS=" + chaincodeSupport.peerAddress}
 	toks := strings.Split(vmname, ":")
 	if toks == nil {
 		return cds, fmt.Errorf("cannot get version from %s", vmname)
@@ -478,7 +447,7 @@ func (chaincodeSupport *ChaincodeSupport) DeployChaincode(context context.Contex
 	//       need to revisit executable name assignment
 	//e.g, for path github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example01
 	//     exec is "chaincode_example01"
-	exec := []string{chaincodeInstallPath + toks[len(toks)-1]}
+	exec := []string{chaincodeSupport.chaincodeInstallPath + toks[len(toks)-1]}
 	chaincodeLog.Debug("Executable is %s", exec[0])
 
 	cir := &container.CreateImageReq{ID: vmname, Args: exec, Reader: targz, Env: envs}

--- a/openchain/chaincode/exectransaction_test.go
+++ b/openchain/chaincode/exectransaction_test.go
@@ -110,7 +110,7 @@ func TestExecuteDeployTransaction(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress = "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:40303"
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
 		t.Fail()
@@ -118,10 +118,12 @@ func TestExecuteDeployTransaction(t *testing.T) {
 		return
 	}
 
-	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport())
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+	    return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer" }, Address: peerAddress}, nil
+	}
 
-	//Override UserRunsCC if set to true
-	UserRunsCC = false
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout))
 
 	go grpcServer.Serve(lis)
 
@@ -217,7 +219,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress = "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:40303"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -226,10 +228,12 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 		return
 	}
 
-	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport())
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+	    return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer" }, Address: peerAddress}, nil
+	}
 
-	//Override UserRunsCC if set to true
-	UserRunsCC = false
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout))
 
 	go grpcServer.Serve(lis)
 
@@ -319,7 +323,7 @@ func TestExecuteQuery(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress = "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:40303"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -328,10 +332,12 @@ func TestExecuteQuery(t *testing.T) {
 		return
 	}
 
-	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport())
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+	    return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer" }, Address: peerAddress}, nil
+	}
 
-	//Override UserRunsCC if set to true
-	UserRunsCC = false
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout))
 
 	go grpcServer.Serve(lis)
 


### PR DESCRIPTION
…added viper config to api_test (it appears to have been leaning on viper config being read from chaincode. When chaincode properties were passed in api_test lost config properties) 
