### PR TITLE
Introduce enable/disable setting for REST service

### DIFF
--- a/main.go
+++ b/main.go
@@ -355,8 +355,10 @@ func serve(args []string) error {
 
 	pb.RegisterOpenchainServer(grpcServer, serverOpenchain)
 
-	// Create and register the REST service
-	go rest.StartOpenchainRESTServer(serverOpenchain, serverDevops)
+	// Create and register the REST service if configured
+	if viper.GetBool("rest.enabled") {
+		go rest.StartOpenchainRESTServer(serverOpenchain, serverDevops)
+	}
 
 	rootNode, err := openchain.GetRootNode()
 	if err != nil {

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -18,6 +18,9 @@ cli:
 ###############################################################################
 rest:
 
+    # Enable/disable setting for the REST service.
+    enabled: true
+
     # The address that the REST service will listen on for incoming requests.
     address: 0.0.0.0:5000
 
@@ -227,7 +230,7 @@ chaincode:
 
     # The id is used by the Chaincode stub to register the executing Chaincode ID with the Peerand is generally supplied through ENV variables
     # the Path form of ID is provided when deploying the chaincode. The name is used for all other requests. The name is really a hashcode
-    # returned by the system in response to the deploy transaction. In development mode where user runs the chaincode, the name can be 
+    # returned by the system in response to the deploy transaction. In development mode where user runs the chaincode, the name can be
     # any string
     id:
         path:


### PR DESCRIPTION
Introduce the enable/disable setting for the REST service inside of
openchain.yaml.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
