### PR TITLE
kill and remove containers in addition to stopping - issue #327

### DIFF
--- a/openchain/container/controller_test.go
+++ b/openchain/container/controller_test.go
@@ -155,7 +155,7 @@ func TestVMCStartContainer(t *testing.T) {
 	//wait for VMController to complete.
 	fmt.Println("VMCStartContainer-waiting for response")
 	<-c
-	stopr := StopImageReq{ID: "simple", Timeout: 0}
+	stopr := StopImageReq{ID: "simple", Timeout: 0, Dontremove: true}
 	VMCProcess(ctxt, "Docker", stopr)
 }
 
@@ -170,7 +170,7 @@ func TestVMCSyncStartContainer(t *testing.T) {
 		t.Logf("Error starting container: %s", err)
 		return
 	}
-	stopr := StopImageReq{ID: "simple", Timeout: 0}
+	stopr := StopImageReq{ID: "simple", Timeout: 0, Dontremove: true}
 	VMCProcess(ctxt, "Docker", stopr)
 }
 


### PR DESCRIPTION
This fixes #327 by killing and removing containers after they are stopped. This will also help keep users's environment clean by reducing containers that are left around after tests.
