### PR TITLE
extraneous view-changes in obcpbft-classic as pbft messages were broadcasted before request

### DIFF
--- a/openchain/consensus/obcpbft/config.yaml
+++ b/openchain/consensus/obcpbft/config.yaml
@@ -13,7 +13,11 @@ general:
     mode: classic
 
     # Maximum number of validators/replicas we expect in the network
-    N: 4
+    # Keep the "N" in quotes, or it will be interpreted as "false".
+    "N": 4
+
+    # Number of byzantine nodes we will tolerate
+    f: 1
 
     # Checkpoint period is the maximum number of pbft requests that must be
     # re-processed in a view change. A smaller checkpoint period will decrease

--- a/openchain/consensus/obcpbft/obc-classic.go
+++ b/openchain/consensus/obcpbft/obc-classic.go
@@ -49,12 +49,11 @@ func (op *obcClassic) RecvMsg(ocMsg *pb.OpenchainMessage, senderHandle *pb.PeerI
 	if ocMsg.Type == pb.OpenchainMessage_CHAIN_TRANSACTION {
 		logger.Info("New consensus request received")
 
-		op.pbft.request(ocMsg.Payload, op.pbft.id)
-
 		req := &Request{Payload: ocMsg.Payload, ReplicaId: op.pbft.id}
 		pbftMsg := &Message{&Message_Request{req}}
 		packedPbftMsg, _ := proto.Marshal(pbftMsg)
 		op.broadcast(packedPbftMsg)
+		op.pbft.request(ocMsg.Payload, op.pbft.id)
 
 		return nil
 	}

--- a/openchain/consensus/obcpbft/obc-sieve.go
+++ b/openchain/consensus/obcpbft/obc-sieve.go
@@ -59,6 +59,13 @@ func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSiev
 	return op
 }
 
+// moreCorrectThanByzantineQuorum returns the number of replicas that
+// have to agree to guarantee that more correct replicas than
+// byzantine replicas agree
+func (op *obcSieve) moreCorrectThanByzantineQuorum() int {
+	return 2*op.pbft.f + 1
+}
+
 // RecvMsg receives both CHAIN_TRANSACTION and CONSENSUS messages from
 // the stack. New transaction requests are broadcast to all replicas,
 // so that the current primary will receive the request.
@@ -347,7 +354,7 @@ func (op *obcSieve) recvVerify(verify *Verify) {
 	}
 	op.verifyStore = append(op.verifyStore, verify)
 
-	if len(op.verifyStore) == 2*op.pbft.f+1 {
+	if len(op.verifyStore) == op.moreCorrectThanByzantineQuorum() {
 		dSet, _ := op.verifyDset(op.verifyStore)
 		verifySet := &VerifySet{
 			View:          op.epoch,

--- a/openchain/consensus/obcpbft/obc-sieve_test.go
+++ b/openchain/consensus/obcpbft/obc-sieve_test.go
@@ -32,9 +32,11 @@ import (
 )
 
 func makeTestnetSieve(inst *instance) {
-	os.Setenv("OPENCHAIN_OBCPBFT_GENERAL_N", fmt.Sprintf("%d", inst.net.N)) // TODO, a little hacky, but needed for state transfer not to get upset
+	os.Setenv("OPENCHAIN_OBCPBFT_GENERAL_N", fmt.Sprintf("%d", inst.net.N))       // TODO, a little hacky, but needed for state transfer not to get upset
+	os.Setenv("OPENCHAIN_OBCPBFT_GENERAL_F", fmt.Sprintf("%d", (inst.net.N-1)/3)) // TODO, a little hacky, but needed for state transfer not to get upset
 	defer func() {
 		os.Unsetenv("OPENCHAIN_OBCPBFT_GENERAL_N")
+		os.Unsetenv("OPENCHAIN_OBCPBFT_GENERAL_F")
 	}()
 
 	config := loadConfig()

--- a/openchain/consensus/obcpbft/pbft-core_mock_test.go
+++ b/openchain/consensus/obcpbft/pbft-core_mock_test.go
@@ -119,17 +119,17 @@ func (inst *instance) verify(replicaID uint64, signature []byte, message []byte)
 func (inst *instance) broadcast(payload []byte) {
 	net := inst.net
 	net.cond.L.Lock()
+	defer net.cond.L.Unlock()
 	net.broadcastFilter(inst, payload)
 	net.cond.Signal()
-	net.cond.L.Unlock()
 }
 
 func (inst *instance) unicast(payload []byte, receiverID uint64) error {
 	net := inst.net
 	net.cond.L.Lock()
+	defer net.cond.L.Unlock()
 	net.msgs = append(net.msgs, taggedMsg{inst.id, int(receiverID), payload})
 	net.cond.Signal()
-	net.cond.L.Unlock()
 	return nil
 }
 
@@ -189,22 +189,22 @@ func (inst *instance) GetNetworkHandles() (self *pb.PeerID, network []*pb.PeerID
 func (inst *instance) Broadcast(msg *pb.OpenchainMessage, peerType pb.PeerEndpoint_Type) error {
 	net := inst.net
 	net.cond.L.Lock()
+	defer net.cond.L.Unlock()
 	net.broadcastFilter(inst, msg.Payload)
 	net.cond.Signal()
-	net.cond.L.Unlock()
 	return nil
 }
 
 func (inst *instance) Unicast(msg *pb.OpenchainMessage, receiverHandle *pb.PeerID) error {
 	net := inst.net
 	net.cond.L.Lock()
+	defer net.cond.L.Unlock()
 	receiverID, err := getValidatorID(receiverHandle)
 	if err != nil {
 		return fmt.Errorf("Couldn't unicast message to %s: %v", receiverHandle.Name, err)
 	}
 	net.msgs = append(net.msgs, taggedMsg{inst.id, int(receiverID), msg.Payload})
 	net.cond.Signal()
-	net.cond.L.Unlock()
 	return nil
 }
 
@@ -308,6 +308,17 @@ func (net *testnet) deliverFilter(msg taggedMsg, senderID int) {
 func (net *testnet) processWithoutDrain() {
 	net.cond.L.Lock()
 	defer net.cond.L.Unlock()
+
+	net.processWithoutDrainSync()
+}
+
+func (net *testnet) processWithoutDrainSync() {
+	doDeliver := func(msg taggedMsg) {
+		net.cond.L.Unlock()
+		defer net.cond.L.Lock()
+		net.deliverFilter(msg)
+	}
+
 	for len(net.msgs) > 0 {
 		msg := net.msgs[0]
 		net.msgs = net.msgs[1:]
@@ -354,9 +365,7 @@ func (net *testnet) processContinually() {
 		if len(net.msgs) == 0 {
 			net.cond.Wait()
 		}
-		net.cond.L.Unlock()
-		net.processWithoutDrain()
-		net.cond.L.Lock()
+		net.processWithoutDrainSync()
 	}
 }
 
@@ -404,9 +413,9 @@ func (net *testnet) close() {
 		}
 	}
 	net.cond.L.Lock()
+	defer net.cond.L.Unlock()
 	net.closed = true
 	net.cond.Signal()
-	net.cond.L.Unlock()
 }
 
 // Create a message of type `OpenchainMessage_CHAIN_TRANSACTION`

--- a/openchain/consensus/obcpbft/viewchange.go
+++ b/openchain/consensus/obcpbft/viewchange.go
@@ -198,7 +198,7 @@ func (instance *pbftCore) recvViewChange(vc *ViewChange) error {
 	}
 	logger.Debug("Replica %d now has %d view change requests for view %d", instance.id, quorum, instance.view)
 
-	if vc.View == instance.view && quorum == 2*instance.f+1 {
+	if vc.View == instance.view && quorum == instance.allCorrectReplicasQuorum() {
 		instance.startTimer(instance.lastNewViewTimeout)
 		instance.lastNewViewTimeout = 2 * instance.lastNewViewTimeout
 
@@ -442,7 +442,7 @@ func (instance *pbftCore) selectInitialCheckpoint(vset []*ViewChange) (checkpoin
 			}
 		}
 
-		if quorum <= 2*instance.f {
+		if quorum < instance.intersectionQuorum() {
 			logger.Debug("Replica %d has no quorum for n:%d", instance.id, idx.SequenceNumber)
 			continue
 		}
@@ -484,7 +484,7 @@ nLoop:
 					quorum++
 				}
 
-				if quorum < 2*instance.f+1 {
+				if quorum < instance.intersectionQuorum() {
 					continue
 				}
 
@@ -524,7 +524,7 @@ nLoop:
 			quorum++
 		}
 
-		if quorum >= 2*instance.f+1 {
+		if quorum >= instance.intersectionQuorum() {
 			// "then select the null request for number n"
 			msgList[n] = ""
 


### PR DESCRIPTION
Primary processing request before broadcasting request.

This caused pre-prepare/prepare/commit/execute to happen before the backups receive the request. The backup then starts its request timer which expires since there's nothing left to do. This then causes a view-change
