### PR TITLE
Removed RSA to have a consistent use of elliptic curve crypto.

### DIFF
--- a/obc-ca/obcca.yaml
+++ b/obc-ca/obcca.yaml
@@ -10,7 +10,13 @@ server:
 #              certfile: "/var/openchain/production/.obcca/tlsca.cert"
 #              keyfile: "/var/openchain/production/.obcca/tlsca.priv"
 
-
+logging:
+        trace: 0
+        info: 1
+        warning: 1
+        error: 1
+        panic: 1
+        
 eca:
         users:
                 # <EnrollmentID>: <role (1:client, 2: peer, 4: validator)> <EnrollmentPWD>

--- a/obc-ca/obcca.yaml
+++ b/obc-ca/obcca.yaml
@@ -15,7 +15,7 @@ eca:
                 system_chaincode_invoker: 2 DRJ20pEql15a
                 diego: 2 DRJ23pEQl16a
                 binhn: 3 7avZQLwcUe9q
-                jim: 4 6avZQLwcUe9b
+                jim: 8 6avZQLwcUe9b
 tca:
 #         tls:
 #                certfile:

--- a/obc-ca/server.go
+++ b/obc-ca/server.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	//	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -42,7 +43,34 @@ func main() {
 		panic(err)
 	}
 
-	obcca.LogInit(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, os.Stdout)
+	var iotrace, ioinfo, iowarning, ioerror, iopanic io.Writer
+	if obcca.GetConfigInt("logging.trace") == 1 {
+		iotrace = os.Stdout
+	} else {
+		iotrace = ioutil.Discard
+	}
+	if obcca.GetConfigInt("logging.info") == 1 {
+		ioinfo = os.Stdout
+	} else {
+		ioinfo = ioutil.Discard
+	}
+	if obcca.GetConfigInt("logging.warning") == 1 {
+		iowarning = os.Stdout
+	} else {
+		iowarning = ioutil.Discard
+	}
+	if obcca.GetConfigInt("logging.error") == 1 {
+		ioerror = os.Stderr
+	} else {
+		ioerror = ioutil.Discard
+	}
+	if obcca.GetConfigInt("logging.panic") == 1 {
+		iopanic = os.Stdout
+	} else {
+		iopanic = ioutil.Discard
+	}
+	
+	obcca.LogInit(iotrace, ioinfo, iowarning, ioerror, iopanic)
 	obcca.Info.Println("CA Server (" + viper.GetString("server.version") + ")")
 
 	eca := obcca.NewECA()

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -6,7 +6,7 @@
 server:
         version: "0.1"
         rootpath: ".obc-ca"
-        port: ":80541"
+        port: ":50541"
 
 eca:
 
@@ -32,13 +32,13 @@ eca:
 peer:
     pki:
         eca:
-            paddr: localhost:80541
+            paddr: localhost:50541
 
         tca:
-            paddr: localhost:80541
+            paddr: localhost:50541
 
         tlsca:
-            paddr: localhost:80541
+            paddr: localhost:50541
 
         tls:
             enabled: true

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -6,7 +6,7 @@
 server:
         version: "0.1"
         rootpath: ".obc-ca"
-        port: ":50051"
+        port: ":80541"
 
 eca:
 
@@ -32,13 +32,13 @@ eca:
 peer:
     pki:
         eca:
-            paddr: localhost:50051
+            paddr: localhost:80541
 
         tca:
-            paddr: localhost:50051
+            paddr: localhost:80541
 
         tlsca:
-            paddr: localhost:50051
+            paddr: localhost:80541
 
         tls:
             enabled: true

--- a/openchain/crypto/ecies/crypto.go
+++ b/openchain/crypto/ecies/crypto.go
@@ -1,0 +1,83 @@
+package ecies
+
+import (
+	"errors"
+	"io"
+)
+
+var (
+	// ErrInvalidKeyParameter Invalid Key Parameter
+	ErrInvalidKeyParameter = errors.New("Invalid Key Parameter.")
+
+	// ErrInvalidKeyGeneratorParameter Invalid Key Generator Parameter
+	ErrInvalidKeyGeneratorParameter = errors.New("Invalid Key Generator Parameter.")
+)
+
+// Parameter is common interface for all the parameters
+type Parameter interface {
+	GetRand() io.Reader
+}
+
+// CipherParameters is common interface to represent cipher parameters
+type CipherParameters interface {
+	Parameter
+}
+
+// AsymmetricKeyParameter is common interface to represent asymmetric cipher parameters
+type AsymmetricCipherParameter interface {
+	Parameter
+
+	IsPublic() bool
+}
+
+// PublicKey is common interface to represent public asymmetric cipher parameters
+type PublicKey interface {
+	AsymmetricCipherParameter
+}
+
+// PrivateKey is common interface to represent private asymmetric cipher parameters
+type PrivateKey interface {
+	AsymmetricCipherParameter
+
+	GetPublicKey() PublicKey
+}
+
+// KeyGeneratorParameter is common interface to represent key generation parameters
+type KeyGeneratorParameter interface {
+	Parameter
+}
+
+// KeyGenerator defines a key generator
+type KeyGenerator interface {
+	Init(params KeyGeneratorParameter) error
+
+	GenerateKey() (PrivateKey, error)
+}
+
+// KeyGenerator defines an asymmetric cipher
+type AsymmetricCipher interface {
+	// Init initializes this cipher with the passed parameters
+	Init(params AsymmetricCipherParameter) error
+
+	// Process processes the byte array given in input
+	Process(msg []byte) ([]byte, error)
+}
+
+// KeySerializer defines a key serializer/deserializer
+type KeySerializer interface {
+	// ToBytes converts a key to bytes
+	ToBytes(key interface{}) ([]byte, error)
+
+	// ToBytes converts bytes to a key
+	FromBytes([]byte) (interface{}, error)
+}
+
+// SPI is the ECIES Service Provider Interface
+type SPI interface {
+	NewAsymmetricCipherFromPrivateKey(priv PrivateKey) (AsymmetricCipher, error)
+	NewAsymmetricCipherFromPublicKey(pub PublicKey) (AsymmetricCipher, error)
+	NewPrivateKey(rand io.Reader, params interface{}) (PrivateKey, error)
+	NewPublicKey(rand io.Reader, params interface{}) (PublicKey, error)
+	SerializePrivateKey(priv PrivateKey) ([]byte, error)
+	DeserializePrivateKey(bytes []byte) (PrivateKey, error)
+}

--- a/openchain/crypto/ecies/generic/engine.go
+++ b/openchain/crypto/ecies/generic/engine.go
@@ -1,0 +1,219 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package generic
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	rand "crypto/rand"
+	"errors"
+	"io"
+
+	"crypto/subtle"
+	"golang.org/x/crypto/hkdf"
+	"golang.org/x/crypto/sha3"
+)
+
+func aesEncrypt(key, plain []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	text := make([]byte, aes.BlockSize+len(plain))
+	iv := text[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+
+	cfb := cipher.NewCFBEncrypter(block, iv)
+	cfb.XORKeyStream(text[aes.BlockSize:], plain)
+
+	return text, nil
+}
+
+func aesDecrypt(key, text []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(text) < aes.BlockSize {
+		return nil, errors.New("cipher text too short")
+	}
+
+	cfb := cipher.NewCFBDecrypter(block, text[:aes.BlockSize])
+	plain := make([]byte, len(text)-aes.BlockSize)
+	cfb.XORKeyStream(plain, text[aes.BlockSize:])
+
+	return plain, nil
+}
+
+func eciesGenerateKey(rand io.Reader, curve elliptic.Curve, params *Params) (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(curve, rand)
+}
+
+func eciesEncrypt(rand io.Reader, pub *ecdsa.PublicKey, s1, s2 []byte, plain []byte) ([]byte, error) {
+	params := pub.Curve.Params()
+
+	// Select an ephemeral elliptic curve key pair associated with
+	// elliptic curve domain parameters params
+	priv, Rx, Ry, err := elliptic.GenerateKey(pub.Curve, rand)
+	//fmt.Printf("Rx %s\n", utils.EncodeBase64(Rx.Bytes()))
+	//fmt.Printf("Ry %s\n", utils.EncodeBase64(Ry.Bytes()))
+
+	// Convert R=(Rx,Ry) to an octed string R bar
+	// This is uncompressed
+	Rb := elliptic.Marshal(pub.Curve, Rx, Ry)
+
+	// Derive a shared secret field element z from the ephemeral secret key k
+	// and convert z to an octet string Z
+	z, _ := params.ScalarMult(pub.X, pub.Y, priv)
+	Z := z.Bytes()
+	//fmt.Printf("Z %s\n", utils.EncodeBase64(Z))
+
+	// generate keying data K of length ecnKeyLen + macKeyLen octects from Z
+	// ans s1
+	kE := make([]byte, 32)
+	kM := make([]byte, 32)
+	hkdf := hkdf.New(sha3.New384, Z, s1, nil)
+	_, err = hkdf.Read(kE)
+	if err != nil {
+		return nil, err
+	}
+	_, err = hkdf.Read(kM)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the encryption operation of the symmetric encryption scheme
+	// to encrypt m under EK as ciphertext EM
+	EM, err := aesEncrypt(kE, plain)
+
+	// Use the tagging operation of the MAC scheme to compute
+	// the tag D on EM || s2
+	mac := hmac.New(sha3.New384, kM)
+	mac.Write(EM)
+	if len(s2) > 0 {
+		mac.Write(s2)
+	}
+	D := mac.Sum(nil)
+
+	// Output R,EM,D
+	ciphertext := make([]byte, len(Rb)+len(EM)+len(D))
+	//fmt.Printf("Rb %s\n", utils.EncodeBase64(Rb))
+	//fmt.Printf("EM %s\n", utils.EncodeBase64(EM))
+	//fmt.Printf("D %s\n", utils.EncodeBase64(D))
+	copy(ciphertext, Rb)
+	copy(ciphertext[len(Rb):], EM)
+	copy(ciphertext[len(Rb)+len(EM):], D)
+
+	return ciphertext, nil
+}
+
+func eciesDecrypt(priv *ecdsa.PrivateKey, s1, s2 []byte, ciphertext []byte) ([]byte, error) {
+	params := priv.Curve.Params()
+
+	var (
+		rLen   int
+		hLen   int = sha3.New384().Size()
+		mStart int
+		mEnd   int
+	)
+
+	//fmt.Printf("Decrypt\n")
+	switch ciphertext[0] {
+	case 2, 3:
+		rLen = ((priv.PublicKey.Curve.Params().BitSize + 7) / 8) + 1
+		if len(ciphertext) < (rLen + hLen + 1) {
+			return nil, errors.New("Invalid ciphertext")
+		}
+		break
+	case 4:
+		rLen = 2*((priv.PublicKey.Curve.Params().BitSize+7)/8) + 1
+		if len(ciphertext) < (rLen + hLen + 1) {
+			return nil, errors.New("Invalid ciphertext")
+		}
+		break
+
+	default:
+		return nil, errors.New("Invalid ciphertext")
+	}
+
+	mStart = rLen
+	mEnd = len(ciphertext) - hLen
+	//fmt.Printf("Rb %s\n", utils.EncodeBase64(ciphertext[:rLen]))
+
+	Rx, Ry := elliptic.Unmarshal(priv.Curve, ciphertext[:rLen])
+	if Rx == nil {
+		return nil, errors.New("Invalid ephemeral PK")
+	}
+	if !priv.Curve.IsOnCurve(Rx, Ry) {
+		return nil, errors.New("Invalid point on curve")
+	}
+	//fmt.Printf("Rx %s\n", utils.EncodeBase64(Rx.Bytes()))
+	//fmt.Printf("Ry %s\n", utils.EncodeBase64(Ry.Bytes()))
+
+	// Derive a shared secret field element z from the ephemeral secret key k
+	// and convert z to an octet string Z
+	z, _ := params.ScalarMult(Rx, Ry, priv.D.Bytes())
+	Z := z.Bytes()
+	//fmt.Printf("Z %s\n", utils.EncodeBase64(Z))
+
+	// generate keying data K of length ecnKeyLen + macKeyLen octects from Z
+	// ans s1
+	kE := make([]byte, 32)
+	kM := make([]byte, 32)
+	hkdf := hkdf.New(sha3.New384, Z, s1, nil)
+	_, err := hkdf.Read(kE)
+	if err != nil {
+		return nil, err
+	}
+	_, err = hkdf.Read(kM)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the tagging operation of the MAC scheme to compute
+	// the tag D on EM || s2 and then compare
+	mac := hmac.New(sha3.New384, kM)
+	mac.Write(ciphertext[mStart:mEnd])
+	if len(s2) > 0 {
+		mac.Write(s2)
+	}
+	D := mac.Sum(nil)
+
+	//fmt.Printf("EM %s\n", utils.EncodeBase64(ciphertext[mStart:mEnd]))
+	//fmt.Printf("D' %s\n", utils.EncodeBase64(D))
+	//fmt.Printf("D %s\n", utils.EncodeBase64(ciphertext[mEnd:]))
+	if subtle.ConstantTimeCompare(ciphertext[mEnd:], D) != 1 {
+		return nil, errors.New("Tag check failed")
+	}
+
+	// Use the decryption operation of the symmetric encryption scheme
+	// to decryptr EM under EK as plaintext
+
+	plaintext, err := aesDecrypt(kE, ciphertext[mStart:mEnd])
+
+	return plaintext, err
+}

--- a/openchain/crypto/ecies/generic/engine_test.go
+++ b/openchain/crypto/ecies/generic/engine_test.go
@@ -1,0 +1,1 @@
+package generic

--- a/openchain/crypto/ecies/generic/es.go
+++ b/openchain/crypto/ecies/generic/es.go
@@ -1,0 +1,74 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package generic
+
+import (
+	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
+)
+
+type encryptionSchemeImpl struct {
+	isForEncryption bool
+
+	// Parameters
+	params ecies.AsymmetricCipherParameter
+	pub    *publicKeyImpl
+	priv   *secretKeyImpl
+}
+
+func (es *encryptionSchemeImpl) Init(params ecies.AsymmetricCipherParameter) error {
+	if params == nil {
+		//fmt.Printf("encryptionSchemeImpl null params")
+		return ecies.ErrInvalidKeyParameter
+	}
+	es.isForEncryption = params.IsPublic()
+	es.params = params
+
+	if es.isForEncryption {
+		switch pk := params.(type) {
+		case *publicKeyImpl:
+			es.pub = pk
+		default:
+			//fmt.Printf("encryptionSchemeImpl failed [%s]", pk)
+			return ecies.ErrInvalidKeyParameter
+		}
+	} else {
+		switch sk := params.(type) {
+		case *secretKeyImpl:
+			es.priv = sk
+		default:
+			//fmt.Printf("encryptionSchemeImpl failed [%s]", sk)
+			return ecies.ErrInvalidKeyParameter
+		}
+	}
+
+	return nil
+}
+
+func (es *encryptionSchemeImpl) Process(msg []byte) ([]byte, error) {
+	if es.isForEncryption {
+		// Encrypt
+		return eciesEncrypt(es.params.GetRand(), es.pub.pub, nil, nil, msg)
+	} else {
+		// Decrypt
+		return eciesDecrypt(es.priv.priv, nil, nil, msg)
+	}
+
+	return nil, nil
+}

--- a/openchain/crypto/ecies/generic/kg.go
+++ b/openchain/crypto/ecies/generic/kg.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package generic
+
+import (
+	"crypto/elliptic"
+	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
+	"io"
+)
+
+type keyGeneratorParameterImpl struct {
+	rand   io.Reader
+	curve  elliptic.Curve
+	params *Params
+}
+
+type keyGeneratorImpl struct {
+	isForEncryption bool
+	params          *keyGeneratorParameterImpl
+}
+
+func (kgp keyGeneratorParameterImpl) GetRand() io.Reader {
+	return kgp.rand
+}
+
+func (kg *keyGeneratorImpl) Init(params ecies.KeyGeneratorParameter) error {
+	if params == nil {
+		return ecies.ErrInvalidKeyGeneratorParameter
+	}
+	switch kgparams := params.(type) {
+	case *keyGeneratorParameterImpl:
+		kg.params = kgparams
+	default:
+		return ecies.ErrInvalidKeyGeneratorParameter
+	}
+
+	return nil
+}
+
+func (kg *keyGeneratorImpl) GenerateKey() (ecies.PrivateKey, error) {
+
+	privKey, err := eciesGenerateKey(
+		kg.params.rand,
+		kg.params.curve,
+		kg.params.params,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &secretKeyImpl{privKey, nil, kg.params.params, kg.params.rand}, nil
+}

--- a/openchain/crypto/ecies/generic/params.go
+++ b/openchain/crypto/ecies/generic/params.go
@@ -1,0 +1,15 @@
+package generic
+
+import (
+	"crypto"
+	"crypto/cipher"
+	"hash"
+)
+
+type Params struct {
+	Hash      func() hash.Hash
+	hashAlgo  crypto.Hash
+	Cipher    func([]byte) (cipher.Block, error)
+	BlockSize int
+	KeyLen    int
+}

--- a/openchain/crypto/ecies/generic/pk.go
+++ b/openchain/crypto/ecies/generic/pk.go
@@ -1,0 +1,39 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package generic
+
+import (
+	"crypto/ecdsa"
+	"io"
+)
+
+type publicKeyImpl struct {
+	pub    *ecdsa.PublicKey
+	rand   io.Reader
+	params *Params
+}
+
+func (pk *publicKeyImpl) GetRand() io.Reader {
+	return pk.rand
+}
+
+func (pk *publicKeyImpl) IsPublic() bool {
+	return true
+}

--- a/openchain/crypto/ecies/generic/sk.go
+++ b/openchain/crypto/ecies/generic/sk.go
@@ -1,0 +1,76 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package generic
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
+	"io"
+)
+
+type secretKeyImpl struct {
+	priv   *ecdsa.PrivateKey
+	pub    ecies.PublicKey
+	params *Params
+	rand   io.Reader
+}
+
+type secretKeySerializerImpl struct {
+}
+
+func (sk *secretKeyImpl) IsPublic() bool {
+	return false
+}
+
+func (sk *secretKeyImpl) GetRand() io.Reader {
+	return sk.rand
+}
+
+func (sk *secretKeyImpl) GetPublicKey() ecies.PublicKey {
+	if sk.pub == nil {
+		sk.pub = &publicKeyImpl{&sk.priv.PublicKey, sk.rand, sk.params}
+	}
+	return sk.pub
+}
+
+func (sks *secretKeySerializerImpl) ToBytes(key interface{}) ([]byte, error) {
+	switch sk := key.(type) {
+	case *secretKeyImpl:
+		fmt.Println("key [%s]\n", sk.priv.Curve)
+		return x509.MarshalECPrivateKey(sk.priv)
+	default:
+		return nil, ecies.ErrInvalidKeyParameter
+	}
+
+	return nil, ecies.ErrInvalidKeyParameter
+}
+
+func (sks *secretKeySerializerImpl) FromBytes(bytes []byte) (interface{}, error) {
+	key, err := x509.ParseECPrivateKey(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: add params here
+	return &secretKeyImpl{key, nil, nil, rand.Reader}, nil
+}

--- a/openchain/crypto/ecies/generic/spi.go
+++ b/openchain/crypto/ecies/generic/spi.go
@@ -1,0 +1,152 @@
+package generic
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
+	"io"
+)
+
+func newKeyGeneratorParameter(rand io.Reader, curve elliptic.Curve) (ecies.KeyGeneratorParameter, error) {
+	return &keyGeneratorParameterImpl{rand, curve, nil}, nil
+}
+
+func newKeyGenerator() (ecies.KeyGenerator, error) {
+	return &keyGeneratorImpl{}, nil
+}
+
+func newKeyGeneratorFromCurve(rand io.Reader, curve elliptic.Curve) (ecies.KeyGenerator, error) {
+	kg, err := newKeyGenerator()
+	if err != nil {
+		return nil, err
+	}
+
+	kgp, err := newKeyGeneratorParameter(rand, curve)
+	if err != nil {
+		return nil, err
+	}
+
+	err = kg.Init(kgp)
+	if err != nil {
+		return nil, err
+	}
+
+	return kg, nil
+}
+
+func newPublicKeyFromECDSA(pk *ecdsa.PublicKey) (ecies.PublicKey, error) {
+	return &publicKeyImpl{pk, rand.Reader, nil}, nil
+}
+
+func newPrivateKeyFromECDSA(sk *ecdsa.PrivateKey) (ecies.PrivateKey, error) {
+	fmt.Printf("[%s]\n", sk)
+	return &secretKeyImpl{sk, nil, nil, rand.Reader}, nil
+}
+
+func serializePrivateKey(priv ecies.PrivateKey) ([]byte, error) {
+	serializer := secretKeySerializerImpl{}
+	return serializer.ToBytes(priv)
+}
+
+func deserializePrivateKey(bytes []byte) (ecies.PrivateKey, error) {
+	serializer := secretKeySerializerImpl{}
+	priv, err := serializer.FromBytes(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return priv.(ecies.PrivateKey), nil
+}
+
+func newAsymmetricCipher() (ecies.AsymmetricCipher, error) {
+	return &encryptionSchemeImpl{}, nil
+}
+
+func newPrivateKey(rand io.Reader, curve elliptic.Curve) (ecies.PrivateKey, error) {
+	kg, err := newKeyGeneratorFromCurve(rand, curve)
+	if err != nil {
+		return nil, err
+	}
+	return kg.GenerateKey()
+}
+
+func newAsymmetricCipherFromPrivateKey(priv ecies.PrivateKey) (ecies.AsymmetricCipher, error) {
+	es, err := newAsymmetricCipher()
+	if err != nil {
+		return nil, err
+	}
+
+	err = es.Init(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	return es, nil
+}
+
+func newAsymmetricCipherFromPublicKey(pub ecies.PublicKey) (ecies.AsymmetricCipher, error) {
+	es, err := newAsymmetricCipher()
+	if err != nil {
+		return nil, err
+	}
+
+	err = es.Init(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	return es, nil
+}
+
+func NewSPI() ecies.SPI {
+	return &spiImpl{}
+}
+
+type spiImpl struct {
+}
+
+func (spi *spiImpl) NewAsymmetricCipherFromPrivateKey(priv ecies.PrivateKey) (ecies.AsymmetricCipher, error) {
+	return newAsymmetricCipherFromPrivateKey(priv)
+}
+
+func (spi *spiImpl) NewAsymmetricCipherFromPublicKey(pub ecies.PublicKey) (ecies.AsymmetricCipher, error) {
+	return newAsymmetricCipherFromPublicKey(pub)
+}
+
+func (spi *spiImpl) NewPrivateKey(r io.Reader, params interface{}) (ecies.PrivateKey, error) {
+	fmt.Printf("NewPrivateKey [%s]\n", params)
+
+	switch t := params.(type) {
+	case *ecdsa.PrivateKey:
+		fmt.Printf("2 [%s]\n", t)
+		return newPrivateKeyFromECDSA(t)
+	case elliptic.Curve:
+		fmt.Printf("1 [%s]\n", params)
+		if r == nil {
+			r = rand.Reader
+		}
+		return newPrivateKey(r, t)
+	default:
+		return nil, ecies.ErrInvalidKeyGeneratorParameter
+	}
+}
+
+func (spi *spiImpl) NewPublicKey(r io.Reader, params interface{}) (ecies.PublicKey, error) {
+
+	switch t := params.(type) {
+	case *ecdsa.PublicKey:
+		return newPublicKeyFromECDSA(t)
+	default:
+		return nil, ecies.ErrInvalidKeyGeneratorParameter
+	}
+}
+
+func (spi *spiImpl) SerializePrivateKey(priv ecies.PrivateKey) ([]byte, error) {
+	return serializePrivateKey(priv)
+}
+
+func (spi *spiImpl) DeserializePrivateKey(bytes []byte) (ecies.PrivateKey, error) {
+	return deserializePrivateKey(bytes)
+}

--- a/openchain/crypto/ecies/generic/spi.go
+++ b/openchain/crypto/ecies/generic/spi.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"fmt"
 	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
 	"io"
 )
@@ -41,7 +40,6 @@ func newPublicKeyFromECDSA(pk *ecdsa.PublicKey) (ecies.PublicKey, error) {
 }
 
 func newPrivateKeyFromECDSA(sk *ecdsa.PrivateKey) (ecies.PrivateKey, error) {
-	fmt.Printf("[%s]\n", sk)
 	return &secretKeyImpl{sk, nil, nil, rand.Reader}, nil
 }
 
@@ -116,14 +114,10 @@ func (spi *spiImpl) NewAsymmetricCipherFromPublicKey(pub ecies.PublicKey) (ecies
 }
 
 func (spi *spiImpl) NewPrivateKey(r io.Reader, params interface{}) (ecies.PrivateKey, error) {
-	fmt.Printf("NewPrivateKey [%s]\n", params)
-
 	switch t := params.(type) {
 	case *ecdsa.PrivateKey:
-		fmt.Printf("2 [%s]\n", t)
 		return newPrivateKeyFromECDSA(t)
 	case elliptic.Curve:
-		fmt.Printf("1 [%s]\n", params)
 		if r == nil {
 			r = rand.Reader
 		}

--- a/openchain/crypto/ecies/generic/spi_test.go
+++ b/openchain/crypto/ecies/generic/spi_test.go
@@ -1,0 +1,159 @@
+package generic
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+	"github.com/openblockchain/obc-peer/openchain/crypto/ecies"
+	"github.com/openblockchain/obc-peer/openchain/crypto/utils"
+	"reflect"
+	"testing"
+)
+
+func TestSPI(t *testing.T) {
+
+	spi := NewSPI()
+
+	ecdsaKey, err := ecdsa.GenerateKey(utils.DefaultCurve, rand.Reader)
+
+	var a interface{}
+	a = ecdsaKey
+
+	switch t := a.(type) {
+	case *ecdsa.PrivateKey:
+		fmt.Printf("a2 [%s]\n", t)
+		break
+	case elliptic.Curve:
+		fmt.Printf("a1 [%s]\n", t)
+		break
+	default:
+		fmt.Printf("a3 [%s]\n", t)
+
+	}
+
+	fmt.Printf("[%s]\n", ecdsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = x509.MarshalECPrivateKey(ecdsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("[%s]\n", ecdsaKey)
+
+	privateKey, err := spi.NewPrivateKey(nil, ecdsaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Printf("[%s]\n", privateKey.(*secretKeyImpl).priv)
+	_, err = x509.MarshalECPrivateKey(privateKey.(*secretKeyImpl).priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawKey, err := spi.SerializePrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateKey, err = spi.DeserializePrivateKey(rawKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encrypt
+	cipher, err := spi.NewAsymmetricCipherFromPublicKey(privateKey.GetPublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := []byte("Hello World!!!")
+	ct, err := cipher.Process(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decrypt
+	cipher, err = spi.NewAsymmetricCipherFromPrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plain, err := cipher.Process(ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(msg, plain) {
+		t.Fatal("Decrypted different message")
+	}
+
+}
+
+func TestKG(t *testing.T) {
+	kg, err := newKeyGenerator()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kgparams, err := newKeyGeneratorParameter(rand.Reader, utils.DefaultCurve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = kg.Init(kgparams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKey, err := kg.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if privKey == nil {
+		t.Fatal("Private Key is nil")
+	}
+}
+
+func TestES(t *testing.T) {
+	cipher, err := newAsymmetricCipher()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privKey := generateKey()
+
+	// Encrypt
+	plaintext := []byte("Hello World!!!")
+	err = cipher.Init(privKey.GetPublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := cipher.Process(plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decrypt
+	err = cipher.Init(privKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext2, err := cipher.Process(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(plaintext, plaintext2) {
+		t.Fatalf("Decryption failed [%s]!=[%s]", string(plaintext), string(plaintext2))
+	}
+}
+
+func generateKey() ecies.PrivateKey {
+	kg, _ := newKeyGenerator()
+	kgparams, _ := newKeyGeneratorParameter(rand.Reader, utils.DefaultCurve)
+	kg.Init(kgparams)
+	privKey, _ := kg.GenerateKey()
+	return privKey
+}

--- a/openchain/crypto/utils/elliptic.go
+++ b/openchain/crypto/utils/elliptic.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	defaultCurve = elliptic.P384()
+	DefaultCurve = elliptic.P384()
 )
 
 // ECDSASignature represents an ECDSA signature
@@ -39,7 +39,7 @@ type ECDSASignature struct {
 
 // NewECDSAKey generates a new ECDSA Key
 func NewECDSAKey() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(defaultCurve, rand.Reader)
+	return ecdsa.GenerateKey(DefaultCurve, rand.Reader)
 }
 
 // ECDSASignDirect signs

--- a/vendor/golang.org/x/crypto/LICENSE
+++ b/vendor/golang.org/x/crypto/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/crypto/PATENTS
+++ b/vendor/golang.org/x/crypto/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/crypto/hkdf/hkdf.go
+++ b/vendor/golang.org/x/crypto/hkdf/hkdf.go
@@ -1,0 +1,75 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package hkdf implements the HMAC-based Extract-and-Expand Key Derivation
+// Function (HKDF) as defined in RFC 5869.
+//
+// HKDF is a cryptographic key derivation function (KDF) with the goal of
+// expanding limited input keying material into one or more cryptographically
+// strong secret keys.
+//
+// RFC 5869: https://tools.ietf.org/html/rfc5869
+package hkdf // import "golang.org/x/crypto/hkdf"
+
+import (
+	"crypto/hmac"
+	"errors"
+	"hash"
+	"io"
+)
+
+type hkdf struct {
+	expander hash.Hash
+	size     int
+
+	info    []byte
+	counter byte
+
+	prev  []byte
+	cache []byte
+}
+
+func (f *hkdf) Read(p []byte) (int, error) {
+	// Check whether enough data can be generated
+	need := len(p)
+	remains := len(f.cache) + int(255-f.counter+1)*f.size
+	if remains < need {
+		return 0, errors.New("hkdf: entropy limit reached")
+	}
+	// Read from the cache, if enough data is present
+	n := copy(p, f.cache)
+	p = p[n:]
+
+	// Fill the buffer
+	for len(p) > 0 {
+		f.expander.Reset()
+		f.expander.Write(f.prev)
+		f.expander.Write(f.info)
+		f.expander.Write([]byte{f.counter})
+		f.prev = f.expander.Sum(f.prev[:0])
+		f.counter++
+
+		// Copy the new batch into p
+		f.cache = f.prev
+		n = copy(p, f.cache)
+		p = p[n:]
+	}
+	// Save leftovers for next run
+	f.cache = f.cache[n:]
+
+	return need, nil
+}
+
+// New returns a new HKDF using the given hash, the secret keying material to expand
+// and optional salt and info fields.
+func New(hash func() hash.Hash, secret, salt, info []byte) io.Reader {
+	if salt == nil {
+		salt = make([]byte, hash().Size())
+	}
+	extractor := hmac.New(hash, salt)
+	extractor.Write(secret)
+	prk := extractor.Sum(nil)
+
+	return &hkdf{hmac.New(hash, prk), extractor.Size(), info, 1, nil, nil}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -223,6 +223,11 @@
 			"revisionTime": "2015-09-11T12:06:27+02:00"
 		},
 		{
+			"path": "golang.org/x/crypto/hkdf",
+			"revision": "c8b9e6388ef638d5a8a9d865c634befdc46a6784",
+			"revisionTime": "2015-06-18T17:47:17-07:00"
+		},
+		{
 			"path": "golang.org/x/crypto/sha3",
 			"revision": "81bf7719a6b7ce9b665598222362b50122dfc13b",
 			"revisionTime": "2015-07-28T14:18:45-07:00"


### PR DESCRIPTION
Encryption enrollment certificates now use EC, replacing RSA and thereby having a consistent use of EC crypto in OBC.

Signed-off by: Thorsten Kramp thk@zurich.ibm.com
