### PR TITLE
Remove deploy payload from blocks for events/api. Issue #518

### DIFF
--- a/openchain/api.go
+++ b/openchain/api.go
@@ -27,6 +27,7 @@ import (
 
 	google_protobuf1 "google/protobuf"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/openblockchain/obc-peer/openchain/ledger"
 	pb "github.com/openblockchain/obc-peer/protos"
 )
@@ -84,7 +85,17 @@ func (s *ServerOpenchain) GetBlockByNumber(ctx context.Context, num *pb.BlockNum
 	blockTransactions := block.GetTransactions()
 	for _, transaction := range blockTransactions {
 		if transaction.Type == pb.Transaction_CHAINCODE_NEW {
-			transaction.Payload = nil
+			deploymentSpec := &pb.ChaincodeDeploymentSpec{}
+			err := proto.Unmarshal(transaction.Payload, deploymentSpec)
+			if err != nil {
+				return nil, err
+			}
+			deploymentSpec.CodePackage = nil
+			deploymentSpecBytes, err := proto.Marshal(deploymentSpec)
+			if err != nil {
+				return nil, err
+			}
+			transaction.Payload = deploymentSpecBytes
 		}
 	}
 

--- a/openchain/api.go
+++ b/openchain/api.go
@@ -76,6 +76,18 @@ func (s *ServerOpenchain) GetBlockByNumber(ctx context.Context, num *pb.BlockNum
 			return nil, fmt.Errorf("Error retrieving block from blockchain: %s", err)
 		}
 	}
+
+	// Remove payload from deploy transactions. This is done to make rest api
+	// calls more lightweight as the payload for these types of transactions
+	// can be very large. If the payload is needed, the caller should fetch the
+	// individual transaction.
+	blockTransactions := block.GetTransactions()
+	for _, transaction := range blockTransactions {
+		if transaction.Type == pb.Transaction_CHAINCODE_NEW {
+			transaction.Payload = nil
+		}
+	}
+
 	return block, nil
 }
 


### PR DESCRIPTION
For issue #518. The goal is to make events and the REST API a bit more lightweight by removing the payload from deploy transactions when blocks are retrieved. If the user wishes to retrieve the payload, they can access the transaction directly via UUID.

@angrbrd @manish-sethi @muralisrini please review. Thanks.
