### PR TITLE
Add transaction results to ledger.CommitTxBatch API. Resolves #483

### DIFF
--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -236,7 +236,7 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	// -----------------------------<Block #0>---------------------
 	// Add the 0th (genesis block)
 	ledger1.BeginTxBatch(0)
-	err := ledger1.CommitTxBatch(0, []*protos.Transaction{}, []byte("dummy-proof"))
+	err := ledger1.CommitTxBatch(0, []*protos.Transaction{}, nil, []byte("dummy-proof"))
 	if err != nil {
 		t.Fatalf("Error in commit: %s", err)
 	}
@@ -250,7 +250,7 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	// TODO Use chaincode instead of contract?
 	// TODO Two types of transactions. Execute transaction, deploy/delete/update contract
 	ledger1.BeginTxBatch(1)
-	transaction1a,err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
+	transaction1a, err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -260,18 +260,18 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	ledger1.TxBegin(transaction1a.Uuid)
 	ledger1.SetState("MyContract1", "code", []byte("code example"))
 	ledger1.TxFinished(transaction1a.Uuid, true)
-	ledger1.CommitTxBatch(1, []*protos.Transaction{transaction1a}, []byte("dummy-proof"))
+	ledger1.CommitTxBatch(1, []*protos.Transaction{transaction1a}, nil, []byte("dummy-proof"))
 	// -----------------------------</Block #1>-----------------------------------
 
 	// -----------------------------<Block #2>------------------------------------
 
 	ledger1.BeginTxBatch(2)
-	transaction2a,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
+	transaction2a, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction2b,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
+	transaction2b, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -284,7 +284,7 @@ func buildTestLedger1(ledger1 *ledger.Ledger, t *testing.T) {
 	ledger1.TxFinished(transaction2a.Uuid, true)
 
 	// Commit txbatch that creates the 2nd block on blockchain
-	ledger1.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, []byte("dummy-proof"))
+	ledger1.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, nil, []byte("dummy-proof"))
 	// -----------------------------</Block #2>-----------------------------------
 	return
 }
@@ -297,7 +297,7 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	// -----------------------------<Block #0>---------------------
 	// Add the 0th (genesis block)
 	ledger.BeginTxBatch(0)
-	ledger.CommitTxBatch(0, []*protos.Transaction{}, []byte("dummy-proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{}, nil, []byte("dummy-proof"))
 	// -----------------------------<Block #0>---------------------
 
 	// -----------------------------<Block #1>------------------------------------
@@ -307,7 +307,7 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	// TODO Use chaincode instead of contract?
 	// TODO Two types of transactions. Execute transaction, deploy/delete/update contract
 	ledger.BeginTxBatch(1)
-	transaction1a,err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
+	transaction1a, err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, generateUUID(t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -317,19 +317,19 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	ledger.TxBegin(transaction1a.Uuid)
 	ledger.SetState("MyContract1", "code", []byte("code example"))
 	ledger.TxFinished(transaction1a.Uuid, true)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction1a}, []byte("dummy-proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction1a}, nil, []byte("dummy-proof"))
 
 	// -----------------------------</Block #1>-----------------------------------
 
 	// -----------------------------<Block #2>------------------------------------
 
 	ledger.BeginTxBatch(2)
-	transaction2a,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
+	transaction2a, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction2b,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
+	transaction2b, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -342,23 +342,23 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	ledger.TxFinished(transaction2a.Uuid, true)
 
 	// Commit txbatch that creates the 2nd block on blockchain
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, []byte("dummy-proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction2a, transaction2b}, nil, []byte("dummy-proof"))
 	// -----------------------------</Block #2>-----------------------------------
 
 	// -----------------------------<Block #3>------------------------------------
 
 	ledger.BeginTxBatch(3)
-	transaction3a,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
+	transaction3a, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction3b,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
+	transaction3b, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction3c,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyImportantContract"}, generateUUID(t), "setZ", []string{"{z: \"super\"}"})
+	transaction3c, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyImportantContract"}, generateUUID(t), "setZ", []string{"{z: \"super\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -368,7 +368,7 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	ledger.SetState("MyOtherContract", "y", []byte("goodbuy"))
 	ledger.SetState("MyImportantContract", "z", []byte("super"))
 	ledger.TxFinished(transaction3a.Uuid, true)
-	ledger.CommitTxBatch(3, []*protos.Transaction{transaction3a, transaction3b, transaction3c}, []byte("dummy-proof"))
+	ledger.CommitTxBatch(3, []*protos.Transaction{transaction3a, transaction3b, transaction3c}, nil, []byte("dummy-proof"))
 
 	// -----------------------------</Block #3>-----------------------------------
 
@@ -378,22 +378,22 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	// Now we want to run the function 'setX' in 'MyContract
 
 	// Create a transaction'
-	transaction4a,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
+	transaction4a, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, generateUUID(t), "setX", []string{"{x: \"hello\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction4b,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
+	transaction4b, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyOtherContract"}, generateUUID(t), "setY", []string{"{y: \"goodbuy\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction4c,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyImportantContract"}, generateUUID(t), "setZ", []string{"{z: \"super\"}"})
+	transaction4c, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyImportantContract"}, generateUUID(t), "setZ", []string{"{z: \"super\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
 	}
-	transaction4d,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyMEGAContract"}, generateUUID(t), "setMEGA", []string{"{mega: \"MEGA\"}"})
+	transaction4d, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyMEGAContract"}, generateUUID(t), "setMEGA", []string{"{mega: \"MEGA\"}"})
 	if err != nil {
 		t.Logf("Error creating NewTransaction: %s", err)
 		t.Fail()
@@ -408,7 +408,7 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 	ledger.TxFinished(transaction4a.Uuid, true)
 
 	// Create the 4th block and add it to the chain
-	ledger.CommitTxBatch(4, []*protos.Transaction{transaction4a, transaction4b, transaction4c, transaction4d}, []byte("dummy-proof"))
+	ledger.CommitTxBatch(4, []*protos.Transaction{transaction4a, transaction4b, transaction4c, transaction4d}, nil, []byte("dummy-proof"))
 	// -----------------------------</Block #4>-----------------------------------
 
 	return

--- a/openchain/consensus/consensus.go
+++ b/openchain/consensus/consensus.go
@@ -37,7 +37,7 @@ type CPI interface {
 
 	BeginTxBatch(id interface{}) error
 	ExecTXs(txs []*pb.Transaction) ([]byte, []error)
-	CommitTxBatch(id interface{}, transactions []*pb.Transaction, proof []byte) error
+	CommitTxBatch(id interface{}, transactions []*pb.Transaction, transactionResults []*pb.TransactionResult, proof []byte) error
 	RollbackTxBatch(id interface{}) error
 
 	GetBlock(id uint64) (block *pb.Block, err error)

--- a/openchain/consensus/helper/helper.go
+++ b/openchain/consensus/helper/helper.go
@@ -142,12 +142,12 @@ func (h *Helper) ExecTXs(txs []*pb.Transaction) ([]byte, []error) {
 // transactions details and state changes (that may have happened
 // during execution of this transaction-batch) have been committed to
 // permanent storage.
-func (h *Helper) CommitTxBatch(id interface{}, transactions []*pb.Transaction, proof []byte) error {
+func (h *Helper) CommitTxBatch(id interface{}, transactions []*pb.Transaction, transactionsResults []*pb.TransactionResult, proof []byte) error {
 	ledger, err := ledger.GetLedger()
 	if err != nil {
 		return fmt.Errorf("Failed to get the ledger: %v", err)
 	}
-	if err := ledger.CommitTxBatch(id, transactions, proof); err != nil {
+	if err := ledger.CommitTxBatch(id, transactions, nil, proof); err != nil {
 		return fmt.Errorf("Failed to commit transaction to the ledger: %v", err)
 	}
 	return nil

--- a/openchain/consensus/noops/noops.go
+++ b/openchain/consensus/noops/noops.go
@@ -172,7 +172,7 @@ func (i *Noops) doTransactions(msg *pb.OpenchainMessage) error {
 	}
 
 	logger.Debug("Committing TX batch with timestamp: %v", msg.Timestamp)
-	if err := i.cpi.CommitTxBatch(msg.Timestamp, txarr, nil); err != nil {
+	if err := i.cpi.CommitTxBatch(msg.Timestamp, txarr, nil, nil); err != nil {
 		logger.Debug("Rolling back TX batch with timestamp: %v", msg.Timestamp)
 		i.cpi.RollbackTxBatch(msg.Timestamp)
 		return err

--- a/openchain/consensus/obcpbft/obc-batch.go
+++ b/openchain/consensus/obcpbft/obc-batch.go
@@ -192,7 +192,7 @@ func (op *obcBatch) execute(tbRaw []byte) {
 		return
 	}
 
-	if err = op.cpi.CommitTxBatch(txBatchID, txs, nil); err != nil {
+	if err = op.cpi.CommitTxBatch(txBatchID, txs, nil, nil); err != nil {
 		logger.Error("Failed to commit transaction batch %s to the ledger: %v", txBatchID, err)
 		if err = op.cpi.RollbackTxBatch(txBatchID); err != nil {
 			panic(fmt.Errorf("Unable to rollback transaction batch %s: %v", txBatchID, err))

--- a/openchain/consensus/obcpbft/obc-classic.go
+++ b/openchain/consensus/obcpbft/obc-classic.go
@@ -146,7 +146,7 @@ func (op *obcClassic) execute(txRaw []byte) {
 		return
 	}
 
-	if err = op.cpi.CommitTxBatch(txBatchID, txs, nil); err != nil {
+	if err = op.cpi.CommitTxBatch(txBatchID, txs, nil, nil); err != nil {
 		logger.Error("Failed to commit transaction %s to the ledger: %v", txBatchID, err)
 		if err = op.cpi.RollbackTxBatch(txBatchID); err != nil {
 			panic(fmt.Errorf("Unable to rollback transaction %s: %v", txBatchID, err))

--- a/openchain/consensus/obcpbft/obc-sieve.go
+++ b/openchain/consensus/obcpbft/obc-sieve.go
@@ -572,7 +572,7 @@ func (op *obcSieve) rollback() error {
 }
 
 func (op *obcSieve) commit() error {
-	if err := op.cpi.CommitTxBatch(op.currentReq, op.currentTx, nil); err != nil {
+	if err := op.cpi.CommitTxBatch(op.currentReq, op.currentTx, nil, nil); err != nil {
 		return fmt.Errorf("Fail to commit transaction: %v", err)
 	}
 	return nil

--- a/openchain/consensus/obcpbft/pbft-core_mock_test.go
+++ b/openchain/consensus/obcpbft/pbft-core_mock_test.go
@@ -174,7 +174,7 @@ func (inst *instance) ExecTXs(txs []*pb.Transaction) ([]byte, []error) {
 	return nil, errs
 }
 
-func (inst *instance) CommitTxBatch(id interface{}, txs []*pb.Transaction, proof []byte) error {
+func (inst *instance) CommitTxBatch(id interface{}, txs []*pb.Transaction, txResults []*pb.TransactionResult, proof []byte) error {
 	if !reflect.DeepEqual(inst.txID, id) {
 		return fmt.Errorf("Invalid batch ID")
 	}

--- a/openchain/ledger/genesis/genesis.go
+++ b/openchain/ledger/genesis/genesis.go
@@ -64,14 +64,14 @@ func MakeGenesis(secCxt crypto.Peer) error {
 
 		if genesis == nil {
 			genesisLogger.Info("No genesis block chaincodes defined.")
-			ledger.CommitTxBatch(0, genesisTransactions, nil)
+			ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
 			return
 		}
 
 		chaincodes, chaincodesOK := genesis["chaincode"].([]interface{})
 		if !chaincodesOK {
 			genesisLogger.Info("No genesis block chaincodes defined.")
-			ledger.CommitTxBatch(0, genesisTransactions, nil)
+			ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
 			return
 		}
 
@@ -156,7 +156,7 @@ func MakeGenesis(secCxt crypto.Peer) error {
 		}
 
 		genesisLogger.Info("Adding %d system chaincodes to the genesis block.", len(genesisTransactions))
-		ledger.CommitTxBatch(0, genesisTransactions, nil)
+		ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
 
 	})
 	return makeGenesisError

--- a/openchain/ledger/ledger.go
+++ b/openchain/ledger/ledger.go
@@ -110,7 +110,7 @@ func (ledger *Ledger) GetTXBatchPreviewBlock(id interface{},
 // CommitTxBatch - gets invoked when the current transaction-batch needs to be committed
 // This function returns successfully iff the transactions details and state changes (that
 // may have happened during execution of this transaction-batch) have been committed to permanent storage
-func (ledger *Ledger) CommitTxBatch(id interface{}, transactions []*protos.Transaction, proof []byte) error {
+func (ledger *Ledger) CommitTxBatch(id interface{}, transactions []*protos.Transaction, transactionResults []*protos.TransactionResult, proof []byte) error {
 	err := ledger.checkValidIDCommitORRollback(id)
 	if err != nil {
 		return err
@@ -128,6 +128,7 @@ func (ledger *Ledger) CommitTxBatch(id interface{}, transactions []*protos.Trans
 
 	writeBatch := gorocksdb.NewWriteBatch()
 	block := protos.NewBlock(transactions)
+	block.NonHashData = &protos.NonHashData{TransactionResults: transactionResults}
 	newBlockNumber, err := ledger.blockchain.addPersistenceChangesForNewBlock(context.TODO(), block, stateHash, writeBatch)
 	if err != nil {
 		success = false

--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -39,7 +39,7 @@ func TestLedgerCommit(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", false), []byte("value1"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1"))
 }
@@ -97,7 +97,7 @@ func TestLedgerDifferentID(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx(t)
-	err := ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("prrof"))
+	err := ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("prrof"))
 	testutil.AssertError(t, err, "ledger should throw error for wrong batch ID")
 }
 
@@ -128,7 +128,7 @@ func TestLedgerGetTempStateHashWithTxDeltaStateHashes(t *testing.T) {
 	if ok {
 		t.Fatalf("Entry for a failed Tx should not be present in txDeltaHashes map")
 	}
-	ledger.CommitTxBatch(1, []*protos.Transaction{}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{}, nil, []byte("proof"))
 
 	ledger.BeginTxBatch(2)
 	ledger.TxBegin("txUuid1")
@@ -150,7 +150,7 @@ func TestLedgerStateSnapshot(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	snapshot, err := ledger.GetStateSnapshot()
 
@@ -168,7 +168,7 @@ func TestLedgerStateSnapshot(t *testing.T) {
 	ledger.SetState("chaincode6", "key6", []byte("value6"))
 	ledger.TxFinished("txUuid", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	var count = 0
 	for snapshot.Next() {
@@ -206,7 +206,7 @@ func TestLedgerSetRawState(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	// Ensure values are in the DB
 	val := ledgerTestWrapper.GetState("chaincode1", "key1", true)
@@ -241,7 +241,7 @@ func TestLedgerSetRawState(t *testing.T) {
 	ledger.DeleteState("chaincode3", "key3")
 	ledger.TxFinished("txUuid2", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	// ensure keys are deleted
 	val = ledgerTestWrapper.GetState("chaincode1", "key1", true)
@@ -311,7 +311,7 @@ func TestDeleteAllStateKeysAndValues(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	// Confirm values are present in state
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1"))
@@ -337,7 +337,7 @@ func TestDeleteAllStateKeysAndValues(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	// Confirm values are present in state
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1"))
@@ -356,7 +356,7 @@ func TestVerifyChain(t *testing.T) {
 		ledger.SetState("chaincode"+strconv.Itoa(i), "key"+strconv.Itoa(i), []byte("value"+strconv.Itoa(i)))
 		ledger.TxFinished("txUuid"+strconv.Itoa(i), true)
 		transaction, _ := buildTestTx(t)
-		ledger.CommitTxBatch(i, []*protos.Transaction{transaction}, []byte("proof"))
+		ledger.CommitTxBatch(i, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	}
 
 	// Verify the chain
@@ -418,7 +418,7 @@ func TestBlockNumberOutOfBoundsError(t *testing.T) {
 		ledger.SetState("chaincode"+strconv.Itoa(i), "key"+strconv.Itoa(i), []byte("value"+strconv.Itoa(i)))
 		ledger.TxFinished("txUuid"+strconv.Itoa(i), true)
 		transaction, _ := buildTestTx(t)
-		ledger.CommitTxBatch(i, []*protos.Transaction{transaction}, []byte("proof"))
+		ledger.CommitTxBatch(i, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	}
 
 	ledgerTestWrapper.GetBlockByNumber(9)
@@ -444,7 +444,7 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3A"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
@@ -457,7 +457,7 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3B"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
@@ -471,7 +471,7 @@ func TestRollBackwardsAndForwards(t *testing.T) {
 	ledger.SetState("chaincode4", "key4", []byte("value4C"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3C"))
@@ -534,7 +534,7 @@ func TestInvalidOrderDelta(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3A"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
@@ -547,7 +547,7 @@ func TestInvalidOrderDelta(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3B"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
@@ -586,7 +586,7 @@ func TestApplyDeltaHash(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3A"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ := buildTestTx(t)
-	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2A"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3A"))
@@ -599,7 +599,7 @@ func TestApplyDeltaHash(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3B"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(1, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2B"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3B"))
@@ -613,7 +613,7 @@ func TestApplyDeltaHash(t *testing.T) {
 	ledger.SetState("chaincode4", "key4", []byte("value4C"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, _ = buildTestTx(t)
-	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(2, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode1", "key1", true), []byte("value1C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode2", "key2", true), []byte("value2C"))
 	testutil.AssertEquals(t, ledgerTestWrapper.GetState("chaincode3", "key3", true), []byte("value3C"))
@@ -668,7 +668,7 @@ func TestPreviewTXBatchBlock(t *testing.T) {
 	previewBlock, err := ledger.GetTXBatchPreviewBlock(0, []*protos.Transaction{transaction}, []byte("proof"))
 	testutil.AssertNoError(t, err, "Error fetching preview block.")
 
-	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, nil, []byte("proof"))
 	commitedBlock := ledgerTestWrapper.GetBlockByNumber(0)
 
 	previewBlockHash, err := previewBlock.GetHash()
@@ -692,7 +692,7 @@ func TestGetTransactionByUUID(t *testing.T) {
 	ledger.SetState("chaincode3", "key3", []byte("value3A"))
 	ledger.TxFinished("txUuid1", true)
 	transaction, uuid := buildTestTx(t)
-	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []byte("proof"))
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, nil, []byte("proof"))
 
 	ledgerTransaction, err := ledger.GetTransactionByUUID(uuid)
 	testutil.AssertNoError(t, err, "Error fetching transaction by UUID.")
@@ -701,4 +701,37 @@ func TestGetTransactionByUUID(t *testing.T) {
 	ledgerTransaction, err = ledger.GetTransactionByUUID("InvalidUUID")
 	testutil.AssertEquals(t, err, ErrResourceNotFound)
 	testutil.AssertNil(t, ledgerTransaction)
+}
+
+func TestTransactionResult(t *testing.T) {
+	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
+	ledger := ledgerTestWrapper.ledger
+
+	// Block 0
+	ledger.BeginTxBatch(0)
+	ledger.TxBegin("txUuid1")
+	ledger.SetState("chaincode1", "key1", []byte("value1A"))
+	ledger.SetState("chaincode2", "key2", []byte("value2A"))
+	ledger.SetState("chaincode3", "key3", []byte("value3A"))
+	ledger.TxFinished("txUuid1", true)
+	transaction, uuid := buildTestTx(t)
+
+	transactionResult := &protos.TransactionResult{Uuid: uuid, Error: "bad"}
+
+	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []*protos.TransactionResult{transactionResult}, []byte("proof"))
+
+	block := ledgerTestWrapper.GetBlockByNumber(0)
+
+	nonHashData := block.GetNonHashData()
+	if nonHashData == nil {
+		t.Fatal("Expected block to have non hash data, but non hash data was nil.")
+	}
+
+	if nonHashData.TransactionResults == nil || len(nonHashData.TransactionResults) == 0 {
+		t.Fatal("Expected block to have non hash data transaction results.")
+	}
+
+	testutil.AssertEquals(t, nonHashData.TransactionResults[0].Uuid, uuid)
+	testutil.AssertEquals(t, nonHashData.TransactionResults[0].Error, "bad")
+
 }

--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -716,7 +716,7 @@ func TestTransactionResult(t *testing.T) {
 	ledger.TxFinished("txUuid1", true)
 	transaction, uuid := buildTestTx(t)
 
-	transactionResult := &protos.TransactionResult{Uuid: uuid, Error: "bad"}
+	transactionResult := &protos.TransactionResult{Uuid: uuid, ErrorCode: 500, Error: "bad"}
 
 	ledger.CommitTxBatch(0, []*protos.Transaction{transaction}, []*protos.TransactionResult{transactionResult}, []byte("proof"))
 
@@ -733,5 +733,6 @@ func TestTransactionResult(t *testing.T) {
 
 	testutil.AssertEquals(t, nonHashData.TransactionResults[0].Uuid, uuid)
 	testutil.AssertEquals(t, nonHashData.TransactionResults[0].Error, "bad")
+	testutil.AssertEquals(t, nonHashData.TransactionResults[0].ErrorCode, uint32(500))
 
 }

--- a/openchain/ledger/pkg_test.go
+++ b/openchain/ledger/pkg_test.go
@@ -112,9 +112,9 @@ func (testWrapper *blockchainTestWrapper) populateBlockChainWithSampleData() (bl
 
 	// -----------------------------<Block 2>-------------------------------------
 	// Deploy a chaincode
-	transaction2a,err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, testutil.GenerateUUID(testWrapper.t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
+	transaction2a, err := protos.NewTransaction(protos.ChaincodeID{Path: "Contracts"}, testutil.GenerateUUID(testWrapper.t), "NewContract", []string{"name: MyContract1, code: var x; function setX(json) {x = json.x}}"})
 	if err != nil {
-		return nil,nil,err
+		return nil, nil, err
 	}
 	// Now we add the transaction to the block 2 and add the block to the chain
 	transactions2a := []*protos.Transaction{transaction2a}
@@ -127,9 +127,9 @@ func (testWrapper *blockchainTestWrapper) populateBlockChainWithSampleData() (bl
 
 	// -----------------------------<Block 3>-------------------------------------
 	// Create a transaction'
-	transaction3a,err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, testutil.GenerateUUID(testWrapper.t), "setX", []string{"{x: \"hello\"}"})
+	transaction3a, err := protos.NewTransaction(protos.ChaincodeID{Path: "MyContract"}, testutil.GenerateUUID(testWrapper.t), "setX", []string{"{x: \"hello\"}"})
 	if err != nil {
-		return nil,nil,err
+		return nil, nil, err
 	}
 	// Create the third block and add it to the chain
 	transactions3a := []*protos.Transaction{transaction3a}

--- a/protos/openchain.pb.go
+++ b/protos/openchain.pb.go
@@ -217,11 +217,13 @@ func (m *TransactionBlock) GetTransactions() []*Transaction {
 // not track potential state changes that were a result of the transaction.
 // uuid - The unique identifier of this transaction.
 // result - The return value of the transaction.
-// error - Any errors that occured as a result of running the transaction.
+// errorCode - An error code. 5xx will be logged as a failure in the dashboard.
+// errorCode - An error string for logging an issue.
 type TransactionResult struct {
-	Uuid   string `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
-	Result []byte `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
-	Error  string `protobuf:"bytes,3,opt,name=error" json:"error,omitempty"`
+	Uuid      string `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
+	Result    []byte `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
+	ErrorCode uint32 `protobuf:"varint,3,opt,name=errorCode" json:"errorCode,omitempty"`
+	Error     string `protobuf:"bytes,4,opt,name=error" json:"error,omitempty"`
 }
 
 func (m *TransactionResult) Reset()         { *m = TransactionResult{} }

--- a/protos/openchain.pb.go
+++ b/protos/openchain.pb.go
@@ -218,7 +218,7 @@ func (m *TransactionBlock) GetTransactions() []*Transaction {
 // uuid - The unique identifier of this transaction.
 // result - The return value of the transaction.
 // errorCode - An error code. 5xx will be logged as a failure in the dashboard.
-// errorCode - An error string for logging an issue.
+// error - An error string for logging an issue.
 type TransactionResult struct {
 	Uuid      string `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
 	Result    []byte `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`

--- a/protos/openchain.proto
+++ b/protos/openchain.proto
@@ -58,7 +58,7 @@ message TransactionBlock {
 // uuid - The unique identifier of this transaction.
 // result - The return value of the transaction.
 // errorCode - An error code. 5xx will be logged as a failure in the dashboard.
-// errorCode - An error string for logging an issue.
+// error - An error string for logging an issue.
 message TransactionResult {
   string uuid = 1;
   bytes result = 2;

--- a/protos/openchain.proto
+++ b/protos/openchain.proto
@@ -57,11 +57,13 @@ message TransactionBlock {
 // not track potential state changes that were a result of the transaction.
 // uuid - The unique identifier of this transaction.
 // result - The return value of the transaction.
-// error - Any errors that occured as a result of running the transaction.
+// errorCode - An error code. 5xx will be logged as a failure in the dashboard.
+// errorCode - An error string for logging an issue.
 message TransactionResult {
   string uuid = 1;
   bytes result = 2;
-  string error = 3;
+  uint32 errorCode = 3;
+  string error = 4;
 }
 
 // Block carries The data that describes a block in the blockchain.


### PR DESCRIPTION
This adds transaction results to the ledger.CommitTxBatch API allowing the consensus plugin to mark "failed" transactions.

Signed-off-by: sheehan@us.ibm.com
