### PR TITLE
Normalize the processing of logging options for obc-peer

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -27,6 +27,45 @@ rest:
     address: 0.0.0.0:5000
 
 
+###############################################################################
+#
+#    LOGGING section
+#
+###############################################################################
+logging:
+
+    # Valid logging levels are case-insensitive strings chosen from
+
+    #     CRITICAL | ERROR | WARNING | NOTICE | INFO | DEBUG
+
+    # Logging 'module' names are also strings, however valid module names are
+    # defined at runtime and are not checked for validity during option
+    # processing.
+
+    # Default logging levels are specified here for each of the obc-peer
+    # commands. For commands that have subcommands, the defaults also apply to
+    # all subcommands of the command. These logging levels can be overridden
+    # on the command line using the --logging-level command-line option, or by
+    # setting the OPENCHAIN_LOGGING_LEVEL environment variable.
+
+    # The logging level specification is of the form
+
+    #     [<module>[,<module>...]=]<level>[:[<module>[,<module>...]=]<level>...]
+
+    # A logging level by itself is taken as the overall default. Otherwise,
+    # overrides for individual or groups of modules can be specified using the 
+    # <module>[,<module>...]=<level> syntax.
+    
+    # Examples:
+    #   info                                       - Set default to INFO
+    #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
+    #   chaincode=info:main=debug:db=debug:warning - Same as above
+    peer:      info
+    status:    warning
+    stop:      warning
+    login:     warning
+    vm:        warning
+    chaincode: warning
 
 
 ###############################################################################
@@ -72,13 +111,6 @@ peer:
     address: 0.0.0.0:30303
     # Whether the Peer should programmatically determine the address to bind to. This case is useful for docker containers.
     addressAutoDetect: false
-
-
-    # Logging settings
-    logging:
-        # Logging level, can be one of [error|warning|info|debug]
-        # One of: CRITICAL | ERROR | WARNING | NOTICE | INFO | DEBUG
-        level: DEBUG
 
     # Peer port to accept connections on
     port:    30303

--- a/openchain/chaincode/config.go
+++ b/openchain/chaincode/config.go
@@ -39,14 +39,14 @@ func init() {
 
 // SetupTestLogging setup the logging during test execution
 func SetupTestLogging() {
-	level, err := logging.LogLevel(viper.GetString("peer.logging.level"))
+	level, err := logging.LogLevel(viper.GetString("logging.peer"))
 	if err == nil {
 		// No error, use the setting
 		logging.SetLevel(level, "main")
 		logging.SetLevel(level, "server")
 		logging.SetLevel(level, "peer")
 	} else {
-		chaincodeLog.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("peer.logging.level"), logging.ERROR, err)
+		chaincodeLog.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("logging.peer"), logging.ERROR, err)
 		logging.SetLevel(logging.ERROR, "main")
 		logging.SetLevel(logging.ERROR, "server")
 		logging.SetLevel(logging.ERROR, "peer")

--- a/openchain/config/config.go
+++ b/openchain/config/config.go
@@ -41,7 +41,7 @@ func init() {
 
 // SetupTestLogging setup the logging during test execution
 func SetupTestLogging() {
-	level, err := logging.LogLevel(viper.GetString("peer.logging.level"))
+	level, err := logging.LogLevel(viper.GetString("logging.peer"))
 	if err == nil {
 		// No error, use the setting
 		logging.SetLevel(level, "main")

--- a/openchain/config/config.go
+++ b/openchain/config/config.go
@@ -48,7 +48,7 @@ func SetupTestLogging() {
 		logging.SetLevel(level, "server")
 		logging.SetLevel(level, "peer")
 	} else {
-		configLogger.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("peer.logging.level"), logging.ERROR, err)
+		configLogger.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("logging.peer"), logging.ERROR, err)
 		logging.SetLevel(logging.ERROR, "main")
 		logging.SetLevel(logging.ERROR, "server")
 		logging.SetLevel(logging.ERROR, "peer")


### PR DESCRIPTION
This is a proposed change that addresses #569 and #310, and also partially
addresses #578. The handling of logging levels, and ways of managing logging
levels are currently inconsistent and incomplete in the obc-peer
application. In this change:

Logging options are now top-level options in the openchain.yaml file and on
the command line. A single command-line option '--logging-level' applies to
all commands. In the openchain.yaml however, defaults can be set for each of
the obc-peer commands individually. This made sense to me since it seems
reasonable that logging requirements are likely different for server
vs. client commands.

The syntax for specifying logging levels allows the specification of both a
default level for all modules as well as module-specific levels.

The file openchain/logging.go had originally been copied from the examples of
the op/go-logging package, and was therefore mostly dead and irrelevant
code. This file has been completely replaced. This file now defines a 'hook'
routine that is called during the Cobra processing of the obc-peer commands to
set up logging options.  This hook correctly allows command-line options to
override config file options (cf. #578).

main.go was simplified by removing all of the module-specific setup, and the
logging command-line options were promoted to global options. The new hook is
installed in the Cobra Command structures.

The default logging level for the 'peer' server is now INFO; For the other
client commands the default level is WARNING. Developers and others can easily
override these setting in their openchain.yaml files or on the command line or
environment of each invocation of obc-peer.
