### PR TITLE
Introducing /transaction/{UUID} REST API + doc

### DIFF
--- a/docs/Openchain API.md
+++ b/docs/Openchain API.md
@@ -143,6 +143,8 @@ You can experiment with the Openchain REST API through any tool of your choice. 
   * GET /chain/blocks/{Block}
 * [Chain](#chain)
   * GET /chain
+* [Transactions](#transactions)
+  * GET /transactions/{UUID}
 * [Devops](#devops)
   * POST /devops/deploy
   * POST /devops/invoke
@@ -179,6 +181,36 @@ message BlockchainInfo {
     uint64 height = 1;
     bytes currentBlockHash = 2;
     bytes previousBlockHash = 3;
+}
+```
+
+#### Transactions
+
+* **GET /transactions/{UUID}**
+
+Use the /transactions/{UUID} endpoint to retrieve an individual transaction matching the UUID from the blockchain. The returned transaction message is defined inside [openchain.proto](https://github.com/openblockchain/obc-peer/blob/master/protos/openchain.proto) .
+
+```
+message Transaction {
+    enum Type {
+        UNDEFINED = 0;
+        CHAINCODE_NEW = 1;
+        CHAINCODE_UPDATE = 2;
+        CHAINCODE_EXECUTE = 3;
+        CHAINCODE_QUERY = 4;
+        CHAINCODE_TERMINATE = 5;
+    }
+    Type type = 1;
+    bytes chaincodeID = 2;
+    bytes payload = 3;
+    string uuid = 4;
+    google.protobuf.Timestamp timestamp = 5;
+
+    ConfidentialityLevel confidentialityLevel = 6;
+    bytes nonce = 7;
+
+    bytes cert = 8;
+    bytes signature = 9;
 }
 ```
 

--- a/openchain/api.go
+++ b/openchain/api.go
@@ -103,3 +103,8 @@ func (s *ServerOpenchain) GetBlockCount(ctx context.Context, e *google_protobuf1
 func (s *ServerOpenchain) GetState(ctx context.Context, chaincodeID, key string) ([]byte, error) {
 	return s.ledger.GetState(chaincodeID, key, true)
 }
+
+// GetTransactionByUUID returns a transaction matching the specified UUID
+func (s *ServerOpenchain) GetTransactionByUUID(ctx context.Context, txUUID string) (*pb.Transaction, error) {
+	return s.ledger.GetTransactionByUUID(txUUID)
+}

--- a/openchain/rest/rest_api.json
+++ b/openchain/rest/rest_api.json
@@ -69,6 +69,37 @@
                 }
             }
         },
+        "/transactions/{UUID}": {
+            "get": {
+                "summary": "Individual Transaction Contents",
+                "description": "The /transactions/{UUID} endpoint returns the transaction matching the specified UUID.",
+                "tags": [
+                    "Transaction"
+                ],
+                "operationId": "getTransaction",
+                "parameters": [{
+                    "name": "UUID",
+                    "in": "path",
+                    "description": "Transaction to retrieve from the blockchain.",
+                    "type": "string",
+                    "required": true
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Individual Transaction contents",
+                        "schema": {
+                           "$ref": "#/definitions/Transaction"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
         "/devops/deploy": {
            "post": {
               "summary": "Service endpoint for deploying Chaincode",
@@ -290,9 +321,9 @@
                     "type": "string",
                     "description": "Creator/originator of the block."
                 },
-                "Timestamp": {
-                    "type": "string",
-                    "description": "Time of block creation."
+                "timestamp": {
+                  "$ref": "#/definitions/Timestamp",
+                  "description": "Time of block creation."
                 },
                 "transactions": {
                     "type": "array",
@@ -309,6 +340,16 @@
                     "type": "string",
                     "format": "bytes",
                     "description": "Hash of the previous block in the blockchain."
+                },
+                "consensusMetadata": {
+                  "type": "string",
+                  "format": "bytes",
+                  "description": "Metadata required for consensus."
+                },
+                "nonHashData": {
+                  "type": "string",
+                  "format": "bytes",
+                  "description": "Data stored in the block, but excluded from the computation of block hash."
                 }
             }
         },
@@ -324,24 +365,15 @@
                         "CHAINCODE_NEW",
                         "CHAINCODE_UPDATE",
                         "CHAINCODE_EXECUTE",
+                        "CHAINCODE_QUERY",
                         "CHAINCODE_TERMINATE"
                     ],
                     "description": "Transaction type."
                 },
                 "chaincodeID": {
-                    "$ref": "#/definitions/ChaincodeID",
-                    "description": "Unique Chaincode identifier."
-                },
-                "function": {
-                    "type": "string",
-                    "description": "Function to execute within a Chaincode."
-                },
-                "args": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Arguments supplied to the Chaincode function."
+                  "type": "string",
+                  "format": "bytes",
+                  "description": "Chaincode identifier as bytes."
                 },
                 "payload": {
                     "type": "string",
@@ -351,6 +383,29 @@
                 "uuid": {
                    "type": "string",
                    "description": "Unique transaction identifier."
+                },
+                "timestamp": {
+                  "$ref": "#/definitions/Timestamp",
+                  "description": "Time at which the chanincode becomes executable."
+                },
+                "confidentialityLevel": {
+                    "$ref": "#/definitions/ConfidentialityLevel",
+                    "description": "Confidentiality level of the Chaincode."
+                },
+                "nonce": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Nonce value generated for this transaction."
+                },
+                "cert": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Certificate of client sending the transaction."
+                },
+                "signature": {
+                    "type": "string",
+                    "format": "bytes",
+                    "description": "Signature of client sending the transaction."
                 }
             }
         },
@@ -444,6 +499,21 @@
                 "enrollSecret": {
                     "type": "string",
                     "description": "User enrollment password registered with the certificate authority."
+                }
+            }
+        },
+        "Timestamp": {
+            "type": "object",
+            "properties": {
+                "seconds": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive."
+                },
+                "nanos": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive."
                 }
             }
         },


### PR DESCRIPTION
Implementing the GET /transaction/{UUID} REST API to retrieve an
individual transaction by it's UUID. Including the required Swagger
updates and API documentation updates.

Closes #388

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
