### PR TITLE
serialize create/start/stop for a container; debug log cleanup and a …

### DIFF
--- a/openchain/chaincode/handler.go
+++ b/openchain/chaincode/handler.go
@@ -161,6 +161,7 @@ func newChaincodeSupportHandler(chaincodeSupport *ChaincodeSupport, peerChatStre
 			"enter_" + endstate:                                      func(e *fsm.Event) { v.enterEndState(e, v.FSM.Current()) },
 		},
 	)
+
 	return v
 }
 
@@ -382,7 +383,7 @@ func (handler *Handler) afterInvokeChaincode(e *fsm.Event, state string) {
 // Handles request to ledger to put state
 func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 	go func() {
-		chaincodeLogger.Debug("[enterBusyState] State is %s", state)
+		chaincodeLogger.Debug("state is %s", state)
 		msg, _ := e.Args[0].(*pb.ChaincodeMessage)
 		// First check if this UUID is a transaction; error otherwise
 		if !handler.isTransaction[msg.Uuid] {
@@ -536,11 +537,11 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 
 func (handler *Handler) enterEstablishedState(e *fsm.Event, state string) {
 	handler.notifyDuringStartup(true)
-	chaincodeLogger.Debug("(enterEstablishedState)Entered state; notified %s", state)
+	chaincodeLogger.Debug("Entered state; notified %s", state)
 }
 
 func (handler *Handler) enterInitState(e *fsm.Event, state string) {
-	chaincodeLogger.Debug("(enterInitState)Entered state %s", state)
+	chaincodeLogger.Debug("Entered state %s", state)
 	ccMsg, ok := e.Args[0].(*pb.ChaincodeMessage)
 	if !ok {
 		e.Cancel(fmt.Errorf("Received unexpected message type"))
@@ -567,11 +568,11 @@ func (handler *Handler) enterReadyState(e *fsm.Event, state string) {
 	}
 	handler.notify(msg)
 
-	chaincodeLogger.Debug("(enterReadyState)Entered state %s", state)
+	chaincodeLogger.Debug("Entered state %s", state)
 }
 
 func (handler *Handler) enterTransactionState(e *fsm.Event, state string) {
-	chaincodeLogger.Debug("(enterTransactionState)Entered state %s", state)
+	chaincodeLogger.Debug("Entered state %s", state)
 }
 
 func (handler *Handler) enterEndState(e *fsm.Event, state string) {
@@ -584,7 +585,7 @@ func (handler *Handler) enterEndState(e *fsm.Event, state string) {
 		return
 	}
 	handler.notify(msg)
-	chaincodeLogger.Debug("(enterEndState)Entered state %s", state)
+	chaincodeLogger.Debug("Entered state %s", state)
 	e.Cancel(fmt.Errorf("Entered end state"))
 }
 

--- a/openchain/chaincode/shim/chaincode.go
+++ b/openchain/chaincode/shim/chaincode.go
@@ -199,11 +199,11 @@ func (stub *ChaincodeStub) DelState(key string) error {
 }
 
 // InvokeChaincode function can be invoked by a chaincode to execute another chaincode.
-func (stub *ChaincodeStub) InvokeChaincode(chaincodeUrl string, chaincodeVersion string, function string, args []string) ([]byte, error) {
-	return handler.handleInvokeChaincode(chaincodeUrl, chaincodeVersion, function, args, stub.UUID)
+func (stub *ChaincodeStub) InvokeChaincode(chaincodeURL string, chaincodeVersion string, function string, args []string) ([]byte, error) {
+	return handler.handleInvokeChaincode(chaincodeURL, chaincodeVersion, function, args, stub.UUID)
 }
 
 // QueryChaincode function can be invoked by a chaincode to query another chaincode.
-func (stub *ChaincodeStub) QueryChaincode(chaincodeUrl string, chaincodeVersion string, function string, args []string) ([]byte, error) {
-	return handler.handleQueryChaincode(chaincodeUrl, chaincodeVersion, function, args, stub.UUID)
+func (stub *ChaincodeStub) QueryChaincode(chaincodeURL string, chaincodeVersion string, function string, args []string) ([]byte, error) {
+	return handler.handleQueryChaincode(chaincodeURL, chaincodeVersion, function, args, stub.UUID)
 }


### PR DESCRIPTION
…few bug fixes
This pull request serializes container related requests such as create image / start container / stop container for each chaincode (container requests for different chaincodes can occur concurrently). Doing it at the container package level frees higher level code from having to worry about this.

This also contains a few minor fixes (such as error checking) and debug code cleanup.
