### PR TITLE
Check for dev mode during deploy on REST

### DIFF
--- a/docs/SandboxSetup.md
+++ b/docs/SandboxSetup.md
@@ -20,7 +20,7 @@ To log in a user through the CLI, issue the commands bellow, where 'username' is
     cd $GOPATH/src/github.com/openblockchain/obc-peer
     ./obc-peer login <username>
 
-The command will prompt for a password, which must match the password listed for the target user in the 'users' section of the [obcca.yaml](https://github.com/openblockchain/obc-peer/blob/master/obc-ca/obcca.yaml). If the password is entered incorrectly, an error will result.
+The command will prompt for a password, which must match the password listed for the target user in the 'users' section of the [obcca.yaml](https://github.com/openblockchain/obc-peer/blob/master/obc-ca/obcca.yaml). If the password is incorrect, an error will result.
 
 To log in the user through the REST API, send a POST request to the /registrar endpoint, containing the enrollId and enrollSecret, listed in the 'users' section of the [obcca.yaml](https://github.com/openblockchain/obc-peer/blob/master/obc-ca/obcca.yaml).
 
@@ -95,7 +95,7 @@ POST localhost:5000/devops/deploy
 }
 ```
 
-**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions within the security setup section above. On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
+**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [security setup section](#security-setup-optional). On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
 
  	  ./obc-peer chaincode deploy -u jim -n mycc -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 
@@ -150,7 +150,7 @@ POST localhost:5000/devops/invoke
 }
 ```
 
-**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions within the security setup section above. On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
+**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [security setup section](#security-setup-optional). On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
 
 	 ./obc-peer chaincode invoke -u jim -l golang -n mycc -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 
@@ -179,7 +179,7 @@ The invoke transaction runs the specified transaction name “invoke” with the
 
 #### Chaincode query via CLI and REST
 
-Run a query on the chaincode to retrieve desired values. The “-n” arg should match those provided in the Chaincode Window.
+Run a query on the chaincode to retrieve desired values. The “-n” arg should match that provided in the Chaincode Window.
 
     ./obc-peer chaincode query -l golang -n mycc -c '{"Function": "query", "Args": ["b"]}'
 
@@ -218,7 +218,7 @@ POST localhost:5000/devops/query
 }
 ```
 
-**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions within the security setup section above. On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
+**Note:** When security is enabled, modify the CLI command and REST API payload to pass the username of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [security setup section](#security-setup-optional). On the CLI the username is passed with the -u parameter and on the REST API the username is passed with the 'secureContext' element.
 
     ./obc-peer chaincode query -u jim -l golang -n mycc -c '{"Function": "query", "Args": ["b"]}'
 

--- a/openchain/rest/rest_api.go
+++ b/openchain/rest/rest_api.go
@@ -452,8 +452,8 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 		// Check that the Chaincode name is not blank.
 		if spec.ChaincodeID.Name == "" {
 			rw.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintf(rw, "{\"Error\": \"Chaincode name may not be blank.\"}")
-			logger.Error("{\"Error\": \"Chaincode name may not be blank.\"}")
+			fmt.Fprintf(rw, "{\"Error\": \"Chaincode name may not be blank in development mode.\"}")
+			logger.Error("{\"Error\": \"Chaincode name may not be blank in development mode.\"}")
 
 			return
 		}

--- a/openchain/rest/rest_api.go
+++ b/openchain/rest/rest_api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/viper"
 
 	oc "github.com/openblockchain/obc-peer/openchain"
+	"github.com/openblockchain/obc-peer/openchain/chaincode"
 	"github.com/openblockchain/obc-peer/openchain/peer"
 	pb "github.com/openblockchain/obc-peer/protos"
 )
@@ -442,13 +443,29 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 		return
 	}
 
-	// Check that the Chaincode path is not left blank.
-	if spec.ChaincodeID.Path == "" {
-		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Chaincode URL path and version may not be blank.\"}")
-		logger.Error("{\"Error\": \"Chaincode URL path and version  may not be blank.\"}")
+	// If the peer is running in development mode, confirm that the Chaincode name
+	// is not left blank. If the peer is running in production mode, confirm that
+	// the Chaincode path is not left blank. This is necessary as in development
+	// mode, the chaincode is identified by name not by path during the deploy
+	// process.
+	if viper.GetString("chaincode.mode") == chaincode.DevModeUserRunsChaincode {
+		// Check that the Chaincode name is not blank.
+		if spec.ChaincodeID.Name == "" {
+			rw.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(rw, "{\"Error\": \"Chaincode name may not be blank.\"}")
+			logger.Error("{\"Error\": \"Chaincode name may not be blank.\"}")
 
-		return
+			return
+		}
+	} else {
+		// Check that the Chaincode path is not left blank.
+		if spec.ChaincodeID.Path == "" {
+			rw.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(rw, "{\"Error\": \"Chaincode path may not be blank.\"}")
+			logger.Error("{\"Error\": \"Chaincode path may not be blank.\"}")
+
+			return
+		}
 	}
 
 	// If security is enabled, add client login token
@@ -566,11 +583,11 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 		return
 	}
 
-	// Check that the Chaincode Name is not blank.
+	// Check that the Chaincode name is not blank.
 	if spec.ChaincodeSpec.ChaincodeID.Name == "" {
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Chaincode URL path and version may not be blank.\"}")
-		logger.Error("{\"Error\": \"Chaincode URL path and version  may not be blank.\"}")
+		fmt.Fprintf(rw, "{\"Error\": \"Chaincode name may not be blank.\"}")
+		logger.Error("{\"Error\": \"Chaincode name may not be blank.\"}")
 
 		return
 	}
@@ -699,11 +716,11 @@ func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 		return
 	}
 
-	// Check that the Chaincode Name is not blank.
+	// Check that the Chaincode name is not blank.
 	if spec.ChaincodeSpec.ChaincodeID.Name == "" {
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Chaincode URL path and version may not be blank.\"}")
-		logger.Error("{\"Error\": \"Chaincode URL path and version  may not be blank.\"}")
+		fmt.Fprintf(rw, "{\"Error\": \"Chaincode name may not be blank.\"}")
+		logger.Error("{\"Error\": \"Chaincode name may not be blank.\"}")
 
 		return
 	}


### PR DESCRIPTION
Add a check for development mode on chaincode deployment for REST. This
is necessary, as when the peer is running in development mode, the
chaincode is identified by "name", while in production mode, the
chaincode is identified by "path". Therefore, different things need to
be checked for being blank in these two cases.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
