### PR TITLE
Query transactions should only read committed state. Issue #612

### DIFF
--- a/openchain/chaincode/exectransaction_test.go
+++ b/openchain/chaincode/exectransaction_test.go
@@ -71,7 +71,13 @@ func deploy(ctx context.Context, spec *pb.ChaincodeSpec) ([]byte, error) {
 		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
 	}
 
+	ledger, err := ledger.GetLedger()
+	ledger.BeginTxBatch("1")
 	b, err := Execute(ctx, GetChain(DefaultChain), transaction)
+	if err != nil {
+		return nil, fmt.Errorf("Error deploying chaincode: %s", err)
+	}
+	ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
 
 	return b, err
 }
@@ -85,12 +91,24 @@ func invoke(ctx context.Context, spec *pb.ChaincodeSpec, typ pb.Transaction_Type
 
 	transaction, err := pb.NewChaincodeExecute(chaincodeInvocationSpec, uuid, typ)
 	if err != nil {
-		return uuid, nil, fmt.Errorf("Error deploying chaincode: %s ", err)
+		return uuid, nil, fmt.Errorf("Error invoking chaincode: %s ", err)
 	}
 
-	retval, err := Execute(ctx, GetChain(DefaultChain), transaction)
+	var retval []byte
+	var execErr error
+	if typ == pb.Transaction_CHAINCODE_QUERY {
+		retval, execErr = Execute(ctx, GetChain(DefaultChain), transaction)
+	} else {
+		ledger, _ := ledger.GetLedger()
+		ledger.BeginTxBatch("1")
+		retval, execErr = Execute(ctx, GetChain(DefaultChain), transaction)
+		if err != nil {
+			return uuid, nil, fmt.Errorf("Error invoking chaincode: %s ", err)
+		}
+		ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+	}
 
-	return uuid, retval, err
+	return uuid, retval, execErr
 }
 
 func closeListenerAndSleep(l net.Listener) {
@@ -152,26 +170,12 @@ func TestExecuteDeployTransaction(t *testing.T) {
 	closeListenerAndSleep(lis)
 }
 
-const (
-	expectedDeltaStringPrefix = "expected delta for transaction"
-)
-
 // Check the correctness of the final state after transaction execution.
 func checkFinalState(uuid string, chaincodeID string) error {
 	// Check the state in the ledger
 	ledgerObj, ledgerErr := ledger.GetLedger()
 	if ledgerErr != nil {
 		return fmt.Errorf("Error checking ledger for <%s>: %s", chaincodeID, ledgerErr)
-	}
-
-	_, delta, err := ledgerObj.GetTempStateHashWithTxDeltaStateHashes()
-
-	if err != nil {
-		return fmt.Errorf("Error getting delta for invoke transaction <%s>: %s", chaincodeID, err)
-	}
-
-	if delta[uuid] == nil {
-		return fmt.Errorf("%s <%s> but found nil", expectedDeltaStringPrefix, uuid)
 	}
 
 	// Invoke ledger to get state
@@ -318,25 +322,7 @@ func exec(ctxt context.Context, chaincodeID string, numTrans int, numQueries int
 			spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: chaincodeID}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
 		}
 
-		uuid, _, err := invoke(ctxt, spec, typ)
-
-		if typ == pb.Transaction_CHAINCODE_EXECUTE {
-			ledgerObj, ledgerErr := ledger.GetLedger()
-			if ledgerErr != nil {
-				errs[qnum] = fmt.Errorf("Error getting ledger %s", ledgerErr)
-				return
-			}
-			_, delta, err := ledgerObj.GetTempStateHashWithTxDeltaStateHashes()
-			if err != nil {
-				errs[qnum] = fmt.Errorf("Error getting delta for invoke transaction <%s> :%s", uuid, err)
-				return
-			}
-
-			if delta[uuid] == nil {
-				errs[qnum] = fmt.Errorf("%s <%s> but found nil", expectedDeltaStringPrefix, uuid)
-				return
-			}
-		}
+		_, _, err := invoke(ctxt, spec, typ)
 
 		if err != nil {
 			errs[qnum] = fmt.Errorf("Error executing <%s>: %s", chaincodeID, err)

--- a/openchain/chaincode/handler.go
+++ b/openchain/chaincode/handler.go
@@ -555,8 +555,9 @@ func (handler *Handler) handleGetState(msg *pb.ChaincodeMessage) {
 
 		// Invoke ledger to get state
 		chaincodeID := handler.ChaincodeID.Name
-		// ToDo: Eventually, once consensus is plugged in, we need to set bool to true for ledger
-		res, err := ledgerObj.GetState(chaincodeID, key, false)
+
+		readCommittedState := !handler.getIsTransaction(msg.Uuid)
+		res, err := ledgerObj.GetState(chaincodeID, key, readCommittedState)
 		if err != nil {
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())
@@ -639,8 +640,9 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 		}
 
 		chaincodeID := handler.ChaincodeID.Name
-		var err error
-		rangeIter, err := ledger.GetStateRangeScanIterator(chaincodeID, rangeQueryState.StartKey, rangeQueryState.EndKey, true)
+
+		readCommittedState := !handler.getIsTransaction(msg.Uuid)
+		rangeIter, err := ledger.GetStateRangeScanIterator(chaincodeID, rangeQueryState.StartKey, rangeQueryState.EndKey, readCommittedState)
 		if err != nil {
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())


### PR DESCRIPTION
There are two types of state that can be read. Committed state is state which has been committed to a block in the chain. Uncommitted state is state that has been modified by an invoke transaction, but may not be committed.

Invoke transactions are run serially and therefore permitted to read and write to uncommitted state.

Query transactions are run in parallel and therefore can only read committed state. If they attempt to read uncommitted state, there may be a concurrent access error due to an invoke transaction attempting to modify uncommitted state during the query transaction read.

This fix resolves a problem where query transactions were reading uncommitted state. Query transactions now only read committed state.

Signed-off-by: sheehan@us.ibm.com
