### PR TITLE
Add a version to the block message. Resolves #431

### DIFF
--- a/protos/openchain.pb.go
+++ b/protos/openchain.pb.go
@@ -232,6 +232,7 @@ func (m *TransactionResult) String() string { return proto.CompactTextString(m) 
 func (*TransactionResult) ProtoMessage()    {}
 
 // Block carries The data that describes a block in the blockchain.
+// version - Version used to track any protocol changes.
 // timestamp - The time at which the block or transaction order
 // was proposed. This may not be used by all consensus modules.
 // transactions - The ordered list of transactions in the block.
@@ -243,6 +244,7 @@ func (*TransactionResult) ProtoMessage()    {}
 // hash. This allows this data to be different per peer or discarded without
 // impacting the blockchain.
 type Block struct {
+	Version           uint32                     `protobuf:"varint,1,opt,name=version" json:"version,omitempty"`
 	Timestamp         *google_protobuf.Timestamp `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp,omitempty"`
 	Transactions      []*Transaction             `protobuf:"bytes,3,rep,name=transactions" json:"transactions,omitempty"`
 	StateHash         []byte                     `protobuf:"bytes,4,opt,name=stateHash,proto3" json:"stateHash,omitempty"`

--- a/protos/openchain.proto
+++ b/protos/openchain.proto
@@ -68,6 +68,7 @@ message TransactionResult {
 }
 
 // Block carries The data that describes a block in the blockchain.
+// version - Version used to track any protocol changes.
 // timestamp - The time at which the block or transaction order
 // was proposed. This may not be used by all consensus modules.
 // transactions - The ordered list of transactions in the block.
@@ -79,6 +80,7 @@ message TransactionResult {
 // hash. This allows this data to be different per peer or discarded without
 // impacting the blockchain.
 message Block {
+    uint32 version = 1;
     google.protobuf.Timestamp timestamp = 2;
     repeated Transaction transactions = 3;
     bytes stateHash = 4;


### PR DESCRIPTION
This adds a version to the protobuf block message to track any protocol changes. See issue #431 

Signed-off-by: sheehan@us.ibm.com
