### PR TITLE
Add iterator for range query

### DIFF
--- a/openchain/api_test.go
+++ b/openchain/api_test.go
@@ -415,9 +415,5 @@ func buildTestLedger2(ledger *ledger.Ledger, t *testing.T) {
 }
 
 func generateUUID(t *testing.T) string {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		t.Fatalf("Error generating UUID: %s", err)
-	}
-	return uuid
+	return util.GenerateUUID()
 }

--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/openblockchain/obc-peer/openchain/container"
 	"github.com/openblockchain/obc-peer/openchain/crypto"
-	"github.com/openblockchain/obc-peer/openchain/ledger/statemgmt"
 	pb "github.com/openblockchain/obc-peer/protos"
 )
 
@@ -178,7 +177,6 @@ func (chaincodeSupport *ChaincodeSupport) registerHandler(chaincodehandler *Hand
 	chaincodehandler.txCtxs = make(map[string]*transactionContext)
 	chaincodehandler.uuidMap = make(map[string]bool)
 	chaincodehandler.isTransaction = make(map[string]bool)
-	chaincodehandler.rangeQueryIteratorMap = make(map[string]statemgmt.RangeScanIterator)
 
 	chaincodeLogger.Debug("registered handler complete for chaincode %s", key)
 
@@ -188,9 +186,10 @@ func (chaincodeSupport *ChaincodeSupport) registerHandler(chaincodehandler *Hand
 func (chaincodeSupport *ChaincodeSupport) deregisterHandler(chaincodehandler *Handler) error {
 
 	// clean up rangeQueryIteratorMap
-	// TODO This should happen after each transaction!
-	for _, v := range chaincodehandler.rangeQueryIteratorMap {
-		v.Close()
+	for _, context := range chaincodehandler.txCtxs {
+		for _, v := range context.rangeQueryIteratorMap {
+			v.Close()
+		}
 	}
 
 	key := chaincodehandler.ChaincodeID.Name

--- a/openchain/chaincode/exectransaction_test.go
+++ b/openchain/chaincode/exectransaction_test.go
@@ -43,6 +43,7 @@ func getNowMillis() int64 {
 	nanos := time.Now().UnixNano()
 	return nanos / 1000000
 }
+
 // Build a chaincode.
 func getDeploymentSpec(context context.Context, spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
 	fmt.Printf("getting deployment spec for chaincode spec: %v\n", spec)
@@ -80,10 +81,7 @@ func invoke(ctx context.Context, spec *pb.ChaincodeSpec, typ pb.Transaction_Type
 	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
 
 	// Now create the Transactions message and send to Peer.
-	uuid, uuidErr := util.GenerateUUID()
-	if uuidErr != nil {
-		return "", nil, uuidErr
-	}
+	uuid := util.GenerateUUID()
 
 	transaction, err := pb.NewChaincodeExecute(chaincodeInvocationSpec, uuid, typ)
 	if err != nil {
@@ -416,7 +414,7 @@ func TestExecuteQuery(t *testing.T) {
 		return
 	}
 
-	time.Sleep(2*time.Second)
+	time.Sleep(2 * time.Second)
 
 	//start := getNowMillis()
 	//fmt.Fprintf(os.Stderr, "Starting: %d\n", start)

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -24,6 +24,13 @@ import (
 
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
 	"github.com/op/go-logging"
 	"github.com/openblockchain/obc-peer/obc-ca/obcca"
 	"github.com/openblockchain/obc-peer/openchain/crypto/utils"
@@ -31,12 +38,6 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io/ioutil"
-	"net"
-	"os"
-	"path/filepath"
-	"reflect"
-	"testing"
 )
 
 type createTxFunc func(t *testing.T) (*obc.Transaction, *obc.Transaction, error)
@@ -976,10 +977,7 @@ func initValidators() error {
 }
 
 func createConfidentialDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cds := &obc.ChaincodeDeploymentSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1001,10 +999,7 @@ func createConfidentialDeployTransaction(t *testing.T) (*obc.Transaction, *obc.T
 }
 
 func createConfidentialExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1024,10 +1019,7 @@ func createConfidentialExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.
 }
 
 func createConfidentialQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1047,10 +1039,7 @@ func createConfidentialQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Tr
 }
 
 func createConfidentialTCertHDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cds := &obc.ChaincodeDeploymentSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1097,10 +1086,7 @@ func createConfidentialTCertHDeployTransaction(t *testing.T) (*obc.Transaction, 
 }
 
 func createConfidentialTCertHExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1145,10 +1131,7 @@ func createConfidentialTCertHExecuteTransaction(t *testing.T) (*obc.Transaction,
 }
 
 func createConfidentialTCertHQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1193,10 +1176,7 @@ func createConfidentialTCertHQueryTransaction(t *testing.T) (*obc.Transaction, *
 }
 
 func createConfidentialECertHDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cds := &obc.ChaincodeDeploymentSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1243,10 +1223,7 @@ func createConfidentialECertHDeployTransaction(t *testing.T) (*obc.Transaction, 
 }
 
 func createConfidentialECertHExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1291,10 +1268,7 @@ func createConfidentialECertHExecuteTransaction(t *testing.T) (*obc.Transaction,
 }
 
 func createConfidentialECertHQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1339,10 +1313,7 @@ func createConfidentialECertHQueryTransaction(t *testing.T) (*obc.Transaction, *
 }
 
 func createPublicDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cds := &obc.ChaincodeDeploymentSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1364,10 +1335,7 @@ func createPublicDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transac
 }
 
 func createPublicExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{
@@ -1387,10 +1355,7 @@ func createPublicExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transa
 }
 
 func createPublicQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Transaction, error) {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	cis := &obc.ChaincodeInvocationSpec{
 		ChaincodeSpec: &obc.ChaincodeSpec{

--- a/openchain/crypto/node_tlsca.go
+++ b/openchain/crypto/node_tlsca.go
@@ -27,14 +27,15 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"google/protobuf"
+	"time"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/openblockchain/obc-peer/openchain/crypto/utils"
 	"github.com/openblockchain/obc-peer/openchain/util"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google/protobuf"
-	"time"
 )
 
 func (node *nodeImpl) initTLS() error {
@@ -142,12 +143,7 @@ func (node *nodeImpl) getTLSCertificateFromTLSCA(id, affiliation string) (interf
 		return nil, nil, err
 	}
 
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		node.log.Error("Failed generating uuid: %s", err)
-
-		return nil, nil, err
-	}
+	uuid := util.GenerateUUID()
 
 	// Prepare the request
 	pubraw, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)

--- a/openchain/devops.go
+++ b/openchain/devops.go
@@ -176,11 +176,7 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 	}
 
 	// Now create the Transactions message and send to Peer.
-	uuid, uuidErr := util.GenerateUUID()
-	if uuidErr != nil {
-		devopsLogger.Error(fmt.Sprintf("Error generating UUID: %s", uuidErr))
-		return nil, uuidErr
-	}
+	uuid := util.GenerateUUID()
 	var transaction *pb.Transaction
 	var err error
 	var sec crypto.Client

--- a/openchain/ledger/pkg_test.go
+++ b/openchain/ledger/pkg_test.go
@@ -143,7 +143,7 @@ func (testWrapper *blockchainTestWrapper) populateBlockChainWithSampleData() (bl
 }
 
 func buildTestTx(t *testing.T) (*protos.Transaction, string) {
-	uuid, _ := util.GenerateUUID()
+	uuid := util.GenerateUUID()
 	tx, err := protos.NewTransaction(protos.ChaincodeID{Path: "testUrl"}, uuid, "anyfunction", []string{"param1, param2"})
 	testutil.AssertNil(t, err)
 	return tx, uuid

--- a/openchain/ledger/testutil/test_util.go
+++ b/openchain/ledger/testutil/test_util.go
@@ -21,12 +21,13 @@ package testutil
 
 import (
 	"fmt"
-	"github.com/op/go-logging"
-	"github.com/openblockchain/obc-peer/openchain/util"
-	"github.com/spf13/viper"
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/op/go-logging"
+	"github.com/openblockchain/obc-peer/openchain/util"
+	"github.com/spf13/viper"
 )
 
 func SetupTestConfig() {
@@ -140,10 +141,7 @@ func AppendAll(content ...[]byte) []byte {
 }
 
 func GenerateUUID(t *testing.T) string {
-	uuid, err := util.GenerateUUID()
-	if err != nil {
-		t.Fatalf("Error generating UUI - Error: %s\n %s", err, getCallerInfo())
-	}
+	uuid := util.GenerateUUID()
 	return uuid
 }
 

--- a/openchain/util/utils.go
+++ b/openchain/util/utils.go
@@ -25,8 +25,9 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/crypto/sha3"
 	gp "google/protobuf"
+
+	"golang.org/x/crypto/sha3"
 )
 
 // ComputeCryptoHash should be used in openchain code so that we can change the actual algo used for crypto-hash at one place
@@ -37,11 +38,11 @@ func ComputeCryptoHash(data []byte) (hash []byte) {
 }
 
 // GenerateUUID returns a UUID based on RFC 4112
-func GenerateUUID() (string, error) {
+func GenerateUUID() string {
 	uuid := make([]byte, 16)
 	_, err := io.ReadFull(rand.Reader, uuid)
 	if err != nil {
-		return "", err
+		panic(fmt.Sprintf("Error generating UUID: %s", err))
 	}
 
 	// variant bits; see section 4.1.1
@@ -50,7 +51,7 @@ func GenerateUUID() (string, error) {
 	// version 4 (pseudo-random); see section 4.1.3
 	uuid[6] = uuid[6]&^0xf0 | 0x40
 
-	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:])
 }
 
 // CreateUtcTimestamp returns a google/protobuf/Timestamp in UTC

--- a/openchain/util/utils_test.go
+++ b/openchain/util/utils_test.go
@@ -35,17 +35,11 @@ func TestComputeCryptoHash(t *testing.T) {
 }
 
 func TestUUIDGeneration(t *testing.T) {
-	uuid, err := GenerateUUID()
-	if err != nil {
-		t.Fatalf("Error generating UUID. Error: %s", err)
-	}
+	uuid := GenerateUUID()
 	if len(uuid) != 36 {
 		t.Fatalf("UUID length is not correct. Expected = 36, Got = %d", len(uuid))
 	}
-	uuid2, err2 := GenerateUUID()
-	if err2 != nil {
-		t.Fatalf("Error generating UUID. Error: %s", err)
-	}
+	uuid2 := GenerateUUID()
 	if uuid == uuid2 {
 		t.Fatalf("Two UUIDs are equal. This should never occur")
 	}

--- a/protos/api.pb.go
+++ b/protos/api.pb.go
@@ -27,7 +27,9 @@ It has these top-level messages:
 	ChaincodeExecutionContext
 	ChaincodeMessage
 	PutStateInfo
-	RangeQueryStateInfo
+	RangeQueryState
+	RangeQueryStateNext
+	RangeQueryStateClose
 	RangeQueryStateKeyValue
 	RangeQueryStateResponse
 	Secret

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -66,24 +66,26 @@ func (x ChaincodeSpec_Type) String() string {
 type ChaincodeMessage_Type int32
 
 const (
-	ChaincodeMessage_UNDEFINED         ChaincodeMessage_Type = 0
-	ChaincodeMessage_REGISTER          ChaincodeMessage_Type = 1
-	ChaincodeMessage_REGISTERED        ChaincodeMessage_Type = 2
-	ChaincodeMessage_INIT              ChaincodeMessage_Type = 3
-	ChaincodeMessage_READY             ChaincodeMessage_Type = 4
-	ChaincodeMessage_TRANSACTION       ChaincodeMessage_Type = 5
-	ChaincodeMessage_COMPLETED         ChaincodeMessage_Type = 6
-	ChaincodeMessage_ERROR             ChaincodeMessage_Type = 7
-	ChaincodeMessage_GET_STATE         ChaincodeMessage_Type = 8
-	ChaincodeMessage_PUT_STATE         ChaincodeMessage_Type = 9
-	ChaincodeMessage_DEL_STATE         ChaincodeMessage_Type = 10
-	ChaincodeMessage_INVOKE_CHAINCODE  ChaincodeMessage_Type = 11
-	ChaincodeMessage_INVOKE_QUERY      ChaincodeMessage_Type = 12
-	ChaincodeMessage_RESPONSE          ChaincodeMessage_Type = 13
-	ChaincodeMessage_QUERY             ChaincodeMessage_Type = 14
-	ChaincodeMessage_QUERY_COMPLETED   ChaincodeMessage_Type = 15
-	ChaincodeMessage_QUERY_ERROR       ChaincodeMessage_Type = 16
-	ChaincodeMessage_RANGE_QUERY_STATE ChaincodeMessage_Type = 17
+	ChaincodeMessage_UNDEFINED               ChaincodeMessage_Type = 0
+	ChaincodeMessage_REGISTER                ChaincodeMessage_Type = 1
+	ChaincodeMessage_REGISTERED              ChaincodeMessage_Type = 2
+	ChaincodeMessage_INIT                    ChaincodeMessage_Type = 3
+	ChaincodeMessage_READY                   ChaincodeMessage_Type = 4
+	ChaincodeMessage_TRANSACTION             ChaincodeMessage_Type = 5
+	ChaincodeMessage_COMPLETED               ChaincodeMessage_Type = 6
+	ChaincodeMessage_ERROR                   ChaincodeMessage_Type = 7
+	ChaincodeMessage_GET_STATE               ChaincodeMessage_Type = 8
+	ChaincodeMessage_PUT_STATE               ChaincodeMessage_Type = 9
+	ChaincodeMessage_DEL_STATE               ChaincodeMessage_Type = 10
+	ChaincodeMessage_INVOKE_CHAINCODE        ChaincodeMessage_Type = 11
+	ChaincodeMessage_INVOKE_QUERY            ChaincodeMessage_Type = 12
+	ChaincodeMessage_RESPONSE                ChaincodeMessage_Type = 13
+	ChaincodeMessage_QUERY                   ChaincodeMessage_Type = 14
+	ChaincodeMessage_QUERY_COMPLETED         ChaincodeMessage_Type = 15
+	ChaincodeMessage_QUERY_ERROR             ChaincodeMessage_Type = 16
+	ChaincodeMessage_RANGE_QUERY_STATE       ChaincodeMessage_Type = 17
+	ChaincodeMessage_RANGE_QUERY_STATE_NEXT  ChaincodeMessage_Type = 18
+	ChaincodeMessage_RANGE_QUERY_STATE_CLOSE ChaincodeMessage_Type = 19
 )
 
 var ChaincodeMessage_Type_name = map[int32]string{
@@ -105,26 +107,30 @@ var ChaincodeMessage_Type_name = map[int32]string{
 	15: "QUERY_COMPLETED",
 	16: "QUERY_ERROR",
 	17: "RANGE_QUERY_STATE",
+	18: "RANGE_QUERY_STATE_NEXT",
+	19: "RANGE_QUERY_STATE_CLOSE",
 }
 var ChaincodeMessage_Type_value = map[string]int32{
-	"UNDEFINED":         0,
-	"REGISTER":          1,
-	"REGISTERED":        2,
-	"INIT":              3,
-	"READY":             4,
-	"TRANSACTION":       5,
-	"COMPLETED":         6,
-	"ERROR":             7,
-	"GET_STATE":         8,
-	"PUT_STATE":         9,
-	"DEL_STATE":         10,
-	"INVOKE_CHAINCODE":  11,
-	"INVOKE_QUERY":      12,
-	"RESPONSE":          13,
-	"QUERY":             14,
-	"QUERY_COMPLETED":   15,
-	"QUERY_ERROR":       16,
-	"RANGE_QUERY_STATE": 17,
+	"UNDEFINED":               0,
+	"REGISTER":                1,
+	"REGISTERED":              2,
+	"INIT":                    3,
+	"READY":                   4,
+	"TRANSACTION":             5,
+	"COMPLETED":               6,
+	"ERROR":                   7,
+	"GET_STATE":               8,
+	"PUT_STATE":               9,
+	"DEL_STATE":               10,
+	"INVOKE_CHAINCODE":        11,
+	"INVOKE_QUERY":            12,
+	"RESPONSE":                13,
+	"QUERY":                   14,
+	"QUERY_COMPLETED":         15,
+	"QUERY_ERROR":             16,
+	"RANGE_QUERY_STATE":       17,
+	"RANGE_QUERY_STATE_NEXT":  18,
+	"RANGE_QUERY_STATE_CLOSE": 19,
 }
 
 func (x ChaincodeMessage_Type) String() string {
@@ -312,15 +318,30 @@ func (m *PutStateInfo) Reset()         { *m = PutStateInfo{} }
 func (m *PutStateInfo) String() string { return proto.CompactTextString(m) }
 func (*PutStateInfo) ProtoMessage()    {}
 
-type RangeQueryStateInfo struct {
+type RangeQueryState struct {
 	StartKey string `protobuf:"bytes,1,opt,name=startKey" json:"startKey,omitempty"`
 	EndKey   string `protobuf:"bytes,2,opt,name=endKey" json:"endKey,omitempty"`
-	Limit    uint32 `protobuf:"varint,3,opt,name=limit" json:"limit,omitempty"`
 }
 
-func (m *RangeQueryStateInfo) Reset()         { *m = RangeQueryStateInfo{} }
-func (m *RangeQueryStateInfo) String() string { return proto.CompactTextString(m) }
-func (*RangeQueryStateInfo) ProtoMessage()    {}
+func (m *RangeQueryState) Reset()         { *m = RangeQueryState{} }
+func (m *RangeQueryState) String() string { return proto.CompactTextString(m) }
+func (*RangeQueryState) ProtoMessage()    {}
+
+type RangeQueryStateNext struct {
+	ID string `protobuf:"bytes,1,opt,name=ID" json:"ID,omitempty"`
+}
+
+func (m *RangeQueryStateNext) Reset()         { *m = RangeQueryStateNext{} }
+func (m *RangeQueryStateNext) String() string { return proto.CompactTextString(m) }
+func (*RangeQueryStateNext) ProtoMessage()    {}
+
+type RangeQueryStateClose struct {
+	ID string `protobuf:"bytes,1,opt,name=ID" json:"ID,omitempty"`
+}
+
+func (m *RangeQueryStateClose) Reset()         { *m = RangeQueryStateClose{} }
+func (m *RangeQueryStateClose) String() string { return proto.CompactTextString(m) }
+func (*RangeQueryStateClose) ProtoMessage()    {}
 
 type RangeQueryStateKeyValue struct {
 	Key   string `protobuf:"bytes,1,opt,name=key" json:"key,omitempty"`
@@ -334,6 +355,7 @@ func (*RangeQueryStateKeyValue) ProtoMessage()    {}
 type RangeQueryStateResponse struct {
 	KeysAndValues []*RangeQueryStateKeyValue `protobuf:"bytes,1,rep,name=keysAndValues" json:"keysAndValues,omitempty"`
 	HasMore       bool                       `protobuf:"varint,2,opt,name=hasMore" json:"hasMore,omitempty"`
+	ID            string                     `protobuf:"bytes,3,opt,name=ID" json:"ID,omitempty"`
 }
 
 func (m *RangeQueryStateResponse) Reset()         { *m = RangeQueryStateResponse{} }

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -136,6 +136,8 @@ message ChaincodeMessage {
         QUERY_COMPLETED = 15;
         QUERY_ERROR = 16;
         RANGE_QUERY_STATE = 17;
+        RANGE_QUERY_STATE_NEXT = 18;
+        RANGE_QUERY_STATE_CLOSE = 19;
     }
 
     Type type = 1;
@@ -149,10 +151,17 @@ message PutStateInfo {
     bytes value = 2;
 }
 
-message RangeQueryStateInfo {
+message RangeQueryState {
     string startKey = 1;
     string endKey = 2;
-    uint32 limit = 3;
+}
+
+message RangeQueryStateNext {
+    string ID = 1;
+}
+
+message RangeQueryStateClose {
+  string ID = 1;
 }
 
 message RangeQueryStateKeyValue {
@@ -163,6 +172,7 @@ message RangeQueryStateKeyValue {
 message RangeQueryStateResponse {
     repeated RangeQueryStateKeyValue keysAndValues = 1;
     bool hasMore = 2;
+    string ID = 3;
 }
 
 // Interface that provides support to chaincode execution. ChaincodeContext


### PR DESCRIPTION
This adds an iterator to the range query API on chaincode shim. The chaincode writer is able to call API on the iterator such as Next() and HasNext(). Calls to the peer to fetch additional state keys/values are transparent.
