### PR TITLE
TLS cert generation

### DIFF
--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -1,13 +1,13 @@
 ---
 server:
         version: "0.1"
-        rootpath: "/var/openchain/production"
+        rootpath: "."
         cadir: ".obcca"
-        port: ":50051"
+        port: ":50951"
         
         tls:
-#                certfile:
-#                keyfile:
+                certfile: ".obcca/tlsca.cert"
+                keyfile: ".obcca/tlsca.priv"
 
 ###############################################################################
 #

--- a/obc-ca/obcca/tlsca.go
+++ b/obc-ca/obcca/tlsca.go
@@ -120,7 +120,7 @@ func (tlscap *TLSCAP) CreateCertificate(ctx context.Context, req *pb.TLSCertCrea
 		return nil, err
 	}
 
-	return &pb.TLSCertCreateResp{&pb.Cert{raw}}, nil
+	return &pb.TLSCertCreateResp{&pb.Cert{raw}, &pb.Cert{tlscap.tlsca.raw}}, nil
 }
 
 // ReadCertificate reads an enrollment certificate from the TLSCA.

--- a/obc-ca/obcca/tlsca_test.go
+++ b/obc-ca/obcca/tlsca_test.go
@@ -1,0 +1,108 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package obcca
+
+import (
+	"golang.org/x/net/context"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
+
+	_ "fmt"
+	obcca "github.com/openblockchain/obc-peer/obc-ca/protos"
+)
+
+var (
+	eca_s   *ECA
+	tlsca_s *TLSCA
+	srv     *grpc.Server
+)
+
+func TestTLS(t *testing.T) {
+	go startTLSCA()
+
+	time.Sleep(time.Second * 30)
+
+	requestTLSCertificate()
+
+	stopTLSCA()
+}
+
+func startTLSCA() {
+	LogInit(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, os.Stdout)
+
+	eca_s = NewECA()
+	tlsca_s = NewTLSCA(eca_s)
+
+	var opts []grpc.ServerOption
+	creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.certfile"), viper.GetString("server.tls.keyfile"))
+	if err != nil {
+		panic("Failed creating credentials for TLS-CA service: " + err.Error())
+	}
+
+	opts = []grpc.ServerOption{grpc.Creds(creds)}
+
+	srv = grpc.NewServer(opts...)
+
+	eca_s.Start(srv)
+	tlsca_s.Start(srv)
+
+	sock, err := net.Listen("tcp", viper.GetString("server.port"))
+	if err != nil {
+		panic(err)
+	}
+
+	srv.Serve(sock)
+}
+
+func requestTLSCertificate() {
+	var opts []grpc.DialOption
+
+	creds, err := credentials.NewClientTLSFromFile(viper.GetString("server.tls.certfile"), "OBC")
+	if err != nil {
+		grpclog.Fatalf("Failed to create TLS credentials %v", err)
+	}
+
+	opts = append(opts, grpc.WithTransportCredentials(creds))
+	sockP, err := grpc.Dial(viper.GetString("peer.pki.tlsca.paddr"), opts...)
+	if err != nil {
+		grpclog.Fatalf("Failed dialing in: %s", err)
+	}
+
+	defer sockP.Close()
+
+	tlscaP := obcca.NewTLSCAPClient(sockP)
+
+	_, err = tlscaP.CreateCertificate(context.Background(), nil)
+	if err != nil {
+		grpclog.Fatalf("Failed requesting tls certificate: %s", err)
+	}
+}
+
+func stopTLSCA() {
+	srv.Stop()
+}

--- a/obc-ca/obcca/tlsca_test.go
+++ b/obc-ca/obcca/tlsca_test.go
@@ -95,7 +95,7 @@ func startTLSCA(t *testing.T) {
 func requestTLSCertificate(t *testing.T) {
 	var opts []grpc.DialOption
 
-	creds, err := credentials.NewClientTLSFromFile(viper.GetString("server.tls.certfile"), "OBC")
+	creds, err := credentials.NewClientTLSFromFile(viper.GetString("server.tls.certfile"), "tlsca")
 	if err != nil {
 		t.Logf("Failed creating credentials for TLS-CA client: %s", err)
 		t.Fail()

--- a/obc-ca/protos/ca.pb.go
+++ b/obc-ca/protos/ca.pb.go
@@ -667,7 +667,8 @@ func (m *TLSCertCreateReq) GetSig() *Signature {
 }
 
 type TLSCertCreateResp struct {
-	Cert *Cert `protobuf:"bytes,1,opt,name=cert" json:"cert,omitempty"`
+	Cert     *Cert `protobuf:"bytes,1,opt,name=cert" json:"cert,omitempty"`
+	RootCert *Cert `protobuf:"bytes,2,opt,name=rootCert" json:"rootCert,omitempty"`
 }
 
 func (m *TLSCertCreateResp) Reset()         { *m = TLSCertCreateResp{} }
@@ -677,6 +678,13 @@ func (*TLSCertCreateResp) ProtoMessage()    {}
 func (m *TLSCertCreateResp) GetCert() *Cert {
 	if m != nil {
 		return m.Cert
+	}
+	return nil
+}
+
+func (m *TLSCertCreateResp) GetRootCert() *Cert {
+	if m != nil {
+		return m.RootCert
 	}
 	return nil
 }

--- a/obc-ca/protos/ca.proto
+++ b/obc-ca/protos/ca.proto
@@ -240,6 +240,7 @@ message TLSCertCreateReq {
 
 message TLSCertCreateResp {
     Cert cert = 1;
+    Cert rootCert = 2;
 }
 
 message TLSCertReadReq {

--- a/openchain/crypto/node_conf.go
+++ b/openchain/crypto/node_conf.go
@@ -160,6 +160,10 @@ func (conf *configuration) getTLSCertFilename() string {
 	return "tls.cert"
 }
 
+func (conf *configuration) getTLSRootCertFilename() string {
+	return "tls.cert.chain"
+}
+
 func (conf *configuration) getEnrollmentChainKeyFilename() string {
 	return "chain.key"
 }

--- a/openchain/crypto/node_crypto.go
+++ b/openchain/crypto/node_crypto.go
@@ -36,6 +36,11 @@ func (node *nodeImpl) initCryptoEngine() error {
 	if err := node.loadEnrollmentChainKey(); err != nil {
 		return err
 	}
+	
+	// Load tls certificate
+ 	if err := node.loadTLSCertificate(); err != nil {
+ 		return err
+ 	}
 
 	node.log.Info("Initializing node crypto engine...done!")
 

--- a/openchain/crypto/node_impl.go
+++ b/openchain/crypto/node_impl.go
@@ -54,6 +54,9 @@ type nodeImpl struct {
 
 	// Enrollment Chain
 	enrollChainKey []byte
+	
+	// TLS
+ 	tlsCert *x509.Certificate
 }
 
 func (node *nodeImpl) GetName() string {

--- a/openchain/crypto/node_keys.go
+++ b/openchain/crypto/node_keys.go
@@ -151,13 +151,13 @@ func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string) error {
 	}
 
 	// Store tls cert
-	if err := node.ks.storeCert(node.conf.getTLSCertFilename(), utils.DERCertToPEM(tlsCertRaw)); err != nil {
+	if err := node.ks.storeCert(node.conf.getTLSCertFilename(), tlsCertRaw); err != nil {
 		node.log.Error("Failed storing tls certificate [id=%s]: %s", id, err)
 		return err
 	}
 
 	// Store tls root ca certificate
-	if err := node.ks.storeCert(node.conf.getTLSRootCertFilename(), utils.DERCertToPEM(tlsRootCertRaw)); err != nil {
+	if err := node.ks.storeCert(node.conf.getTLSRootCertFilename(), tlsRootCertRaw); err != nil {
 		node.log.Error("Failed storing tls root certificate [id=%s]: %s", id, err)
 		return err
 	}

--- a/openchain/crypto/node_keys.go
+++ b/openchain/crypto/node_keys.go
@@ -134,7 +134,7 @@ func (node *nodeImpl) loadEnrollmentID() error {
 }
 
 func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string) error {
-	key, tlsCertRaw, err := node.getTLSCertificateFromTLSCA(id, affiliation)
+	key, tlsCertRaw, tlsRootCertRaw, err := node.getTLSCertificateFromTLSCA(id, affiliation)
 	if err != nil {
 		node.log.Error("Failed getting tls certificate [id=%s] %s", id, err)
 
@@ -153,6 +153,12 @@ func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string) error {
 	// Store tls cert
 	if err := node.ks.storeCert(node.conf.getTLSCertFilename(), utils.DERCertToPEM(tlsCertRaw)); err != nil {
 		node.log.Error("Failed storing tls certificate [id=%s]: %s", id, err)
+		return err
+	}
+
+	// Store tls root ca certificate
+	if err := node.ks.storeCert(node.conf.getTLSRootCertFilename(), utils.DERCertToPEM(tlsRootCertRaw)); err != nil {
+		node.log.Error("Failed storing tls root certificate [id=%s]: %s", id, err)
 		return err
 	}
 

--- a/openchain/crypto/node_tlsca.go
+++ b/openchain/crypto/node_tlsca.go
@@ -34,6 +34,20 @@ import (
 	"time"
 )
 
+func (node *nodeImpl) loadTLSCertificate() error {
+ 	node.log.Debug("Loading tls certificate...")
+ 
+ 	cert, _, err := node.ks.loadCertX509AndDer(node.conf.getTLSCertFilename())
+ 	if err != nil {
+ 		node.log.Error("Failed parsing tls certificate [%s].", err.Error())
+ 
+ 		return err
+ 	}
+ 	node.tlsCert = cert
+ 
+ 	return nil
+}
+
 func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interface{}, []byte, []byte, error) {
 	node.log.Info("getTLSCertificate...")
 

--- a/openchain/crypto/node_tlsca.go
+++ b/openchain/crypto/node_tlsca.go
@@ -34,7 +34,7 @@ import (
 	"time"
 )
 
-func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interface{}, []byte, error) {
+func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interface{}, []byte, []byte, error) {
 	node.log.Info("getTLSCertificate...")
 
 	priv, err := utils.NewECDSAKey()
@@ -42,14 +42,14 @@ func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interf
 	if err != nil {
 		node.log.Error("Failed generating key: %s", err)
 
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	uuid, err := util.GenerateUUID()
 	if err != nil {
 		node.log.Error("Failed generating uuid: %s", err)
 
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Prepare the request
@@ -77,7 +77,7 @@ func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interf
 	if err != nil {
 		node.log.Error("Failed requesting tls certificate: %s", err)
 
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	node.log.Info("Verifing tls certificate...")
@@ -88,7 +88,7 @@ func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interf
 
 	node.log.Info("Verifing tls certificate...done!")
 
-	return priv, pbCert.Cert.Cert, nil
+	return priv, pbCert.Cert.Cert, pbCert.RootCert.Cert, nil
 }
 
 func (node *nodeImpl) callTLSCACreateCertificate(ctx context.Context, in *obcca.TLSCertCreateReq, opts ...grpc.CallOption) (*obcca.TLSCertCreateResp, error) {


### PR DESCRIPTION
- Added the retrieval of the TLS CA root certificate when requesting a TLS certificate to the TLS-CA in order to allow un-authenticated client connections.
- Fixed TLS certs storage (code from @adecaro to fix issue #534)
- Added tlsca_test.go. The test performs an un-authenticated client connection using tls against the TLS-CA and requests a tls certificate. The test is working but it is skipped since it is just an example on how to perform the connection.
