### PR TITLE
use chaincode id instead of path to name a chaincode executable

### DIFF
--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -253,20 +252,10 @@ func (chaincodeSupport *ChaincodeSupport) sendInitOrReady(context context.Contex
 
 //get args and env given chaincodeID
 func (chaincodeSupport *ChaincodeSupport) getArgsAndEnv(cID *pb.ChaincodeID) (args []string, envs []string, err error) {
-	//openchain.yaml in the container likely will not have the right url:version. We know the right
-	//values, lets construct and pass as envs
-	toks := strings.Split(cID.Path, "/")
-	if toks == nil {
-		return nil, nil, fmt.Errorf("cannot get path components from %s", cID.Name)
-	}
-
 	envs = []string{"OPENCHAIN_CHAINCODE_ID_NAME=" + cID.Name}
 
-	//TODO : chaincode executable will be same as the name of the last folder (golang thing...)
-	//       need to revisit executable name assignment
-	//e.g, for path (http(s)://)github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example01
-	//     exec is "chaincode_example01 --peer.address=1.1.1.1:11111"
-	args = []string{chaincodeSupport.chaincodeInstallPath + toks[len(toks)-1], fmt.Sprintf("-peer.address=%s", chaincodeSupport.peerAddress)}
+	//chaincode executable will be same as the name of the chaincode
+	args = []string{chaincodeSupport.chaincodeInstallPath + cID.Name, fmt.Sprintf("-peer.address=%s", chaincodeSupport.peerAddress)}
 
 	chaincodeLog.Debug("Executable is %s", args[0])
 


### PR DESCRIPTION
In progress PR for review and comments. This will fix bug #648 
