### PR TITLE
Fix for issue #415. Alignment between obbca.yaml and openchain.yaml missing in PR #486.

### DIFF
--- a/obc-ca/obcca.yaml
+++ b/obc-ca/obcca.yaml
@@ -10,4 +10,7 @@ server:
 
 eca:
         users:
-#                 donq: 9gvZQRwhUq9q
+                donq: 7avZQLwcUe9q
+                nepumuk: 9gvZQRwhUq9q
+                jim: AwbeJH2kw9qK
+                lukas: NPKYL39uKbkj

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -139,9 +139,9 @@ peer:
         eca:
             paddr: localhost:50051
         tca:
-            paddr: localhost:50551
+            paddr: localhost:50051
         tlsca:
-            paddr: localhost:50951
+            paddr: localhost:50051
 
     # Peer discovery settings.  Controls how this peer discovers other peers
     discovery:

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -87,6 +87,21 @@ func TestMain(m *testing.M) {
 	os.Exit(ret)
 }
 
+func TestRegistrationSameEnrollIDDifferentRole(t *testing.T) {
+	conf := utils.NodeConfiguration{Type: "client", Name: "TestRegistrationSameEnrollIDDifferentRole"}
+	if err := RegisterClient(conf.Name, nil, conf.GetEnrollmentID(), conf.GetEnrollmentPWD()); err != nil {
+		t.Fatalf("Failed client registration [%s]", err)
+	}
+
+	if err := RegisterValidator(conf.Name, nil, conf.GetEnrollmentID(), conf.GetEnrollmentPWD()); err == nil {
+		t.Fatalf("Reusing the same enrollment id must be forbidden", err)
+	}
+
+	if err := RegisterPeer(conf.Name, nil, conf.GetEnrollmentID(), conf.GetEnrollmentPWD()); err == nil {
+		t.Fatalf("Reusing the same enrollment id must be forbidden", err)
+	}
+}
+
 func TestClientDeployTransaction(t *testing.T) {
 	_, tx, err := createConfidentialDeployTransaction()
 

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	_ "time"
 )
 
 var (

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -24,6 +24,7 @@ import (
 
 	"bytes"
 	"fmt"
+	"github.com/op/go-logging"
 	"github.com/openblockchain/obc-peer/obc-ca/obcca"
 	"github.com/openblockchain/obc-peer/openchain/crypto/utils"
 	"github.com/openblockchain/obc-peer/openchain/util"
@@ -649,6 +650,11 @@ func setup() {
 	if err != nil {                    // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file [%s] \n", err))
 	}
+	var formatter = logging.MustStringFormatter(
+		`%{color}%{time:15:04:05.000} [%{module}] %{shortfunc} [%{shortfile}] -> %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+	)
+	logging.SetFormatter(formatter)
+
 	removeFolders()
 }
 

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -6,6 +6,7 @@
 eca:
 
     users:
+        temp: 9gvZQRwhUq9q
         user1: 9gvZQRwhUq9q
         user2: 9gvZQRwhUq9q
         validator: 9gvZQRwhUq9q
@@ -46,6 +47,10 @@ tests:
     crypto:
 
         users:
+
+            temp:
+                enrollid: temp
+                enrollpw: 9gvZQRwhUq9q
 
             user1:
                 enrollid: user1

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -11,6 +11,7 @@ eca:
         user2: 9gvZQRwhUq9q
         validator: 9gvZQRwhUq9q
         peer: 9gvZQRwhUq9q
+        TestRegistrationSameEnrollIDDifferentRole: 9gvZQRwhUq9q
 
 server:
         version: "0.1"
@@ -67,3 +68,8 @@ tests:
             peer:
                 enrollid: peer
                 enrollpw: 9gvZQRwhUq9q
+
+            TestRegistrationSameEnrollIDDifferentRole:
+                enrollid: TestRegistrationSameEnrollIDDifferentRole
+                enrollpw: 9gvZQRwhUq9q
+

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -6,7 +6,6 @@
 eca:
 
     users:
-        TestRegistrationUser: 9gvZQRwhUq9q
         user1: 9gvZQRwhUq9q
         user2: 9gvZQRwhUq9q
         validator: 9gvZQRwhUq9q
@@ -48,10 +47,6 @@ tests:
     crypto:
 
         users:
-
-            TestRegistrationUser:
-                enrollid: TestRegistrationUser
-                enrollpw: 9gvZQRwhUq9q
 
             user1:
                 enrollid: user1

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -6,7 +6,7 @@
 eca:
 
     users:
-        temp: 9gvZQRwhUq9q
+        TestRegistrationUser: 9gvZQRwhUq9q
         user1: 9gvZQRwhUq9q
         user2: 9gvZQRwhUq9q
         validator: 9gvZQRwhUq9q
@@ -48,8 +48,8 @@ tests:
 
         users:
 
-            temp:
-                enrollid: temp
+            TestRegistrationUser:
+                enrollid: TestRegistrationUser
                 enrollpw: 9gvZQRwhUq9q
 
             user1:

--- a/openchain/crypto/node_eca.go
+++ b/openchain/crypto/node_eca.go
@@ -55,7 +55,7 @@ func (node *nodeImpl) retrieveECACertsChain(userID string) error {
 	}
 
 	// Store ECA cert
-	node.log.Debug("Storing ECA certificate for validator [%s]...", userID)
+	node.log.Debug("Storing ECA certificate for [%s]...", userID)
 
 	err = ioutil.WriteFile(node.conf.getECACertsChainPath(), utils.DERCertToPEM(ecaCertRaw), 0700)
 	if err != nil {

--- a/openchain/crypto/node_keys.go
+++ b/openchain/crypto/node_keys.go
@@ -48,7 +48,7 @@ func (node *nodeImpl) retrieveEnrollmentData(userID, pwd string) error {
 	//	validatorLogger.Info("Register:key  ", utils.EncodeBase64(key))
 
 	// Store enrollment  key
-	node.log.Debug("Storing enrollment data for user [%s]...", userID)
+	node.log.Debug("Storing enrollment data for [%s]...", userID)
 
 	rawKey, err := utils.PrivateKeyToPEM(key)
 	if err != nil {
@@ -157,7 +157,7 @@ func (node *nodeImpl) loadEnrollmentID() error {
 	return nil
 }
 
-func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string ) error {
+func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string) error {
 	key, tlsCertRaw, err := node.getTLSCertificateFromTLSCA(id, affiliation)
 	if err != nil {
 		node.log.Error("Failed getting tls certificate [id=%s] %s", id, err)
@@ -167,7 +167,7 @@ func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string ) error {
 	node.log.Info("Register:cert %s", utils.EncodeBase64(tlsCertRaw))
 
 	// Store enrollment  key
-	node.log.Info("Storing enrollment key and certificate for user [%s]...", id)
+	node.log.Info("Storing enrollment key and certificate for [%s]...", id)
 
 	rawKey, err := utils.PrivateKeyToPEM(key)
 	if err != nil {

--- a/openchain/crypto/node_tca.go
+++ b/openchain/crypto/node_tca.go
@@ -48,7 +48,7 @@ func (node *nodeImpl) retrieveTCACertsChain(userID string) error {
 	}
 
 	// Store TCA cert
-	node.log.Debug("Storing TCA certificate for validator [%s]...", userID)
+	node.log.Debug("Storing TCA certificate for [%s]...", userID)
 
 	err = ioutil.WriteFile(node.conf.getTCACertsChainPath(), utils.DERCertToPEM(tcaCertRaw), 0700)
 	if err != nil {


### PR DESCRIPTION
The ECA enforces that a pair (enrollID,enrollPWD) can be used only once. A test has been added to check this behavior.

The PR contains also an alignment between obbca.yaml and openchain.yaml that was missing in the PR #486.
Some minor cleanups are also in.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
