### PR TITLE
implement --peer-chaincodedev option

### DIFF
--- a/docs/SandboxSetup.md
+++ b/docs/SandboxSetup.md
@@ -10,20 +10,16 @@ Go to obc-peer directory:
 
     cd $GOPATH/src/github.com/openblockchain/obc-peer
 
-Edit openchain.yaml to set the peer mode “mode” to “dev”, as shown below:
+Also edit openchain.yaml to set the “mode” to “dev” under the "chaincode" property, as shown below:
 
-	 mode: dev
-
-Also edit openchain.yaml to set the “chaincoderunmode” to “dev_mode”, as shown below:
-
-    chaincoderunmode: dev_mode
+    mode: dev
 
 This will run the chaincode independent of the validating peers. We need 3 terminal windows: the first terminal runs the validating peer; the second terminal runs the chaincode; and the third terminal runs the CLI (or REST API) to execute transactions.
 
 ###Window 1 (validating peer)
 Run obc-peer:
 
-    ./obc-peer peer
+    ./obc-peer peer --peer-chaincodedev
 
 ###Window 2 (chaincode)
 Use the example chaincode_example02 provided in the source code repository and build it:

--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func serve(args []string) error {
 		logger.Debug("In chaincode development mode [consensus - noops, chaincode run by - user, peer mode - validator]")
 		viper.Set("peer.validator.enabled", "true")
 		viper.Set("peer.validator.consensus", "noops")
-		viper.Set("chaincode.chaincoderunmode", chaincode.DevModeUserRunsChaincode)
+		viper.Set("chaincode.mode", chaincode.DevModeUserRunsChaincode)
 	}
 
 	var opts []grpc.ServerOption
@@ -354,7 +354,7 @@ func stop() {
 func registerChaincodeSupport(chainname chaincode.ChainName, grpcServer *grpc.Server) {
 	//get user mode
 	userRunsCC := false
-	if viper.GetString("chaincode.chaincoderunmode") == chaincode.DevModeUserRunsChaincode {
+	if viper.GetString("chaincode.mode") == chaincode.DevModeUserRunsChaincode {
 		userRunsCC = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ var (
 	chaincodeCtorJSON string
 	chaincodePath     string
 	chaincodeVersion  string
+	chaincodeDevMode  bool
 )
 
 var chaincodeCmd = &cobra.Command{
@@ -189,13 +190,16 @@ func main() {
 	flags.Int("peer-gomaxprocs", 2, "The maximum number threads excuting peer code")
 	flags.Bool("peer-discovery-enabled", true, "Whether peer discovery is enabled")
 
+	flags.BoolVarP(&chaincodeDevMode, "peer-chaincodedev", "", false, "Whether peer in chaincode development mode")
+
 	viper.BindPFlag("peer_logging_level", flags.Lookup("peer-logging-level"))
 	viper.BindPFlag("peer_tls_enabled", flags.Lookup("peer-tls-enabled"))
 	viper.BindPFlag("peer_tls_cert_file", flags.Lookup("peer-tls-cert-file"))
 	viper.BindPFlag("peer_tls_key_file", flags.Lookup("peer-tls-key-file"))
-	viper.BindPFlag("peer_port", flags.Lookup("peer-ports"))
+	viper.BindPFlag("peer_port", flags.Lookup("peer-port"))
 	viper.BindPFlag("peer_gomaxprocs", flags.Lookup("peer-gomaxprocs"))
 	viper.BindPFlag("peer_discovery_enabled", flags.Lookup("peer-discovery-enabled"))
+
 
 	// Now set the configuration file.
 	viper.SetConfigName(cmdRoot) // Name of config file (without extension)
@@ -250,6 +254,13 @@ func serve(args []string) error {
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}
+	if chaincodeDevMode {
+		logger.Debug("In chaincode development mode [consensus - noops, chaincode run by - user, peer mode - validator]")
+		viper.Set("peer.validator.enabled", "true")
+		viper.Set("peer.validator.consensus", "noops")
+		viper.Set("chaincode.chaincoderunmode", chaincode.DevModeUserRunsChaincode)
+	}
+
 	var opts []grpc.ServerOption
 	if viper.GetBool("peer.tls.enabled") {
 		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
@@ -258,17 +269,15 @@ func serve(args []string) error {
 		}
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
+
 	grpcServer := grpc.NewServer(opts...)
 
 	// Register the Peer server
 	//pb.RegisterPeerServer(grpcServer, openchain.NewPeer())
 	var peerServer *peer.Peer
 
-	if viper.GetString("peer.mode") == "dev" {
-		logger.Debug("Running in DEV mode, using NOOPS handler factory")
-		peerServer, _ = peer.NewPeerWithHandler(helper.NewConsensusHandler)
-	} else if viper.GetBool("peer.validator.enabled") {
-		logger.Debug("Installing consensus message handler")
+	if viper.GetBool("peer.validator.enabled") {
+		logger.Debug("Running as validator - installing consensus %s", viper.GetString("peer.validator.consensus"))
 		peerServer, _ = peer.NewPeerWithHandler(helper.NewConsensusHandler)
 	} else {
 		logger.Debug("Running as peer")

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -37,9 +37,6 @@ peer:
     # The Peer id is used for identifying this Peer instance.
     id: jdoe
 
-    # Mode the Peer is to run in, one of [dev|production]
-    mode: production
-
     # The privateKey to be used by this peer
     privateKey: 794ef087680e2494fa4918fd8fb80fb284b50b57d321a31423fe42b9ccf6216047cea0b66fe8365a8e3f2a8140c6866cc45852e63124668bee1daa9c97da0c2a
 

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -206,10 +206,10 @@ chaincode:
     #timeout for starting up a container and waiting for Register to come through
     startuptimeout: 20000
 
-    #chaincoderunmode - options are "dev_mode", "net_mode"
-    #dev_mode - in dev mode, user runs the chaincode after starting validator from command line on local machine
-    #net_mode - in net mode validator will run chaincode in a docker container
+    #mode - options are "dev", "net"
+    #dev - in dev mode, user runs the chaincode after starting validator from command line on local machine
+    #net - in net mode validator will run chaincode in a docker container
 
-    chaincoderunmode: net_mode
+    mode: net
 
-    chaincodeinstallpath: /go/bin/
+    installpath: /go/bin/

--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -47,7 +47,7 @@ const (
 	// DefaultChain is the name of the default chain.
 	DefaultChain ChainName = "default"
 	// DevModeUserRunsChaincode property allows user to run chaincode in development environment
-	DevModeUserRunsChaincode       string = "dev_mode"
+	DevModeUserRunsChaincode       string = "dev"
 	chaincodeStartupTimeoutDefault int    = 5000
 	chaincodeInstallPathDefault    string = "/go/bin/"
 	peerAddressDefault             string = "0.0.0.0:30303"

--- a/openchain/chaincode/handler.go
+++ b/openchain/chaincode/handler.go
@@ -187,7 +187,7 @@ func (handler *Handler) notifyDuringStartup(val bool) {
 		handler.readyNotify <- val
 		chaincodeLogger.Debug("Notified during startup")
 	} else {
-		chaincodeLogger.Debug("readyNotify is nil!!!!")
+		chaincodeLogger.Debug("nothing to notify (dev mode ?)")
 	}
 }
 

--- a/openchain/consensus/controller/controller.go
+++ b/openchain/consensus/controller/controller.go
@@ -45,10 +45,6 @@ func init() {
 // NewConsenter constructs a consenter object.
 // Called by handler.NewConsensusHandler().
 func NewConsenter(cpi consensus.CPI) consensus.Consenter {
-	if viper.GetString("peer.mode") == "dev" {
-		return noops.New(cpi)
-	}
-
 	plugin := viper.GetString("peer.validator.consensus")
 	var algo consensus.Consenter
 	if plugin == "pbft" {

--- a/openchain/devops.go
+++ b/openchain/devops.go
@@ -51,7 +51,7 @@ type Devops struct {
 
 // Build builds the supplied chaincode image
 func (*Devops) Build(context context.Context, spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
-	mode := viper.GetString("chaincode.chaincoderunmode")
+	mode := viper.GetString("chaincode.mode")
 	var codePackageBytes []byte
 	if mode != chaincode.DevModeUserRunsChaincode {
 		devopsLogger.Debug("Received build request for chaincode spec: %v", spec)
@@ -95,7 +95,7 @@ func (d *Devops) Deploy(ctx context.Context, spec *pb.ChaincodeSpec) (*pb.Chainc
 	if err != nil {
 		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
 	}
-	//mode := viper.GetString("chaincode.chaincoderunmode")
+	//mode := viper.GetString("chaincode.mode")
 
 	//if mode == chaincode.DevModeUserRunsChaincode {
 	//	_, execErr := chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
@@ -141,7 +141,7 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
 	}
 
-	// mode := viper.GetString("chaincode.chaincoderunmode")
+	// mode := viper.GetString("chaincode.mode")
 
 	// //in dev mode, we invoke locally (whether user runs chaincode or validator does)
 	// if mode == chaincode.DevModeUserRunsChaincode {
@@ -223,7 +223,7 @@ func pathExists(path string) (bool, error) {
 //BuildLocal builds a given chaincode code
 func BuildLocal(context context.Context, spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
 	devopsLogger.Debug("Received build request for chaincode spec: %v", spec)
-	mode := viper.GetString("chaincode.chaincoderunmode")
+	mode := viper.GetString("chaincode.mode")
 	var codePackageBytes []byte
 	if mode != chaincode.DevModeUserRunsChaincode {
 		if err := checkSpec(spec); err != nil {

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -451,7 +451,7 @@ func (p *Peer) handleChat(ctx context.Context, stream ChatStream, initiatedStrea
 //The address to stream requests to
 func getValidatorStreamAddress() string {
 	var localaddr = viper.GetString("peer.address")
-	if viper.GetString("peer.mode") == "dev" { //in dev mode, we have the "noops" validator
+	if viper.GetBool("peer.validator.enabled") { //in validator mode, send your own address
 		return localaddr
 	} else if valaddr := viper.GetString("peer.discovery.rootnode"); valaddr != "" {
 		return valaddr
@@ -463,8 +463,7 @@ func getValidatorStreamAddress() string {
 func ExecuteTransaction(transaction *pb.Transaction) *pb.Response {
 	peerAddress := getValidatorStreamAddress()
 	var response *pb.Response
-	if viper.GetString("peer.mode") == "dev" {
-		//TODO in dev mode, we have to do something else
+	if viper.GetBool("peer.validator.enabled") { //send gRPC request to yourself
 		response = sendTransactionsToThisPeer(peerAddress, transaction)
 
 	} else {


### PR DESCRIPTION
@jeffgarratt , @binhn 

Implemented --peer-chaincodedev mode option. With this option we no longer need a "peer.mode" property in openchain.yaml. The option sets the following properties to put the peer in "chaincode developer" mode
                 "peer.validator.enabled" - true
                 "peer.validator.consensus" -  "noops"
                 "chaincode.chaincoderunmode" -  "dev_mode"

Also peer.validator.enabled is used in peer.go to determine of a request needs to be looped back or sent to a validator. With this change, the following configurations appear to work correctly
               CLI -> VP -> 3 VPs
               CLI -> NVP -> 4 VPs
