### PR TITLE
Get tests in api_test.go to run once again

### DIFF
--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -20,8 +20,9 @@ under the License.
 package openchain
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
+	"os"
 	"testing"
 
 	"google/protobuf"
@@ -35,13 +36,13 @@ import (
 
 func TestMain(m *testing.M) {
 	setupTestConfig()
+	os.Exit(m.Run())
 }
-
 
 func setupTestConfig() {
 	viper.SetConfigName("openchain") // name of config file (without extension)
-	viper.AddConfigPath("./")   // path to look for the config file in
-	viper.AddConfigPath("./..")   // path to look for the config file in
+	viper.AddConfigPath("./")        // path to look for the config file in
+	viper.AddConfigPath("./..")      // path to look for the config file in
 	err := viper.ReadInConfig()      // Find and read the config file
 	if err != nil {                  // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))


### PR DESCRIPTION
Missing line below in test setup was causing tests to stop running.

os.Exit(m.Run())

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
