### PR TITLE
Mem leak fixes/issue#589

### DIFF
--- a/openchain/consensus/helper/handler.go
+++ b/openchain/consensus/helper/handler.go
@@ -43,7 +43,6 @@ func init() {
 type ConsensusHandler struct {
 	consenter   consensus.Consenter
 	coordinator peer.MessageHandlerCoordinator
-	done        chan struct{}
 	peerHandler peer.MessageHandler
 }
 
@@ -64,7 +63,6 @@ func NewConsensusHandler(coord peer.MessageHandlerCoordinator,
 	}
 
 	handler.consenter = controller.NewConsenter(NewHelper(coord))
-	handler.done = make(chan struct{})
 
 	return handler, nil
 }
@@ -176,7 +174,6 @@ func (handler *ConsensusHandler) SendMessage(msg *pb.OpenchainMessage) error {
 // Stop stops this MessageHandler, which then delegates to the contained PeerHandler to stop (and thus deregister this Peer)
 func (handler *ConsensusHandler) Stop() error {
 	err := handler.peerHandler.Stop() // deregister the handler
-	handler.done <- struct{}{}
 	if err != nil {
 		return fmt.Errorf("Error stopping ConsensusHandler: %s", err)
 	}

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -521,6 +521,13 @@ func sendTransactionsToThisPeer(peerAddress string, transaction *pb.Transaction)
 	if err != nil {
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transactions to peer address=%s:  %s", peerAddress, err))}
 	}
+
+	peerLogger.Debug("Marshalling transaction %s to send to self", transaction.Type)
+	data, err := proto.Marshal(transaction)
+	if err != nil {
+		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transaction to local peer: %s", err))}
+	}
+
 	waitc := make(chan struct{})
 	var response *pb.Response
 	go func() {
@@ -555,11 +562,6 @@ func sendTransactionsToThisPeer(peerAddress string, transaction *pb.Transaction)
 		}
 	}()
 
-	peerLogger.Debug("Sending transaction %s to self", transaction.Type)
-	data, err := proto.Marshal(transaction)
-	if err != nil {
-		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transaction to local peer: %s", err))}
-	}
 	var ttyp pb.OpenchainMessage_Type
 	if transaction.Type == pb.Transaction_CHAINCODE_EXECUTE || transaction.Type == pb.Transaction_CHAINCODE_NEW {
 		ttyp = pb.OpenchainMessage_CHAIN_TRANSACTION

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -426,7 +426,12 @@ func (p *PeerImpl) SendTransactionsToPeer(peerAddress string, transaction *pb.Tr
 	}
 	defer conn.Close()
 	serverClient := pb.NewPeerClient(conn)
-	stream, err := serverClient.Chat(context.Background())
+
+	//cancel the context to free the waiting transport and clean up resources
+	ctx,cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := serverClient.Chat(ctx)
 	if err != nil {
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transactions to peer address=%s:  %s", peerAddress, err))}
 	}
@@ -498,7 +503,12 @@ func sendTransactionsToThisPeer(peerAddress string, transaction *pb.Transaction)
 	}
 	defer conn.Close()
 	serverClient := pb.NewPeerClient(conn)
-	stream, err := serverClient.Chat(context.Background())
+
+	//cancel the context to free the waiting transport and clean up resources
+	ctx,cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := serverClient.Chat(ctx)
 	if err != nil {
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transactions to peer address=%s:  %s", peerAddress, err))}
 	}

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -427,11 +427,7 @@ func (p *PeerImpl) SendTransactionsToPeer(peerAddress string, transaction *pb.Tr
 	defer conn.Close()
 	serverClient := pb.NewPeerClient(conn)
 
-	//cancel the context to free the waiting transport and clean up resources
-	ctx,cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	stream, err := serverClient.Chat(ctx)
+	stream, err := serverClient.Chat(context.Background())
 	if err != nil {
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transactions to peer address=%s:  %s", peerAddress, err))}
 	}
@@ -504,11 +500,7 @@ func sendTransactionsToThisPeer(peerAddress string, transaction *pb.Transaction)
 	defer conn.Close()
 	serverClient := pb.NewPeerClient(conn)
 
-	//cancel the context to free the waiting transport and clean up resources
-	ctx,cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	stream, err := serverClient.Chat(ctx)
+	stream, err := serverClient.Chat(context.Background())
 	if err != nil {
 		return &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(fmt.Sprintf("Error sending transactions to peer address=%s:  %s", peerAddress, err))}
 	}


### PR DESCRIPTION
some fixes for mem leak.  This takes care of some big leaks.

As discussed with @jeffgarratt, one issue still remains. gRPC NewClientStream and friends created in sendTransactionsToThisPeer are not getting GCed. All relevent transport clean up calls (in particular, Close and CloseSend) and channel notifications are in place and appear to be working as expected. One (remote and startling) possibility is  local gRPC is suspect and somehow keeps references to these data structures.

Assigning to @jeffgarratt for investigating this. Can pick it up in a few days,
