### PR TITLE
first try to fix #572

### DIFF
--- a/openchain/consensus/controller/controller.go
+++ b/openchain/consensus/controller/controller.go
@@ -38,10 +38,10 @@ func init() {
 func NewConsenter(stack consensus.Stack) (consenter consensus.Consenter) {
 	plugin := viper.GetString("peer.validator.consensus")
 	if plugin == "obcpbft" {
-		logger.Info("Running with consensus plugin %s", plugin)
+		//logger.Info("Running with consensus plugin %s", plugin)
 		consenter = obcpbft.GetPlugin(stack)
 	} else {
-		logger.Info("Running with default consensus plugin (noops)")
+		//logger.Info("Running with default consensus plugin (noops)")
 		consenter = noops.GetNoops(stack)
 	}
 	return

--- a/openchain/consensus/noops/config.yaml
+++ b/openchain/consensus/noops/config.yaml
@@ -1,0 +1,21 @@
+---
+###############################################################################
+#
+#   NOOPS PROPERTIES
+#
+# These properties may be passed as environment variables when starting up
+# a validating peer with prefix  OPENCHAIN_NOOPS. For example:
+#    OPENCHAIN_NOOPS_BLOCK_SIZE=1000
+#    OPENCHAIN_NOOPS_BLOCK_TIMEOUT=2
+#
+###############################################################################
+
+# Define properties for a block: A block is created whenever "size" or "timeout"
+# occurs. When we process a block, we grab all transactions in the queue, so
+# the number of transactions in a block may be greater than the "size".
+block:
+    # Number of transactions per block. Must be > 0. Set to 1 for testing
+    size: 500
+
+    # Number of seconds to wait for a block. Min is 1 second
+    timeout: 1

--- a/openchain/consensus/noops/configutil.go
+++ b/openchain/consensus/noops/configutil.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package noops
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+const configPrefix = "OPENCHAIN_NOOPS"
+
+func loadConfig() (config *viper.Viper) {
+	config = viper.New()
+
+	// for environment variables
+	config.SetEnvPrefix(configPrefix)
+	config.AutomaticEnv()
+	replacer := strings.NewReplacer(".", "_")
+	config.SetEnvKeyReplacer(replacer)
+
+	config.SetConfigName("config")
+	config.AddConfigPath("./")
+	config.AddConfigPath("./openchain/consensus/noops/")
+	err := config.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Error reading %s plugin config: %s", configPrefix, err))
+	}
+	return config
+}

--- a/openchain/consensus/noops/noops.go
+++ b/openchain/consensus/noops/noops.go
@@ -21,7 +21,6 @@ package noops
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -44,7 +43,6 @@ func init() {
 type Noops struct {
 	stack    consensus.Stack
 	txQ      *txq
-	lock     *sync.Mutex
 	timer    *time.Timer
 	duration time.Duration
 	channel  chan *pb.Transaction
@@ -68,7 +66,6 @@ func newNoops(c consensus.Stack) consensus.Consenter {
 	}
 	i := &Noops{}
 	i.stack = c
-	i.lock = &sync.Mutex{}
 	config := loadConfig()
 	i.txQ = newTXQ(config.GetInt("block.size"))
 	i.duration = time.Second * time.Duration(config.GetInt("block.timeout"))
@@ -168,9 +165,7 @@ func (i *Noops) handleChannels() {
 }
 
 func (i *Noops) processBlock() error {
-	i.lock.Lock()
 	i.timer.Stop()
-	defer i.lock.Unlock()
 
 	if i.txQ.size() < 1 {
 		if logger.IsEnabledFor(logging.DEBUG) {

--- a/openchain/consensus/noops/noops.go
+++ b/openchain/consensus/noops/noops.go
@@ -21,19 +21,18 @@ package noops
 
 import (
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/op/go-logging"
 
 	"github.com/openblockchain/obc-peer/openchain/consensus"
 	"github.com/openblockchain/obc-peer/openchain/ledger"
+	"github.com/openblockchain/obc-peer/openchain/ledger/statemgmt"
 	"github.com/openblockchain/obc-peer/openchain/util"
 	pb "github.com/openblockchain/obc-peer/protos"
 )
-
-// =============================================================================
-// Init
-// =============================================================================
 
 var logger *logging.Logger // package-level logger
 
@@ -41,43 +40,49 @@ func init() {
 	logger = logging.MustGetLogger("consensus/noops")
 }
 
-// =============================================================================
-// Structures go here
-// =============================================================================
-
 // Noops is a plugin object implementing the consensus.Consenter interface.
 type Noops struct {
-	stack consensus.Stack
-	txQ   *util.Queue
+	stack    consensus.Stack
+	txQ      *util.Queue
+	lock     *sync.Mutex
+	timer    *time.Timer
+	size     int
+	duration time.Duration
 }
 
+// Setting up a singleton NOOPS consenter
 var iNoops consensus.Consenter
-
-// =============================================================================
-// Constructors go here
-// =============================================================================
-
-// NewNoops is a constructor returning a consensus.Consenter object.
-func NewNoops(c consensus.Stack) consensus.Consenter {
-	logger.Debug("Creating a NOOPS object")
-	i := &Noops{}
-	i.stack = c
-	i.txQ = util.NewQueue()
-	return i
-}
 
 // GetNoops returns a singleton of NOOPS
 func GetNoops(c consensus.Stack) consensus.Consenter {
 	if iNoops == nil {
-		iNoops = NewNoops(c)
+		iNoops = newNoops(c)
 	}
 	return iNoops
 }
 
+// newNoops is a constructor returning a consensus.Consenter object.
+func newNoops(c consensus.Stack) consensus.Consenter {
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Creating a NOOPS object")
+	}
+	i := &Noops{}
+	i.stack = c
+	i.txQ = util.NewQueue()
+	i.lock = &sync.Mutex{}
+	config := loadConfig()
+	i.size = config.GetInt("block.size")
+	i.duration = time.Second * time.Duration(config.GetInt("block.timeout"))
+	i.timer = time.NewTimer(i.duration)
+	go i.handleTimer()
+	return i
+}
+
 // RecvMsg is called for OpenchainMessage_CHAIN_TRANSACTION and OpenchainMessage_CONSENSUS messages.
 func (i *Noops) RecvMsg(msg *pb.OpenchainMessage) error {
-	logger.Debug("Handling OpenchainMessage of type: %s ", msg.Type)
-
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Handling OpenchainMessage of type: %s ", msg.Type)
+	}
 	if msg.Type == pb.OpenchainMessage_CHAIN_TRANSACTION {
 		if err := i.broadcastConsensusMsg(msg); nil != err {
 			return err
@@ -88,18 +93,10 @@ func (i *Noops) RecvMsg(msg *pb.OpenchainMessage) error {
 		if nil != err {
 			return err
 		}
-		if i.canProcess(txarr) {
-			i.txQ.Push(txarr)
-			if err = i.doTransactions(msg); err == nil {
-				//transactions succeeed, broadcast
-				//spin the broadcast in go routine so
-				//(a)we make RecvMsg light and
-				//(b)we separate send from receive
-				go i.notifyBlockAdded()
-			}
-			return err
-		}
 		i.queueTransactions(txarr)
+		if i.canProcess(txarr) {
+			i.processBlock()
+		}
 	}
 	return nil
 }
@@ -113,7 +110,9 @@ func (i *Noops) broadcastConsensusMsg(msg *pb.OpenchainMessage) error {
 	// Change the msg type to consensus and broadcast to the network so that
 	// other validators may execute the transaction
 	msg.Type = pb.OpenchainMessage_CONSENSUS
-	logger.Debug("Broadcasting %s", msg.Type)
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Broadcasting %s", msg.Type)
+	}
 	txs := &pb.TransactionBlock{Transactions: []*pb.Transaction{t}}
 	payload, err := proto.Marshal(txs)
 	if err != nil {
@@ -122,6 +121,82 @@ func (i *Noops) broadcastConsensusMsg(msg *pb.OpenchainMessage) error {
 	msg.Payload = payload
 	if errs := i.stack.Broadcast(msg, pb.PeerEndpoint_VALIDATOR); nil != errs {
 		return fmt.Errorf("Failed to broadcast with errors: %v", errs)
+	}
+	return nil
+}
+
+func (i *Noops) canProcess(txarr []*pb.Transaction) bool {
+	// For NOOPS, if we have completed the sync since we last connected,
+	// we can assume that we are at the current state; otherwise, we need to
+	// wait for the sync process to complete before we can exec the transactions
+
+	// TODO: Ask coordinator if we need to start sync
+
+	if i.txQ.Size() < i.size {
+		return false
+	}
+	return true
+}
+
+func (i *Noops) handleTimer() {
+	for {
+		<-i.timer.C
+		if err := i.processBlock(); nil != err {
+			logger.Error(err.Error())
+		}
+	}
+}
+
+func (i *Noops) processBlock() error {
+	i.lock.Lock()
+	i.timer.Stop()
+	defer i.lock.Unlock()
+	defer i.timer.Reset(i.duration)
+
+	var data *pb.Block
+	var delta *statemgmt.StateDelta
+	var err error
+
+	if err = i.processTransactions(); nil != err {
+		return err
+	}
+	if data, delta, err = i.getBlockData(); nil != err {
+		return err
+	}
+	go i.notifyBlockAdded(data, delta)
+	return nil
+}
+
+func (i *Noops) processTransactions() error {
+	timestamp := util.CreateUtcTimestamp()
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Starting TX batch with timestamp: %v", timestamp)
+	}
+	if err := i.stack.BeginTxBatch(timestamp); err != nil {
+		return err
+	}
+
+	// Grab all transactions from the FIFO queue and run them in order
+	txarr := i.getTransactionsFromQueue()
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Executing batch of %d transactions with timestamp %v", len(txarr), timestamp)
+	}
+	_, err := i.stack.ExecTxs(timestamp, txarr)
+
+	//consensus does not need to understand transaction errors, errors here are
+	//actual ledger errors, and often irrecoverable
+	if err != nil {
+		logger.Debug("Rolling back TX batch with timestamp: %v", timestamp)
+		i.stack.RollbackTxBatch(timestamp)
+		return fmt.Errorf("Fail to execute transactions: %v", err)
+	}
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Committing TX batch with timestamp: %v", timestamp)
+	}
+	if _, err := i.stack.CommitTxBatch(timestamp, nil); err != nil {
+		logger.Debug("Rolling back TX batch with timestamp: %v", timestamp)
+		i.stack.RollbackTxBatch(timestamp)
+		return err
 	}
 	return nil
 }
@@ -147,82 +222,50 @@ func (i *Noops) getTransactionsFromQueue() []*pb.Transaction {
 	return txarr
 }
 
-func (i *Noops) canProcess(txarr []*pb.Transaction) bool {
-	// For NOOPS, if we have completed the sync since we last connected,
-	// we can assume that we are at the current state; otherwise, we need to
-	// wait for the sync process to complete before we can exec the transactions
-
-	// TODO: Ask coordinator if we need to start sync
-
-	return true
-}
-
-func (i *Noops) doTransactions(msg *pb.OpenchainMessage) error {
-	logger.Debug("Executing transactions")
-	logger.Debug("Starting TX batch with timestamp: %v", msg.Timestamp)
-	if err := i.stack.BeginTxBatch(msg.Timestamp); err != nil {
-		return err
-	}
-
-	// Grab all transactions from the FIFO queue and run them in order
-	txarr := i.getTransactionsFromQueue()
-	logger.Debug("Executing batch of %d transactions", len(txarr))
-	_, err := i.stack.ExecTxs(msg.Timestamp, txarr)
-
-	//consensus does not need to understand transaction errors, errors here are
-	//actual ledger errors, and often irrecoverable
-	if err != nil {
-		logger.Debug("Rolling back TX batch with timestamp: %v", msg.Timestamp)
-		i.stack.RollbackTxBatch(msg.Timestamp)
-		return fmt.Errorf("Fail to execute transactions: %v", err)
-	}
-
-	logger.Debug("Committing TX batch with timestamp: %v", msg.Timestamp)
-	if _, err := i.stack.CommitTxBatch(msg.Timestamp, nil); err != nil {
-		logger.Debug("Rolling back TX batch with timestamp: %v", msg.Timestamp)
-		i.stack.RollbackTxBatch(msg.Timestamp)
-		return err
-	}
-
-	return nil
-}
-
-func (i *Noops) notifyBlockAdded() error {
+func (i *Noops) getBlockData() (*pb.Block, *statemgmt.StateDelta, error) {
 	ledger, err := ledger.GetLedger()
 	if err != nil {
-		return fmt.Errorf("Fail to get the ledger: %v", err)
+		return nil, nil, fmt.Errorf("Fail to get the ledger: %v", err)
 	}
 
-	// TODO: Broadcast SYNC_BLOCK_ADDED to connected NVPs
-	// VPs already know about this newly added block since they participate
-	// in the execution. That is, they can compare their current block with
-	// the network block
-	// For now, send to everyone until broadcast has better discrimination
 	blockHeight := ledger.GetBlockchainSize()
-	logger.Debug("Preparing to broadcast with block number %v", blockHeight)
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Preparing to broadcast with block number %v", blockHeight)
+	}
 	block, err := ledger.GetBlockByNumber(blockHeight - 1)
 	if nil != err {
-		return err
+		return nil, nil, err
 	}
 	//delta, err := ledger.GetStateDeltaBytes(blockHeight)
 	delta, err := ledger.GetStateDelta(blockHeight - 1)
 	if nil != err {
-		return err
+		return nil, nil, err
+	}
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Got the delta state of block number %v", blockHeight)
 	}
 
+	return block, delta, nil
+}
+
+func (i *Noops) notifyBlockAdded(block *pb.Block, delta *statemgmt.StateDelta) error {
 	//make Payload nil to reduce block size..
 	//anything else to remove .. do we need StateDelta ?
 	for _, tx := range block.Transactions {
 		tx.Payload = nil
 	}
-
-	logger.Debug("Got the delta state of block number %v", blockHeight)
 	data, err := proto.Marshal(&pb.BlockState{Block: block, StateDelta: delta.Marshal()})
 	if err != nil {
 		return fmt.Errorf("Fail to marshall BlockState structure: %v", err)
 	}
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Broadcasting OpenchainMessage_SYNC_BLOCK_ADDED to non-validators")
+	}
 
-	logger.Debug("Broadcasting OpenchainMessage_SYNC_BLOCK_ADDED to non-validators")
+	// Broadcast SYNC_BLOCK_ADDED to connected NVPs
+	// VPs already know about this newly added block since they participate
+	// in the execution. That is, they can compare their current block with
+	// the network block
 	msg := &pb.OpenchainMessage{Type: pb.OpenchainMessage_SYNC_BLOCK_ADDED,
 		Payload: data, Timestamp: util.CreateUtcTimestamp()}
 	if errs := i.stack.Broadcast(msg, pb.PeerEndpoint_NON_VALIDATOR); nil != errs {
@@ -233,5 +276,7 @@ func (i *Noops) notifyBlockAdded() error {
 
 func (i *Noops) queueTransactions(txarr []*pb.Transaction) {
 	i.txQ.Push(txarr)
-	logger.Debug("Transaction queue size: %d", i.txQ.Size())
+	if logger.IsEnabledFor(logging.DEBUG) {
+		logger.Debug("Queue transaction. Queue size: %d", i.txQ.Size())
+	}
 }

--- a/openchain/consensus/noops/txq.go
+++ b/openchain/consensus/noops/txq.go
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package noops
+
+import (
+	pb "github.com/openblockchain/obc-peer/protos"
+)
+
+type txq struct {
+	i int
+	q []*pb.Transaction
+}
+
+func newTXQ(size int) *txq {
+	o := &txq{}
+	o.i = 0
+	if size < 1 {
+		size = 1
+	}
+	o.q = make([]*pb.Transaction, size)
+	return o
+}
+
+func (o *txq) append(tx *pb.Transaction) {
+	if cap(o.q) > o.i {
+		o.q[o.i] = tx
+		o.i++
+	}
+}
+
+func (o *txq) getTXs() []*pb.Transaction {
+	length := o.i
+	o.i = 0
+	return o.q[:length]
+}
+
+func (o *txq) isFull() bool {
+	if cap(o.q) == o.i {
+		return true
+	}
+	return false
+}
+
+func (o *txq) size() int {
+	return o.i
+}
+
+func (o *txq) reset() {
+	o.i = 0
+}

--- a/openchain/peer/peer.go
+++ b/openchain/peer/peer.go
@@ -151,7 +151,7 @@ func GetLocalAddress() (peerAddress string, err error) {
 			return "", err
 		}
 		peerAddress = net.JoinHostPort(GetLocalIP(), port)
-		peerLogger.Info("Auto detected peer address: %s", peerAddress)
+		//peerLogger.Info("Auto detected peer address: %s", peerAddress)
 	} else {
 		peerAddress = viper.GetString("peer.address")
 	}

--- a/openchain/util/queue.go
+++ b/openchain/util/queue.go
@@ -70,6 +70,7 @@ func (q *Queue) Push(item interface{}) {
 }
 
 // Pop returns the data item at the head of the queue
+// Example e := q.Pop().(T)  -- cast e to type T
 func (q *Queue) Pop() interface{} {
 	q.lock.Lock()
 	defer q.lock.Unlock()

--- a/openchain/util/queue.go
+++ b/openchain/util/queue.go
@@ -19,11 +19,14 @@ under the License.
 
 package util
 
+import "sync"
+
 // Queue is a classic implmentation of a FIFO queue object
 type Queue struct {
 	head  *element
 	tail  *element
 	count int
+	lock  *sync.Mutex
 }
 
 // Element is a single linked list with a data field containing any data
@@ -36,17 +39,23 @@ type element struct {
 // NewQueue is a constructor returning a Queue object
 func NewQueue() *Queue {
 	q := &Queue{}
+	q.lock = &sync.Mutex{}
 	return q
 }
 
 // Size returns the number of elements on the queue
 func (q *Queue) Size() int {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	return q.count
 }
 
 // Push appends an item on the queue
 // @param item - any application data
 func (q *Queue) Push(item interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
 	element := &element{data: item}
 
 	// Move tail along where t.next points the new element
@@ -62,6 +71,9 @@ func (q *Queue) Push(item interface{}) {
 
 // Pop returns the data item at the head of the queue
 func (q *Queue) Pop() interface{} {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
 	if q.head == nil {
 		return nil
 	}
@@ -81,6 +93,9 @@ func (q *Queue) Pop() interface{} {
 
 // Peek returns the data at the head of the queue
 func (q *Queue) Peek() interface{} {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
 	element := q.head
 	if element == nil {
 		return nil


### PR DESCRIPTION
I introduced a number of things in this PR:
1) serialize processing of blocks
2) added block size and time window in noops/config.yaml file. The  default size = 500 and time =1
3) more async so the query from #572 script may not return the right data since it might still process the blocks. Best is wait until the script returns and manually issue a query transaction
4) commented out a few annoying log info in the main transaction processing loop

@bcbrock @muralisrini @jeffgarratt  please take a look. We still need to synchronize query transactions
