### PR TITLE
Added peer.listenAddress config

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,10 +258,25 @@ func main() {
 }
 
 func serve(args []string) error {
-	lis, err := net.Listen("tcp", viper.GetString("peer.address"))
+
+	peerEndpoint, err := peer.GetPeerEndpoint()
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed to get Peer Endpoint: %s", err))
+		return err
+	}
+
+	listenAddr := viper.GetString("peer.listenaddress")
+	
+	if "" == listenAddr {
+		logger.Debug("Listen address not specified, using peer endpoint address")
+		listenAddr = peerEndpoint.Address
+	}
+	
+	lis, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		grpclog.Fatalf("failed to listen: %v", err)
 	}
+
 	if chaincodeDevMode {
 		logger.Debug("In chaincode development mode [consensus - noops, chaincode run by - user, peer mode - validator]")
 		viper.Set("peer.validator.enabled", "true")
@@ -320,11 +335,7 @@ func serve(args []string) error {
 	if err != nil {
 		grpclog.Fatalf("Failed to get peer.discovery.rootnode valey: %s", err)
 	}
-	peerEndpoint, err := peer.GetPeerEndpoint()
-	if err != nil {
-		logger.Error(fmt.Sprintf("Failed to get Peer Endpoint: %s", err))
-		return err
-	}
+
 	logger.Info("Starting peer with id=%s, network id=%s, address=%s, discovery.rootnode=%s, validator=%v",
 		peerEndpoint.ID, viper.GetString("peer.networkId"),
 		peerEndpoint.Address, rootNode, viper.GetBool("peer.validator.enabled"))

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -63,6 +63,8 @@ peer:
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
         RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
+    # The Address this Peer will listen on
+    listenAddress: 0.0.0.0:30303
     # The Address this Peer will bind to for providing services
     address: 0.0.0.0:30303
     # Whether the Peer should programmatically determine the address to bind to. This case is useful for docker containers.


### PR DESCRIPTION
The IP:PORT of the address to listen on can be different from the peer.address being sent on discovery, if obc-peer is running inside a docker container.

It should send the docker host's address:port for discovery, but it should be listening to a IP:Port inside the docker container.
