### PR TITLE
Revert commits that moved hashing algorithm from SHA3 to SHA2

### DIFF
--- a/obc-ca/obcca/ca.go
+++ b/obc-ca/obcca/ca.go
@@ -34,7 +34,7 @@ import (
 
 	// Needed to use sqlite3
 	_ "github.com/mattn/go-sqlite3"
-	"crypto/sha512"
+	"golang.org/x/crypto/sha3"
 )
 
 // CA is the base certificate authority.
@@ -185,7 +185,7 @@ func (ca *CA) newCertificate(id string, pub *ecdsa.PublicKey, timestamp int64, o
 		Panic.Panicln(err)
 	}
 
-	hash := sha512.New384()
+	hash := sha3.New384()
 	hash.Write(raw)
 	if _, err = ca.db.Exec("INSERT INTO Certificates (id, timestamp, cert, hash) VALUES (?, ?, ?, ?)", id, timestamp, raw, hash.Sum(nil)); err != nil {
 		if isCA {

--- a/obc-ca/obcca/eca.go
+++ b/obc-ca/obcca/eca.go
@@ -34,7 +34,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	pb "github.com/openblockchain/obc-peer/obc-ca/protos"
 	"github.com/spf13/viper"
-	"crypto/sha512"
+	"golang.org/x/crypto/sha3"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -184,7 +184,7 @@ func (ecap *ECAP) CreateCertificate(ctx context.Context, req *pb.ECertCreateReq)
 		return nil, err
 	}
 
-	hash := sha512.New384()
+	hash := sha3.New384()
 	raw, _ = proto.Marshal(req)
 	hash.Write(raw)
 	if ecdsa.Verify(pub.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {

--- a/obc-ca/obcca/tca.go
+++ b/obc-ca/obcca/tca.go
@@ -36,7 +36,7 @@ import (
 	"strconv"
 	"sync"
 
-	"crypto/sha512"
+	"golang.org/x/crypto/sha3"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/openblockchain/obc-peer/obc-ca/protos"
@@ -198,7 +198,7 @@ func (tcap *TCAP) CreateCertificate(ctx context.Context, req *pb.TCertCreateReq)
 		return nil, err
 	}
 
-	hash := sha512.New384()
+	hash := sha3.New384()
 	raw, _ = proto.Marshal(req)
 	hash.Write(raw)
 	if ecdsa.Verify(cert.PublicKey.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {
@@ -237,7 +237,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, req *pb.TCertCreateS
 	r.UnmarshalText(sig.R)
 	s.UnmarshalText(sig.S)
 
-	hash := sha512.New384()
+	hash := sha3.New384()
 	raw, _ = proto.Marshal(req)
 	hash.Write(raw)
 	if ecdsa.Verify(pub, hash.Sum(nil), r, s) == false {
@@ -249,7 +249,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, req *pb.TCertCreateS
 	tcap.tca.rand.Read(nonce[:8])
 	binary.LittleEndian.PutUint64(nonce[8:], uint64(req.Ts.Seconds))
 	
-	mac := hmac.New(sha512.New384, tcap.tca.hmacKey)
+	mac := hmac.New(sha3.New384, tcap.tca.hmacKey)
 	raw, _ = x509.MarshalPKIXPublicKey(pub)
 	mac.Write(raw)
 	kdfKey := mac.Sum(nil)
@@ -264,13 +264,13 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, req *pb.TCertCreateS
 		tidx := []byte(strconv.Itoa(i))
 		tidx = append(tidx[:], nonce[:]...)
 
-		mac = hmac.New(sha512.New384, kdfKey)
+		mac = hmac.New(sha3.New384, kdfKey)
 		mac.Write([]byte{1})
 		extKey := mac.Sum(nil)[:32]
 
-		mac = hmac.New(sha512.New384, kdfKey)
+		mac = hmac.New(sha3.New384, kdfKey)
 		mac.Write([]byte{2})
-		mac = hmac.New(sha512.New384, mac.Sum(nil))
+		mac = hmac.New(sha3.New384, mac.Sum(nil))
 		mac.Write(tidx)
 
 		one := new(big.Int).SetInt64(1)
@@ -324,7 +324,7 @@ func (tcap *TCAP) ReadCertificate(ctx context.Context, req *pb.TCertReadReq) (*p
 	r.UnmarshalText(sig.R)
 	s.UnmarshalText(sig.S)
 
-	hash := sha512.New384()
+	hash := sha3.New384()
 	raw, _ = proto.Marshal(req)
 	hash.Write(raw)
 	if ecdsa.Verify(cert.PublicKey.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {

--- a/openchain/crypto/utils/hash.go
+++ b/openchain/crypto/utils/hash.go
@@ -21,12 +21,12 @@ package utils
 
 import (
 	"crypto/hmac"
-	"crypto/sha512"
+	"golang.org/x/crypto/sha3"
 	"hash"
 )
 
 var (
-	newHash = sha512.New384
+	newHash = sha3.New384
 )
 
 // NewHash returns a new hash function

--- a/openchain/util/utils.go
+++ b/openchain/util/utils.go
@@ -25,14 +25,14 @@ import (
 	"io"
 	"time"
 
-	"crypto/sha512"
+	"golang.org/x/crypto/sha3"
 	gp "google/protobuf"
 )
 
 // ComputeCryptoHash should be used in openchain code so that we can change the actual algo used for crypto-hash at one place
 func ComputeCryptoHash(data []byte) (hash []byte) {
-	byte64array := sha512.Sum512(data)
-	hash = byte64array[:]
+	hash = make([]byte, 64)
+	sha3.ShakeSum256(hash, data)
 	return
 }
 


### PR DESCRIPTION
I am reverting the recent commit that moved the hashing algorithm from SHA3 to SHA2 as we did not allow enough time for comments and discussion. Will continue conversation in issue #408

Signed-off-by: sheehan@us.ibm.com
