### PR TITLE
Adding privacy check on CLI and REST

### DIFF
--- a/main.go
+++ b/main.go
@@ -676,6 +676,11 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// If privacy is enabled, mark chaincode as confidential
+	if viper.GetBool("security.privacy") {
+		spec.ConfidentialityLevel = pb.ConfidentialityLevel_CONFIDENTIAL
+	}
+
 	chaincodeDeploymentSpec, err := devopsClient.Deploy(context.Background(), spec)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error building %s: %s\n", chainFuncName, err)
@@ -747,6 +752,11 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) {
 			// Unexpected error
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
 		}
+	}
+
+	// If privacy is enabled, mark chaincode as confidential
+	if viper.GetBool("security.privacy") {
+		spec.ConfidentialityLevel = pb.ConfidentialityLevel_CONFIDENTIAL
 	}
 
 	// Build the ChaincodeInvocationSpec message

--- a/openchain/rest/rest_api.go
+++ b/openchain/rest/rest_api.go
@@ -500,6 +500,11 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 		}
 	}
 
+	// If privacy is enabled, mark chaincode as confidential
+	if viper.GetBool("security.privacy") {
+		spec.ConfidentialityLevel = pb.ConfidentialityLevel_CONFIDENTIAL
+	}
+
 	// Deploy the ChaincodeSpec
 	_, err = s.devops.Deploy(context.Background(), &spec)
 	if err != nil {
@@ -628,6 +633,11 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 		}
 	}
 
+	// If privacy is enabled, mark chaincode as confidential
+	if viper.GetBool("security.privacy") {
+		spec.ChaincodeSpec.ConfidentialityLevel = pb.ConfidentialityLevel_CONFIDENTIAL
+	}
+
 	// Invoke the chainCode
 	_, err = s.devops.Invoke(context.Background(), &spec)
 	if err != nil {
@@ -754,6 +764,11 @@ func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 			fmt.Fprintf(rw, "{\"Error\": \"Fatal error -- %s\"}", err)
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
 		}
+	}
+
+	// If privacy is enabled, mark chaincode as confidential
+	if viper.GetBool("security.privacy") {
+		spec.ChaincodeSpec.ConfidentialityLevel = pb.ConfidentialityLevel_CONFIDENTIAL
 	}
 
 	// Query the chainCode


### PR DESCRIPTION
Adding a check for the privacy setting. If privacy is enabled inside of
openchain.yaml, the chaincode confidentiality level is set to
CONFIDENTIAL in the ChaincodeSpec and ChaincodeInvocationSpec.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
