### PR TITLE
Change host port to match rest port in openchain.yaml

### DIFF
--- a/openchain/rest/rest_api.json
+++ b/openchain/rest/rest_api.json
@@ -5,7 +5,7 @@
         "description": "Interact with the enterprise Blockchain through Openchain API",
         "version": "1.0.0"
     },
-    "host": "127.0.0.1:3000",
+    "host": "127.0.0.1:5000",
     "schemes": [
         "http"
     ],


### PR DESCRIPTION
The rest service port for the peer defaults to 5000 via the openchain.yaml. The rest_api.json looks for the service on port 3000. 
