### PR TITLE
Changed key usage for TLS certificates

### DIFF
--- a/obc-ca/obcca/tlsca.go
+++ b/obc-ca/obcca/tlsca.go
@@ -115,7 +115,7 @@ func (tlscap *TLSCAP) CreateCertificate(ctx context.Context, req *pb.TLSCertCrea
 		return nil, errors.New("signature does not verify")
 	}
 
-	if raw, err = tlscap.tlsca.createCertificate(id, pub.(*ecdsa.PublicKey), x509.KeyUsageKeyAgreement, req.Ts.Seconds, nil); err != nil {
+	if raw, err = tlscap.tlsca.createCertificate(id, pub.(*ecdsa.PublicKey), x509.KeyUsageDigitalSignature, req.Ts.Seconds, nil); err != nil {
 		Error.Println(err)
 		return nil, err
 	}


### PR DESCRIPTION
After checking with David we changed the Key usage attribute of the TLS certificates to KeyUsageDigitalSignature.

@jeffgarratt, @binhn this is the right key usage to use for TLS certificates
