### PR TITLE
broadcast request before doing pbft messages when doing classic consensus

### DIFF
--- a/openchain/consensus/obcpbft/obc-classic.go
+++ b/openchain/consensus/obcpbft/obc-classic.go
@@ -49,12 +49,11 @@ func (op *obcClassic) RecvMsg(ocMsg *pb.OpenchainMessage, senderHandle *pb.PeerI
 	if ocMsg.Type == pb.OpenchainMessage_CHAIN_TRANSACTION {
 		logger.Info("New consensus request received")
 
-		op.pbft.request(ocMsg.Payload, op.pbft.id)
-
 		req := &Request{Payload: ocMsg.Payload, ReplicaId: op.pbft.id}
 		pbftMsg := &Message{&Message_Request{req}}
 		packedPbftMsg, _ := proto.Marshal(pbftMsg)
 		op.broadcast(packedPbftMsg)
+		op.pbft.request(ocMsg.Payload, op.pbft.id)
 
 		return nil
 	}


### PR DESCRIPTION
updated obcClassic.RecvMsg() to broadcast the request before doing pbft processing.

Previously, the backups were getting the requests after we had finished with pre-prepare/prepare/commit/execute. This causes the request timer to start and expire (since that request was finished ) causing many view-changes to occur.
