### PR TITLE
make TestExecuteInvokeInvalidTransaction use /var/openchain/tmpdb

### DIFF
--- a/openchain/chaincode/exectransaction_test.go
+++ b/openchain/chaincode/exectransaction_test.go
@@ -440,6 +440,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
 	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.db.path", "/var/openchain/tmpdb")
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go


### PR DESCRIPTION
need to make this test cases use tmpdb like other testcases do now
