### PR TITLE
Document the required maximum number of open files setting. Issue #651

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ govendor list
 ## Building outside of Vagrant
 This is not recommended, however some users may wish to build Openchain outside of Vagrant if they use an editor with built in Go tooling. The instructions are
 
-1. Follow all steps required to setup and run a Vagrant image.
+1. Follow all steps required to setup and run a Vagrant image
 - Make you you have [Go 1.5.1](https://golang.org/) or later installed
 - Set the GO15VENDOREXPERIMENT environmental variable to 1. `export GO15VENDOREXPERIMENT=1`
+- Set the maximum number of open files to 10000 or greater for your OS
 - Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1
-- Run the following commands replacing `/opt/rocksdb` with the path where you installed RocksDB
+- Run the following commands replacing `/opt/rocksdb` with the path where you installed RocksDB:
 ```
 cd $GOPATH/src/github.com/openblockchain/obc-peer
 CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install


### PR DESCRIPTION
This is a small change to the documentation for building OBC outside of the vagrant image. It documents that the maximum number of open files for one's OS must be set to 10000 or greater. For changes in the vagrant image see https://github.com/openblockchain/obc-dev-env/pull/43
