### PR TITLE
set default command line peer address to empty string

### DIFF
--- a/openchain/chaincode/shim/chaincode.go
+++ b/openchain/chaincode/shim/chaincode.go
@@ -67,7 +67,7 @@ func Start(cc Chaincode) error {
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
 
-	flag.StringVar(&peerAddress, "peer.address", "172.17.42.1:30303", "peer address")
+	flag.StringVar(&peerAddress, "peer.address", "", "peer address")
 
 	flag.Parse()
 


### PR DESCRIPTION
The fix is needed so chaincode with use ENV var if peer address is not passed in
