### PR TITLE
Fix cc dependencies [Issue #455]

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -244,9 +244,9 @@ chaincode:
 
     #timeout in millisecs for starting up a container and waiting for Register to come through. 1sec should be plenty for chaincode unit tests
     startuptimeout: 1000
-	
-	#timeout in millisecs for deploying chaincode from a remote repository.  This takes between 20 and 30 secs, typically.
-	deploytimeout: 30000
+
+    #timeout in millisecs for deploying chaincode from a remote repository.  This takes between 20 and 30 secs, typically.
+    deploytimeout: 30000
 
     #mode - options are "dev", "net"
     #dev - in dev mode, user runs the chaincode after starting validator from command line on local machine

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -244,6 +244,9 @@ chaincode:
 
     #timeout in millisecs for starting up a container and waiting for Register to come through. 1sec should be plenty for chaincode unit tests
     startuptimeout: 1000
+	
+	#timeout in millisecs for deploying chaincode from a remote repository.  This takes between 20 and 30 secs, typically.
+	deploytimeout: 30000
 
     #mode - options are "dev", "net"
     #dev - in dev mode, user runs the chaincode after starting validator from command line on local machine

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -245,7 +245,7 @@ chaincode:
     #timeout in millisecs for starting up a container and waiting for Register to come through. 1sec should be plenty for chaincode unit tests
     startuptimeout: 1000
 
-    #timeout in millisecs for deploying chaincode from a remote repository.  This takes between 20 and 30 secs, typically.
+    #timeout in millisecs for deploying chaincode from a remote repository.
     deploytimeout: 30000
 
     #mode - options are "dev", "net"

--- a/openchain/container/hashfromcode.go
+++ b/openchain/container/hashfromcode.go
@@ -140,21 +140,21 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	// Create a go routine that will wait for the command to finish
 	done := make(chan error, 1)
 	go func() {
-    	done <- cmd.Wait()
+		done <- cmd.Wait()
 	}()
 	
 	select {
 	case <-time.After(time.Duration(viper.GetInt("chaincode.deploytimeout")) * time.Millisecond):
 		// If pulling repos takes too long, we should give up
 		// (This can happen if a repo is private and the git clone asks for credentials)
-		if err := cmd.Process.Kill(); err != nil {
-			err = errors.New(fmt.Sprintf("failed to kill: %s", err))
+		if err = cmd.Process.Kill(); err != nil {
+			err = fmt.Errorf("failed to kill: %s", err)
 		}
 		err = errors.New("Getting chaincode took too long")
-	case err := <-done:
+	case err = <-done:
 		// If we're here, the 'go get' command must have finished
 		if err != nil {
-			err = errors.New(fmt.Sprintf("process done with error = %v", err))
+			err = fmt.Errorf("process done with error = %v", err)
 		}
 	}
 	return

--- a/openchain/container/hashfromcode.go
+++ b/openchain/container/hashfromcode.go
@@ -149,8 +149,9 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 		// (This can happen if a repo is private and the git clone asks for credentials)
 		if err = cmd.Process.Kill(); err != nil {
 			err = fmt.Errorf("failed to kill: %s", err)
+		} else {
+			err = errors.New("Getting chaincode took too long")
 		}
-		err = errors.New("Getting chaincode took too long")
 	case err = <-done:
 		// If we're here, the 'go get' command must have finished
 		if err != nil {


### PR DESCRIPTION
@muralisrini 

I've added a timeout to the process of pulling chaincode from a repository.  This fixes the issue where a peer will get stuck waiting for github repository credentials forever, messing up the peers environment variables (GOPATH gets modified during this process).  Instead of hanging, the timeout will cause getCodeFromHTTP to throw an error.  The client's chaincode still won't deploy if they have any dependencies in private repositories, but at least they will get an error instead of nothing.

I will remove the commented sections with another commit to this request once I have your approval.

Thanks!
