### PR TITLE
Free slice. Fixes /chain memory leak. Issue #608

### DIFF
--- a/openchain/db/db.go
+++ b/openchain/db/db.go
@@ -251,7 +251,9 @@ func (openchainDB *OpenchainDB) get(cfHandler *gorocksdb.ColumnFamilyHandle, key
 		fmt.Println("Error while trying to retrieve key:", key)
 		return nil, err
 	}
-	return slice.Data(), nil
+	defer slice.Free()
+	data := append([]byte(nil), slice.Data()...)
+	return data, nil
 }
 
 func (openchainDB *OpenchainDB) getFromSnapshot(snapshot *gorocksdb.Snapshot, cfHandler *gorocksdb.ColumnFamilyHandle, key []byte) ([]byte, error) {
@@ -262,7 +264,9 @@ func (openchainDB *OpenchainDB) getFromSnapshot(snapshot *gorocksdb.Snapshot, cf
 		fmt.Println("Error while trying to retrieve key:", key)
 		return nil, err
 	}
-	return slice.Data(), nil
+	defer slice.Free()
+	data := append([]byte(nil), slice.Data()...)
+	return data, nil
 }
 
 func (openchainDB *OpenchainDB) getIterator(cfHandler *gorocksdb.ColumnFamilyHandle) *gorocksdb.Iterator {

--- a/openchain/ledger/statemgmt/buckettree/db_helper.go
+++ b/openchain/ledger/statemgmt/buckettree/db_helper.go
@@ -63,16 +63,11 @@ func fetchDataNodesFromDBFor(bucketKey *bucketKey) (dataNodes, error) {
 	itr.Seek(minimumDataKeyBytes)
 
 	for ; itr.Valid(); itr.Next() {
-		kSlice := itr.Key()
-		defer kSlice.Free()
-		vSlice := itr.Value()
-		defer vSlice.Free()
-		k := kSlice.Data()
-		v := vSlice.Data()
+
 		// making a copy of key-value bytes because, underlying key bytes are reused by itr.
-		//Did not observe the same behaviour for value but for now making copy for both key and value bytes
-		keyBytes := statemgmt.Copy(k)
-		valueBytes := statemgmt.Copy(v)
+		// no need to free slices as iterator frees memory when closed.
+		keyBytes := statemgmt.Copy(itr.Key().Data())
+		valueBytes := statemgmt.Copy(itr.Value().Data())
 
 		dataKey := newDataKeyFromEncodedBytes(keyBytes)
 		logger.Debug("Retrieved data key [%s] from DB for bucket [%s]", dataKey, bucketKey)

--- a/openchain/ledger/statemgmt/buckettree/db_helper.go
+++ b/openchain/ledger/statemgmt/buckettree/db_helper.go
@@ -63,8 +63,12 @@ func fetchDataNodesFromDBFor(bucketKey *bucketKey) (dataNodes, error) {
 	itr.Seek(minimumDataKeyBytes)
 
 	for ; itr.Valid(); itr.Next() {
-		k := itr.Key().Data()
-		v := itr.Value().Data()
+		kSlice := itr.Key()
+		defer kSlice.Free()
+		vSlice := itr.Value()
+		defer vSlice.Free()
+		k := kSlice.Data()
+		v := vSlice.Data()
 		// making a copy of key-value bytes because, underlying key bytes are reused by itr.
 		//Did not observe the same behaviour for value but for now making copy for both key and value bytes
 		keyBytes := statemgmt.Copy(k)

--- a/openchain/ledger/statemgmt/buckettree/range_scan_iterator.go
+++ b/openchain/ledger/statemgmt/buckettree/range_scan_iterator.go
@@ -56,13 +56,11 @@ func (itr *RangeScanIterator) Next() bool {
 	}
 
 	for itr.dbItr.Valid() {
-		keySlice := itr.dbItr.Key()
-		defer keySlice.Free()
-		valueSlice := itr.dbItr.Value()
-		defer valueSlice.Free()
-		// TODO Why do we copy the key, but not the value?
-		keyBytes := statemgmt.Copy(keySlice.Data())
-		valueBytes := valueSlice.Data()
+
+		// making a copy of key-value bytes because, underlying key bytes are reused by itr.
+		// no need to free slices as iterator frees memory when closed.
+		keyBytes := statemgmt.Copy(itr.dbItr.Key().Data())
+		valueBytes := statemgmt.Copy(itr.dbItr.Value().Data())
 
 		dataNode := unmarshalDataNodeFromBytes(keyBytes, valueBytes)
 		dataKey := dataNode.dataKey

--- a/openchain/ledger/statemgmt/buckettree/range_scan_iterator.go
+++ b/openchain/ledger/statemgmt/buckettree/range_scan_iterator.go
@@ -56,8 +56,13 @@ func (itr *RangeScanIterator) Next() bool {
 	}
 
 	for itr.dbItr.Valid() {
-		keyBytes := statemgmt.Copy(itr.dbItr.Key().Data())
-		valueBytes := itr.dbItr.Value().Data()
+		keySlice := itr.dbItr.Key()
+		defer keySlice.Free()
+		valueSlice := itr.dbItr.Value()
+		defer valueSlice.Free()
+		// TODO Why do we copy the key, but not the value?
+		keyBytes := statemgmt.Copy(keySlice.Data())
+		valueBytes := valueSlice.Data()
 
 		dataNode := unmarshalDataNodeFromBytes(keyBytes, valueBytes)
 		dataKey := dataNode.dataKey

--- a/openchain/ledger/statemgmt/buckettree/snapshot_iterator.go
+++ b/openchain/ledger/statemgmt/buckettree/snapshot_iterator.go
@@ -45,8 +45,13 @@ func (snapshotItr *StateSnapshotIterator) Next() bool {
 
 // GetRawKeyValue - see interface 'statemgmt.StateSnapshotIterator' for details
 func (snapshotItr *StateSnapshotIterator) GetRawKeyValue() ([]byte, []byte) {
-	keyBytes := statemgmt.Copy(snapshotItr.dbItr.Key().Data())
-	valueBytes := snapshotItr.dbItr.Value().Data()
+	keySlice := snapshotItr.dbItr.Key()
+	defer keySlice.Free()
+	valueSlice := snapshotItr.dbItr.Value()
+	defer valueSlice.Free()
+	// TODO Why do we copy the key, but not the value?
+	keyBytes := statemgmt.Copy(keySlice.Data())
+	valueBytes := valueSlice.Data()
 	dataNode := unmarshalDataNodeFromBytes(keyBytes, valueBytes)
 	return dataNode.getCompositeKey(), dataNode.getValue()
 }

--- a/openchain/ledger/statemgmt/buckettree/snapshot_iterator.go
+++ b/openchain/ledger/statemgmt/buckettree/snapshot_iterator.go
@@ -45,13 +45,11 @@ func (snapshotItr *StateSnapshotIterator) Next() bool {
 
 // GetRawKeyValue - see interface 'statemgmt.StateSnapshotIterator' for details
 func (snapshotItr *StateSnapshotIterator) GetRawKeyValue() ([]byte, []byte) {
-	keySlice := snapshotItr.dbItr.Key()
-	defer keySlice.Free()
-	valueSlice := snapshotItr.dbItr.Value()
-	defer valueSlice.Free()
-	// TODO Why do we copy the key, but not the value?
-	keyBytes := statemgmt.Copy(keySlice.Data())
-	valueBytes := valueSlice.Data()
+
+	// making a copy of key-value bytes because, underlying key bytes are reused by itr.
+	// no need to free slices as iterator frees memory when closed.
+	keyBytes := statemgmt.Copy(snapshotItr.dbItr.Key().Data())
+	valueBytes := statemgmt.Copy(snapshotItr.dbItr.Value().Data())
 	dataNode := unmarshalDataNodeFromBytes(keyBytes, valueBytes)
 	return dataNode.getCompositeKey(), dataNode.getValue()
 }

--- a/openchain/ledger/statemgmt/trie/range_scan_iterator.go
+++ b/openchain/ledger/statemgmt/trie/range_scan_iterator.go
@@ -49,13 +49,11 @@ func (itr *RangeScanIterator) Next() bool {
 		return false
 	}
 	for ; itr.dbItr.Valid(); itr.dbItr.Next() {
-		trieKeySlice := itr.dbItr.Key()
-		defer trieKeySlice.Free()
-		trieNodeSlice := itr.dbItr.Value()
-		defer trieNodeSlice.Free()
-		// TODO Do we need to copy the key and value?
-		trieKeyBytes := trieKeySlice.Data()
-		trieNodeBytes := trieNodeSlice.Data()
+
+		// making a copy of key-value bytes because, underlying key bytes are reused by itr.
+		// no need to free slices as iterator frees memory when closed.
+		trieKeyBytes := statemgmt.Copy(itr.dbItr.Key().Data())
+		trieNodeBytes := statemgmt.Copy(itr.dbItr.Value().Data())
 		value := unmarshalTrieNodeValue(trieNodeBytes)
 		if util.IsNil(value) {
 			continue

--- a/openchain/ledger/statemgmt/trie/range_scan_iterator.go
+++ b/openchain/ledger/statemgmt/trie/range_scan_iterator.go
@@ -49,8 +49,13 @@ func (itr *RangeScanIterator) Next() bool {
 		return false
 	}
 	for ; itr.dbItr.Valid(); itr.dbItr.Next() {
-		trieKeyBytes := itr.dbItr.Key().Data()
-		trieNodeBytes := itr.dbItr.Value().Data()
+		trieKeySlice := itr.dbItr.Key()
+		defer trieKeySlice.Free()
+		trieNodeSlice := itr.dbItr.Value()
+		defer trieNodeSlice.Free()
+		// TODO Do we need to copy the key and value?
+		trieKeyBytes := trieKeySlice.Data()
+		trieNodeBytes := trieNodeSlice.Data()
 		value := unmarshalTrieNodeValue(trieNodeBytes)
 		if util.IsNil(value) {
 			continue

--- a/openchain/ledger/statemgmt/trie/snapshot_iterator.go
+++ b/openchain/ledger/statemgmt/trie/snapshot_iterator.go
@@ -45,8 +45,13 @@ func newStateSnapshotIterator(snapshot *gorocksdb.Snapshot) (*StateSnapshotItera
 func (snapshotItr *StateSnapshotIterator) Next() bool {
 	var available bool
 	for ; snapshotItr.dbItr.Valid(); snapshotItr.dbItr.Next() {
-		trieKeyBytes := snapshotItr.dbItr.Key().Data()
-		trieNodeBytes := snapshotItr.dbItr.Value().Data()
+		trieKeySlice := snapshotItr.dbItr.Key()
+		defer trieKeySlice.Free()
+		trieNodeSlice := snapshotItr.dbItr.Value()
+		defer trieNodeSlice.Free()
+		// TODO Do we need to copy the key and value?
+		trieKeyBytes := trieKeySlice.Data()
+		trieNodeBytes := trieNodeSlice.Data()
 		value := unmarshalTrieNodeValue(trieNodeBytes)
 		if util.NotNil(value) {
 			snapshotItr.currentKey = trieKeyEncoderImpl.decodeTrieKeyBytes(statemgmt.Copy(trieKeyBytes))


### PR DESCRIPTION
This fixes the /chain memory leak in issue #608. I was able to run 50,000+ GET requests to /chain without seeing a significant increase in memory with this fix.

@jeffgarratt @muralisrini - Please check that this resolves the issue in your environment.

The root cause of this issue is that RocksDB Go wrapper requires that Free() be called on returned slices to free up the allocated memory. This was not being done in the low level functions called by /chain requests.

@manish-sethi Please review the change. There are at least several more locations we need to investigate/fix. They are
buckettree/db_helper.go
buckettree/range_scan_iterator.go
buckettree/snapshot_iterator.go
trie/range_scan_iterator.go
trie/snapshot_iterator.go
Let me know if you find more locations.
