### PR TITLE
Ability to rollback applied deltas. Issue #414

### DIFF
--- a/openchain/ledger/ledger.go
+++ b/openchain/ledger/ledger.go
@@ -230,7 +230,7 @@ func (ledger *Ledger) CommitStateDelta(id interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer ledger.resetForNextTxGroup()
+	defer ledger.resetForNextTxGroup(true)
 	return ledger.state.CommitStateDelta()
 }
 
@@ -241,7 +241,7 @@ func (ledger *Ledger) RollbackStateDelta(id interface{}) error {
 	if err != nil {
 		return err
 	}
-	ledger.resetForNextTxGroup()
+	ledger.resetForNextTxGroup(false)
 	return nil
 }
 

--- a/openchain/ledger/ledger.go
+++ b/openchain/ledger/ledger.go
@@ -195,7 +195,9 @@ func (ledger *Ledger) GetStateDelta(blockNumber uint64) (*statemgmt.StateDelta, 
 	return ledger.state.FetchStateDeltaFromDB(blockNumber)
 }
 
-// ApplyStateDelta applies a state delta to the current state.
+// ApplyStateDelta applies a state delta to the current state. This is an
+// in memory change only. You must call ledger.CommitStateDelta to persist
+// the change to the DB.
 // This should only be used as part of state synchronization. State deltas
 // can be retrieved from another peer though the Ledger.GetStateDelta function
 // or by creating state deltas with keys retrieved from
@@ -211,8 +213,36 @@ func (ledger *Ledger) GetStateDelta(blockNumber uint64) (*statemgmt.StateDelta, 
 // be used to roll forwards from state at block 2 to state at block 3. If
 // stateDelta.RollBackwards=false, the delta retrived for block 3 can be
 // used to roll backwards from the state at block 3 to the state at block 2.
-func (ledger *Ledger) ApplyStateDelta(delta *statemgmt.StateDelta) error {
-	return ledger.state.ApplyStateDelta(delta)
+func (ledger *Ledger) ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error {
+	err := ledger.checkValidIDBegin()
+	if err != nil {
+		return err
+	}
+	ledger.currentID = id
+	ledger.state.ApplyStateDelta(delta)
+	return nil
+}
+
+// CommitStateDelta will commit the state delta passed to ledger.ApplyStateDelta
+// to the DB
+func (ledger *Ledger) CommitStateDelta(id interface{}) error {
+	err := ledger.checkValidIDCommitORRollback(id)
+	if err != nil {
+		return err
+	}
+	defer ledger.resetForNextTxGroup()
+	return ledger.state.CommitStateDelta()
+}
+
+// RollbackStateDelta will discard the state delta passed
+// to ledger.ApplyStateDelta
+func (ledger *Ledger) RollbackStateDelta(id interface{}) error {
+	err := ledger.checkValidIDCommitORRollback(id)
+	if err != nil {
+		return err
+	}
+	ledger.resetForNextTxGroup()
+	return nil
 }
 
 // DeleteALLStateKeysAndValues deletes all keys and values from the state.

--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -57,6 +57,36 @@ func TestLedgerRollback(t *testing.T) {
 	testutil.AssertNil(t, ledgerTestWrapper.GetState("chaincode1", "key1", false))
 }
 
+func TestLedgerRollbackWithHash(t *testing.T) {
+	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
+	ledger := ledgerTestWrapper.ledger
+
+	ledger.BeginTxBatch(0)
+	ledger.TxBegin("txUuid")
+	ledger.SetState("chaincode0", "key1", []byte("value1"))
+	ledger.SetState("chaincode0", "key2", []byte("value2"))
+	ledger.SetState("chaincode0", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
+	ledger.RollbackTxBatch(0)
+
+	hash0 := ledgerTestWrapper.GetTempStateHash()
+
+	ledger.BeginTxBatch(1)
+	ledger.TxBegin("txUuid")
+	ledger.SetState("chaincode1", "key1", []byte("value1"))
+	ledger.SetState("chaincode2", "key2", []byte("value2"))
+	ledger.SetState("chaincode3", "key3", []byte("value3"))
+	ledger.TxFinished("txUuid", true)
+
+	hash1 := ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertNotEquals(t, hash1, hash0)
+
+	ledger.RollbackTxBatch(1)
+	hash1 = ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, hash1, hash0)
+	testutil.AssertNil(t, ledgerTestWrapper.GetState("chaincode1", "key1", false))
+}
+
 func TestLedgerDifferentID(t *testing.T) {
 	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
 	ledger := ledgerTestWrapper.ledger
@@ -180,15 +210,15 @@ func TestLedgerSetRawState(t *testing.T) {
 	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
 
 	// Ensure values are in the DB
-	val, err := ledger.GetState("chaincode1", "key1", true)
+	val := ledgerTestWrapper.GetState("chaincode1", "key1", true)
 	if bytes.Compare(val, []byte("value1")) != 0 {
 		t.Fatalf("Expected initial chaincode1 key1 to be %s, but got %s", []byte("value1"), val)
 	}
-	val, err = ledger.GetState("chaincode2", "key2", true)
+	val = ledgerTestWrapper.GetState("chaincode2", "key2", true)
 	if bytes.Compare(val, []byte("value2")) != 0 {
 		t.Fatalf("Expected initial chaincode1 key2 to be %s, but got %s", []byte("value2"), val)
 	}
-	val, err = ledger.GetState("chaincode3", "key3", true)
+	val = ledgerTestWrapper.GetState("chaincode3", "key3", true)
 	if bytes.Compare(val, []byte("value3")) != 0 {
 		t.Fatalf("Expected initial chaincode1 key3 to be %s, but got %s", []byte("value3"), val)
 	}
@@ -215,15 +245,15 @@ func TestLedgerSetRawState(t *testing.T) {
 	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
 
 	// ensure keys are deleted
-	val, err = ledger.GetState("chaincode1", "key1", true)
+	val = ledgerTestWrapper.GetState("chaincode1", "key1", true)
 	if val != nil {
 		t.Fatalf("Expected chaincode1 key1 to be nil, but got %s", val)
 	}
-	val, err = ledger.GetState("chaincode2", "key2", true)
+	val = ledgerTestWrapper.GetState("chaincode2", "key2", true)
 	if val != nil {
 		t.Fatalf("Expected chaincode2 key2 to be nil, but got %s", val)
 	}
-	val, err = ledger.GetState("chaincode3", "key3", true)
+	val = ledgerTestWrapper.GetState("chaincode3", "key3", true)
 	if val != nil {
 		t.Fatalf("Expected chaincode3 key3 to be nil, but got %s", val)
 	}
@@ -246,21 +276,19 @@ func TestLedgerSetRawState(t *testing.T) {
 		delta.Set(cID, kID, v, nil)
 	}
 
-	err = ledger.ApplyStateDelta(delta)
-	if err != nil {
-		t.Fatalf("Error applying raw state delta, %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(1, delta)
+	ledgerTestWrapper.CommitStateDelta(1)
 
 	// Ensure values are back in the DB
-	val, err = ledger.GetState("chaincode1", "key1", true)
+	val = ledgerTestWrapper.GetState("chaincode1", "key1", true)
 	if bytes.Compare(val, []byte("value1")) != 0 {
 		t.Fatalf("Expected chaincode1 key1 to be %s, but got %s", []byte("value1"), val)
 	}
-	val, err = ledger.GetState("chaincode2", "key2", true)
+	val = ledgerTestWrapper.GetState("chaincode2", "key2", true)
 	if bytes.Compare(val, []byte("value2")) != 0 {
 		t.Fatalf("Expected chaincode1 key2 to be %s, but got %s", []byte("value2"), val)
 	}
-	val, err = ledger.GetState("chaincode3", "key3", true)
+	val = ledgerTestWrapper.GetState("chaincode3", "key3", true)
 	if bytes.Compare(val, []byte("value3")) != 0 {
 		t.Fatalf("Expected chaincode1 key3 to be %s, but got %s", []byte("value3"), val)
 	}
@@ -453,10 +481,8 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	// Roll backwards once
 	delta2 := ledgerTestWrapper.GetStateDelta(2)
 	delta2.RollBackwards = true
-	err := ledger.ApplyStateDelta(delta2)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(1, delta2)
+	ledgerTestWrapper.CommitStateDelta(1)
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
@@ -464,10 +490,8 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 
 	// Now roll forwards once
 	delta2.RollBackwards = false
-	err = ledger.ApplyStateDelta(delta2)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(2, delta2)
+	ledgerTestWrapper.CommitStateDelta(2)
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3C"))
@@ -476,15 +500,12 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	// Now roll backwards twice
 	delta2.RollBackwards = true
 	delta1 := ledgerTestWrapper.GetStateDelta(1)
-	err = ledger.ApplyStateDelta(delta2)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(3, delta2)
+	ledgerTestWrapper.CommitStateDelta(3)
+
 	delta1.RollBackwards = true
-	err = ledger.ApplyStateDelta(delta1)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(4, delta1)
+	ledgerTestWrapper.CommitStateDelta(4)
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
@@ -492,16 +513,142 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	// Now roll forwards twice
 	delta2.RollBackwards = false
 	delta1.RollBackwards = false
-	err = ledger.ApplyStateDelta(delta1)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
-	err = ledger.ApplyStateDelta(delta2)
-	if err != nil {
-		t.Fatalf("Error applying delta: %s", err)
-	}
+	ledgerTestWrapper.ApplyStateDelta(5, delta1)
+	ledgerTestWrapper.CommitStateDelta(5)
+	ledgerTestWrapper.ApplyStateDelta(6, delta2)
+	ledgerTestWrapper.CommitStateDelta(6)
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode4", "key4", true), []byte("value4C"))
+}
+
+func TestInvalidOrderDelta(t *testing.T) {
+	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
+	ledger := ledgerTestWrapper.ledger
+
+	// Block 0
+	ledger.BeginTxBatch(0)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1A"))
+	ledger.SetState("chaincode2", "key2", []byte("value2A"))
+	ledger.SetState("chaincode3", "key3", []byte("value3A"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, _ := buildTestTx()
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
+
+	// Block 1
+	ledger.BeginTxBatch(1)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1B"))
+	ledger.SetState("chaincode2", "key2", []byte("value2B"))
+	ledger.SetState("chaincode3", "key3", []byte("value3B"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, _ = buildTestTx()
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
+
+	delta := ledgerTestWrapper.GetStateDelta(1)
+
+	err := ledger.CommitStateDelta(1)
+	testutil.AssertError(t, err, "Expected error commiting delta")
+
+	err = ledger.RollbackTxBatch(1)
+	testutil.AssertError(t, err, "Expected error rolling back delta")
+
+	ledgerTestWrapper.ApplyStateDelta(2, delta)
+
+	err = ledger.ApplyStateDelta(3, delta)
+	testutil.AssertError(t, err, "Expected error applying delta")
+
+	err = ledger.CommitStateDelta(3)
+	testutil.AssertError(t, err, "Expected error applying delta")
+
+	err = ledger.RollbackStateDelta(3)
+	testutil.AssertError(t, err, "Expected error applying delta")
+
+}
+
+func TestApplyDeltaHash(t *testing.T) {
+
+	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
+	ledger := ledgerTestWrapper.ledger
+
+	// Block 0
+	ledger.BeginTxBatch(0)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1A"))
+	ledger.SetState("chaincode2", "key2", []byte("value2A"))
+	ledger.SetState("chaincode3", "key3", []byte("value3A"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, _ := buildTestTx()
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
+
+	// Block 1
+	ledger.BeginTxBatch(1)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1B"))
+	ledger.SetState("chaincode2", "key2", []byte("value2B"))
+	ledger.SetState("chaincode3", "key3", []byte("value3B"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, _ = buildTestTx()
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
+
+	// Block 2
+	ledger.BeginTxBatch(2)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1C"))
+	ledger.SetState("chaincode2", "key2", []byte("value2C"))
+	ledger.SetState("chaincode3", "key3", []byte("value3C"))
+	ledger.SetState("chaincode4", "key4", []byte("value4C"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, _ = buildTestTx()
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1C"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2C"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3C"))
+	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode4", "key4", true), []byte("value4C"))
+
+	hash2 := ledgerTestWrapper.GetTempStateHash()
+
+	// Roll backwards once
+	delta2 := ledgerTestWrapper.GetStateDelta(2)
+	delta2.RollBackwards = true
+	ledgerTestWrapper.ApplyStateDelta(1, delta2)
+
+	preHash1 := ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertNotEquals(t, preHash1, hash2)
+
+	ledgerTestWrapper.CommitStateDelta(1)
+
+	hash1 := ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, preHash1, hash1)
+	testutil.AssertNotEquals(t, hash1, hash2)
+
+	// Roll forwards once
+	delta2.RollBackwards = false
+	ledgerTestWrapper.ApplyStateDelta(2, delta2)
+	preHash2 := ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, preHash2, hash2)
+	ledgerTestWrapper.RollbackStateDelta(2)
+	preHash2 = ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, preHash2, hash1)
+	ledgerTestWrapper.ApplyStateDelta(3, delta2)
+	preHash2 = ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, preHash2, hash2)
+	ledgerTestWrapper.CommitStateDelta(3)
+	preHash2 = ledgerTestWrapper.GetTempStateHash()
+	testutil.AssertEquals(t, preHash2, hash2)
+
 }

--- a/openchain/ledger/pkg_test.go
+++ b/openchain/ledger/pkg_test.go
@@ -189,3 +189,24 @@ func (ledgerTestWrapper *ledgerTestWrapper) GetStateDelta(blockNumber uint64) *s
 	testutil.AssertNoError(ledgerTestWrapper.t, err, "error while getting state delta from ledger")
 	return delta
 }
+
+func (ledgerTestWrapper *ledgerTestWrapper) GetTempStateHash() []byte {
+	hash, err := ledgerTestWrapper.ledger.GetTempStateHash()
+	testutil.AssertNoError(ledgerTestWrapper.t, err, "error while getting state hash from ledger")
+	return hash
+}
+
+func (ledgerTestWrapper *ledgerTestWrapper) ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) {
+	err := ledgerTestWrapper.ledger.ApplyStateDelta(id, delta)
+	testutil.AssertNoError(ledgerTestWrapper.t, err, "error applying state delta")
+}
+
+func (ledgerTestWrapper *ledgerTestWrapper) CommitStateDelta(id interface{}) {
+	err := ledgerTestWrapper.ledger.CommitStateDelta(id)
+	testutil.AssertNoError(ledgerTestWrapper.t, err, "error committing state delta")
+}
+
+func (ledgerTestWrapper *ledgerTestWrapper) RollbackStateDelta(id interface{}) {
+	err := ledgerTestWrapper.ledger.RollbackStateDelta(id)
+	testutil.AssertNoError(ledgerTestWrapper.t, err, "error rolling back state delta")
+}

--- a/openchain/ledger/statemgmt/state/state.go
+++ b/openchain/ledger/statemgmt/state/state.go
@@ -36,11 +36,6 @@ var logger = logging.MustGetLogger("state")
 
 const detaultStateImpl = "buckettree"
 
-var stateImplFactory = map[string]statemgmt.HashableState{
-	"buckettree": buckettree.NewStateImpl(),
-	"trie":       trie.NewStateTrie(),
-}
-
 var stateImpl statemgmt.HashableState
 
 // State structure for maintaining world state.
@@ -61,10 +56,17 @@ func NewState() *State {
 	stateImplName := viper.GetString("ledger.state.dataStructure")
 	if len(stateImplName) == 0 {
 		stateImplName = detaultStateImpl
-	} else if _, ok := stateImplFactory[stateImplName]; !ok {
+	}
+
+	switch stateImplName {
+	case "buckettree":
+		stateImpl = buckettree.NewStateImpl()
+	case "trie":
+		stateImpl = trie.NewStateTrie()
+	default:
 		panic(fmt.Errorf("Error during initialization of state implementation. State data structure '%s' is not valid.", stateImplName))
 	}
-	stateImpl = stateImplFactory[stateImplName]
+
 	err := stateImpl.Initialize()
 	if err != nil {
 		panic(fmt.Errorf("Error during initialization of state implementation: %s", err))

--- a/openchain/ledger/statemgmt/state/state.go
+++ b/openchain/ledger/statemgmt/state/state.go
@@ -252,18 +252,25 @@ func (state *State) AddChangesForPersistence(blockNumber uint64, writeBatch *gor
 	logger.Debug("state.addChangesForPersistence()...finished")
 }
 
-// ApplyStateDelta applies already prepared stateDelta to the existing state
-// This method is to be used in state transfer
-func (state *State) ApplyStateDelta(delta *statemgmt.StateDelta) error {
-	state.stateImpl.PrepareWorkingSet(delta)
+// ApplyStateDelta applies already prepared stateDelta to the existing state.
+// This is an in memory change only. state.CommitStateDelta must be used to
+// commit the state to the DB. This method is to be used in state transfer.
+func (state *State) ApplyStateDelta(delta *statemgmt.StateDelta) {
+	state.stateDelta = delta
+	state.updateStateImpl = true
+}
+
+// CommitStateDelta commits the changes from state.ApplyStateDelta to the
+// DB.
+func (state *State) CommitStateDelta() error {
+	if state.updateStateImpl {
+		state.stateImpl.PrepareWorkingSet(state.stateDelta)
+		state.updateStateImpl = false
+	}
 	writeBatch := gorocksdb.NewWriteBatch()
 	state.stateImpl.AddChangesForPersistence(writeBatch)
 	opt := gorocksdb.NewDefaultWriteOptions()
-	err := db.GetDBHandle().DB.Write(opt, writeBatch)
-	if err != nil {
-		return err
-	}
-	return nil
+	return db.GetDBHandle().DB.Write(opt, writeBatch)
 }
 
 // DeleteState deletes ALL state keys/values from the DB. This is generally


### PR DESCRIPTION
@manish-sethi This PR is for issue #414. It allows for applied deltas (used during sync) to be rolled back by calling `ledger.ApplyStateDelta` followed by either `ledger.CommitStateDelta` or `ledger.RollbackStateDelta`. This is similar to `ledger.BeginTxBatch`, `ledger.RollbackBatch`, and `ledger.CommitTxBatch`. However, I found a problem.

See the `ledger_test.TestLedgerRollbackWithHash` test in this PR. It does the following
1. Begin a TX batch and manipulate the state
2. Get the hash using `ledger.GetTempStateHash()`
3. Rollback the TX batch
4. Get the hash again using `ledger.GetTempStateHash()`

The problem is that we're not recalculating the hash in step 4. If you remove step 2, it works. It seems we're too aggressive in caching the hash. At first I thought the solution was to modify `state.ClearInMemoryChanges` and add `state.updateStateImpl = true`, but the bucket tree implementation ignores an empty delta in `state_impl.PrepareWorkingSet` so the state hash is still not recalculated. Do you have thoughts on how this bug should be resolved? I was trying to do so without modifying the state implementations, but I'm not sure that is possible. I only tested the bukettree and have not yet investigated if the trie has this same issue.
