### PR TITLE
If TLS to obc-ca is disabled then tls root cert must not loaded.

### DIFF
--- a/openchain/crypto/node_tlsca.go
+++ b/openchain/crypto/node_tlsca.go
@@ -40,23 +40,27 @@ import (
 func (node *nodeImpl) initTLS() error {
 	node.log.Debug("Initiliazing TLS...")
 
-	pem, err := node.ks.loadExternalCert(node.conf.getTLSCACertsExternalPath())
-	if err != nil {
-		node.log.Error("Failed loading TLSCA certificates chain [%s].", err.Error())
+	if node.conf.isTLSEnabled() {
+		pem, err := node.ks.loadExternalCert(node.conf.getTLSCACertsExternalPath())
+		if err != nil {
+			node.log.Error("Failed loading TLSCA certificates chain [%s].", err.Error())
 
-		return err
-	}
+			return err
+		}
 
-	node.tlsCertPool = x509.NewCertPool()
-	ok := node.tlsCertPool.AppendCertsFromPEM(pem)
-	if !ok {
-		node.log.Error("Failed appending TLSCA certificates chain.")
+		node.tlsCertPool = x509.NewCertPool()
+		ok := node.tlsCertPool.AppendCertsFromPEM(pem)
+		if !ok {
+			node.log.Error("Failed appending TLSCA certificates chain.")
 
-		return errors.New("Failed appending TLSCA certificates chain.")
+			return errors.New("Failed appending TLSCA certificates chain.")
+		}
+		node.log.Debug("Initiliazing TLS...Done")
+	} else {
+		node.log.Debug("Initiliazing TLS...Disabled!!!")
 	}
 
 	return nil
-
 }
 
 func (node *nodeImpl) retrieveTLSCertificate(id, affiliation string) error {
@@ -100,20 +104,28 @@ func (node *nodeImpl) loadTLSCertificate() error {
 }
 
 func (node *nodeImpl) loadTLSCACertsChain() error {
-	node.log.Debug("Loading TLSCA certificates chain...")
+	if node.conf.isTLSEnabled() {
+		node.log.Debug("Loading TLSCA certificates chain...")
 
-	pem, err := node.ks.loadExternalCert(node.conf.getTLSCACertsExternalPath())
-	if err != nil {
-		node.log.Error("Failed loading TLSCA certificates chain [%s].", err.Error())
+		pem, err := node.ks.loadExternalCert(node.conf.getTLSCACertsExternalPath())
+		if err != nil {
+			node.log.Error("Failed loading TLSCA certificates chain [%s].", err.Error())
 
-		return err
-	}
+			return err
+		}
 
-	ok := node.tlsCertPool.AppendCertsFromPEM(pem)
-	if !ok {
-		node.log.Error("Failed appending TLSCA certificates chain.")
+		ok := node.tlsCertPool.AppendCertsFromPEM(pem)
+		if !ok {
+			node.log.Error("Failed appending TLSCA certificates chain.")
 
-		return errors.New("Failed appending TLSCA certificates chain.")
+			return errors.New("Failed appending TLSCA certificates chain.")
+		}
+
+		node.log.Debug("Loading TLSCA certificates chain...done")
+
+		return nil
+	} else {
+		node.log.Debug("TLS is disabled!!!")
 	}
 
 	return nil


### PR DESCRIPTION
This PR is to address Issue 580. Namely, when TLS connections to obc-ca are disabled then tls root cert is not loaded.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
