### PR TITLE
CLI Changes to support scripting

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func main() {
 	chaincodeCmd.AddCommand(chaincodeQueryCmd)
 
 	mainCmd.AddCommand(chaincodeCmd)
-	
+
 	// On failure Cobra prints the usage message and error string, so we only
 	// need to exit with a non-0 status
 	if mainCmd.Execute() != nil {
@@ -623,7 +623,7 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 		logger.Debug("Security is enabled. Include security context in deploy spec")
 		if chaincodeUsr == undefinedParamValue {
 			err = errors.New("Must supply username for chaincode when security is enabled")
-			return 
+			return
 		}
 
 		// Retrieve the CLI data storage path
@@ -712,7 +712,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 	if viper.GetBool("security.enabled") {
 		if chaincodeUsr == undefinedParamValue {
 			err = errors.New("Must supply username for chaincode when security is enabled")
-			return 
+			return
 		}
 
 		// Retrieve the CLI data storage path
@@ -767,9 +767,9 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 		return
 	}
 	if invoke {
-		transactionId := string(resp.Msg)
-		logger.Info("Successfully invoked transaction: %s(%s)", invocation, transactionId)
-		fmt.Println(transactionId)
+		transactionID := string(resp.Msg)
+		logger.Info("Successfully invoked transaction: %s(%s)", invocation, transactionID)
+		fmt.Println(transactionID)
 	} else {
 		logger.Info("Successfully queried transaction: %s", invocation)
 		if resp != nil {
@@ -777,9 +777,8 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 				if chaincodeQueryHex {
 					err = errors.New("Options --raw (-r) and --hex (-x) are not compatible\n")
 					return
-				} else {
-					os.Stdout.Write(resp.Msg)
 				}
+				os.Stdout.Write(resp.Msg)
 			} else {
 				if chaincodeQueryHex {
 					fmt.Printf("%x\n", resp.Msg)

--- a/main.go
+++ b/main.go
@@ -651,7 +651,7 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 		} else {
 			// Check if the token is not there and fail
 			if os.IsNotExist(err) {
-				logger.Error("Error: User not logged in. Use the 'login' command to obtain a security token.\n")
+				err = fmt.Errorf("User '%s' not logged in. Use the 'login' command to obtain a security token.", chaincodeUsr)
 				return
 			}
 			// Unexpected error
@@ -740,7 +740,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 		} else {
 			// Check if the token is not there and fail
 			if os.IsNotExist(err) {
-				logger.Error("Error: User not logged in. Use the 'login' command to obtain a security token.\n")
+				err = fmt.Errorf("User '%s' not logged in. Use the 'login' command to obtain a security token.", chaincodeUsr)
 				return
 			}
 			// Unexpected error


### PR DESCRIPTION
This PR addresses #453.

New documentation (to be added in a separate pull request to obc-docs):

---

To facilitate its use in scripted applications, the `obc-peer` command always
produces a non-0 return code in the event of command failure. Upon success,
many of the subcommands produce a result on **stdout** as shown in the table
below:

| Command | **stdout** result in the event of success |
| --- | --- |
| `peer` | N/A |
| `status` | String form of ServerStatus_StatusCode |
| `stop` | String form of ServerStatus_StatusCode |
| `login` | N/A |
| `vm` | String form of ServerStatus_StatusCode |
| `chaincode deploy` | The chaincode container name (hash) required for subsequent `chaincode invoke` and `chaincode query` commands |
| `chaincode invoke` | The transaction ID (UUID) |
| `chaincode query` | By default, the query result is formatted as a printable string. Command line options support writing this value as raw bytes (-r, --raw), or formatted as the hexadecimal representation of the raw bytes (-x, --hex). If the query response is empty then nothing is output. |

---

Although many lines of main.go are changed, the changes are primarily
cosmetic:

The commands now use the Cobra 'RunE' interface because they return errors to
top-level command processing.

Since Cobra command processing prints the usage message and error string when
commands fail, several places where the code was doing this explicitly have
been removed.

In a few cases logging messages were converted to error objects and returned.

Things are written to **stdout** as documented.

Note that many of the commands still do ad-hoc error processing, e.g., they
call `panic` in the event of certain errors. I tried to change as little as
possible to implement the required function here so did not change these - I
did not feel comfortable to completely "rewrite" error handling. 
