### PR TITLE
Add delta state check for tx/issue/249

### DIFF
--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -252,6 +252,11 @@ type ChaincodeMessage struct {
 	Timestamp *google_protobuf.Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp,omitempty"`
 	Payload   []byte                     `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
 	Uuid      string                     `protobuf:"bytes,4,opt,name=uuid" json:"uuid,omitempty"`
+	// need this to distinguish between ERROR to be sent
+	// to validator vs ERROR received from it (probably
+	// better done with another state but don't want to
+	// disturb the FSM right now)
+	SendError bool `protobuf:"varint,5,opt,name=sendError" json:"sendError,omitempty"`
 }
 
 func (m *ChaincodeMessage) Reset()         { *m = ChaincodeMessage{} }

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -123,6 +123,11 @@ message ChaincodeMessage {
     google.protobuf.Timestamp timestamp = 2;
     bytes payload = 3;
     string uuid = 4;
+    //need this to distinguish between ERROR to be sent
+    //to validator vs ERROR received from it (probably
+    //better done with another state but don't want to
+    //disturb the FSM right now)
+    bool sendError = 5;
 
 }
 


### PR DESCRIPTION
One thing to bring up attention to ... 

Added a "bool sendError = 5;" field to ChaincodeMessage in chaincode.proto. It was needed to fix a bug where the "ERROR" state needed to be distinguished between ERROR received by the chaincode from the validator vs ERROR to be sent to the validator. 

Adding the field in ChaincodeMessage didn't feel the right thing to do. A cleaner alternative would be to do it with a new error state, but did not want to disturb the state machine right now.  Also, ChaincodeMessage is an internal communication structure anyway, so its not too bad. We should clean this up at some point
