### PR TITLE
Internal crypto instances garbage collector for clients, peers and validator

### DIFF
--- a/openchain/crypto/client.go
+++ b/openchain/crypto/client.go
@@ -106,7 +106,7 @@ func CloseClient(client Client) error {
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
 
-	return closeClientInternal(client)
+	return closeClientInternal(client, false)
 }
 
 // CloseAllClients closes all the clients initialized so far
@@ -118,7 +118,7 @@ func CloseAllClients() (bool, []error) {
 
 	errs := make([]error, len(clients))
 	for _, value := range clients {
-		err := closeClientInternal(value.client)
+		err := closeClientInternal(value.client, true)
 
 		errs = append(errs, err)
 	}
@@ -130,7 +130,7 @@ func CloseAllClients() (bool, []error) {
 
 // Private Methods
 
-func closeClientInternal(client Client) error {
+func closeClientInternal(client Client, force bool) error {
 	if client == nil {
 		return utils.ErrNilArgument
 	}
@@ -141,7 +141,7 @@ func closeClientInternal(client Client) error {
 	if !ok {
 		return utils.ErrInvalidReference
 	}
-	if entry.counter == 1 {
+	if entry.counter == 1 || force {
 		defer delete(clients, name)
 		err := clients[name].client.(*clientImpl).close()
 		log.Info("Closing client [%s]...done! [%s].", name, utils.ErrToString(err))

--- a/openchain/crypto/client.go
+++ b/openchain/crypto/client.go
@@ -26,9 +26,14 @@ import (
 
 // Private Variables
 
+type clientEntry struct {
+	client  Client
+	counter int64
+}
+
 var (
 	// Map of initialized clients
-	clients = make(map[string]Client)
+	clients = make(map[string]clientEntry)
 
 	// Sync
 	clientMutex sync.Mutex
@@ -43,7 +48,7 @@ func RegisterClient(name string, pwd []byte, enrollID, enrollPWD string) error {
 
 	log.Info("Registering client [%s] with name [%s]...", enrollID, name)
 
-	if clients[name] != nil {
+	if _, ok := clients[name]; ok {
 		log.Info("Registering client [%s] with name [%s]...done. Already initialized.", enrollID, name)
 
 		return nil
@@ -75,10 +80,12 @@ func InitClient(name string, pwd []byte) (Client, error) {
 
 	log.Info("Initializing client [%s]...", name)
 
-	if clients[name] != nil {
-		log.Info("Client already initiliazied [%s].", name)
+	if entry, ok := clients[name]; ok {
+		log.Info("Client already initiliazied [%s]. Increasing counter from [%d]", name, clients[name].counter)
+		entry.counter++
+		clients[name] = entry
 
-		return clients[name], nil
+		return clients[name].client, nil
 	}
 
 	client := new(clientImpl)
@@ -88,7 +95,7 @@ func InitClient(name string, pwd []byte) (Client, error) {
 		return nil, err
 	}
 
-	clients[name] = client
+	clients[name] = clientEntry{client, 1}
 	log.Info("Initializing client [%s]...done!", name)
 
 	return client, nil
@@ -111,7 +118,7 @@ func CloseAllClients() (bool, []error) {
 
 	errs := make([]error, len(clients))
 	for _, value := range clients {
-		err := closeClientInternal(value)
+		err := closeClientInternal(value.client)
 
 		errs = append(errs, err)
 	}
@@ -130,14 +137,21 @@ func closeClientInternal(client Client) error {
 
 	name := client.GetName()
 	log.Info("Closing client [%s]...", name)
-	if _, ok := clients[name]; !ok {
+	entry, ok := clients[name]
+	if !ok {
 		return utils.ErrInvalidReference
 	}
-	defer delete(clients, name)
+	if entry.counter == 1 {
+		defer delete(clients, name)
+		err := clients[name].client.(*clientImpl).close()
+		log.Info("Closing client [%s]...done! [%s].", name, utils.ErrToString(err))
+		return err
+	} else {
+		// decrease counter
+		entry.counter--
+		clients[name] = entry
+		log.Info("Closing client [%s]...decreased counter at [%d].", name, clients[name].counter)
+	}
 
-	err := clients[name].(*clientImpl).close()
-
-	log.Info("Closing client [%s]...done! [%s].", name, utils.ErrToString(err))
-
-	return err
+	return nil
 }

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"time"
 )
 
 type createTxFunc func(t *testing.T) (*obc.Transaction, *obc.Transaction, error)
@@ -104,6 +105,66 @@ func TestMain(m *testing.M) {
 	cleanup()
 
 	os.Exit(ret)
+}
+
+func TestBla(t *testing.T) {
+	conf := utils.NodeConfiguration{Type: "client", Name: "userthread"}
+	RegisterClient(conf.Name, nil, conf.GetEnrollmentID(), conf.GetEnrollmentPWD())
+
+	done := make(chan bool)
+
+	go func() {
+		for i := 0; i < 5; i++ {
+			client, err := InitClient(conf.Name, nil)
+			if err != nil {
+				t.Log("Init failed")
+			}
+			time.Sleep(3 * time.Second)
+			err = CloseClient(client)
+			if err != nil {
+				t.Log("Close failed")
+			}
+		}
+		done <- true
+
+	}()
+	go func() {
+		for i := 0; i < 5; i++ {
+			client, err := InitClient(conf.Name, nil)
+			if err != nil {
+				t.Log("Init failed")
+			}
+			time.Sleep(5 * time.Second)
+			err = CloseClient(client)
+			if err != nil {
+				t.Log("Close failed")
+			}
+		}
+		done <- true
+
+	}()
+	go func() {
+		for i := 0; i < 5; i++ {
+			client, err := InitClient(conf.Name, nil)
+			if err != nil {
+				t.Log("Init failed")
+			}
+			time.Sleep(1 * time.Second)
+			err = CloseClient(client)
+			if err != nil {
+				t.Log("Close failed")
+			}
+		}
+		done <- true
+
+	}()
+
+	for i := 0; i < 3; i++ {
+		t.Log("Waiting")
+		<-done
+		t.Log("+1")
+	}
+	//
 }
 
 func TestRegistrationSameEnrollIDDifferentRole(t *testing.T) {

--- a/openchain/crypto/crypto_test.go
+++ b/openchain/crypto/crypto_test.go
@@ -107,7 +107,8 @@ func TestMain(m *testing.M) {
 	os.Exit(ret)
 }
 
-func TestBla(t *testing.T) {
+func TestParallelInitClose(t *testing.T) {
+	// TODO: complete this
 	conf := utils.NodeConfiguration{Type: "client", Name: "userthread"}
 	RegisterClient(conf.Name, nil, conf.GetEnrollmentID(), conf.GetEnrollmentPWD())
 
@@ -119,7 +120,7 @@ func TestBla(t *testing.T) {
 			if err != nil {
 				t.Log("Init failed")
 			}
-			time.Sleep(3 * time.Second)
+			time.Sleep(1 * time.Second)
 			err = CloseClient(client)
 			if err != nil {
 				t.Log("Close failed")
@@ -134,7 +135,7 @@ func TestBla(t *testing.T) {
 			if err != nil {
 				t.Log("Init failed")
 			}
-			time.Sleep(5 * time.Second)
+			time.Sleep(2 * time.Second)
 			err = CloseClient(client)
 			if err != nil {
 				t.Log("Close failed")

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -12,6 +12,7 @@ eca:
 
     users:
         # clients
+        userthread: 1 9gvZQRwhUq9q
         user1: 1 9gvZQRwhUq9q
         user2: 1 9gvZQRwhUq9q
         TestRegistrationSameEnrollIDDifferentRole: 1 9gvZQRwhUq9q
@@ -81,5 +82,9 @@ tests:
 
             TestRegistrationSameEnrollIDDifferentRole:
                 enrollid: TestRegistrationSameEnrollIDDifferentRole
+                enrollpw: 9gvZQRwhUq9q
+
+            userthread:
+                enrollid: userthread
                 enrollpw: 9gvZQRwhUq9q
 

--- a/openchain/crypto/validator.go
+++ b/openchain/crypto/validator.go
@@ -24,11 +24,16 @@ import (
 	"sync"
 )
 
-// Private Variables
+// Private type and variables
+
+type validatorEntry struct {
+	validator Peer
+	counter   int64
+}
 
 var (
 	// Map of initialized validators
-	validators = make(map[string]Peer)
+	validators = make(map[string]validatorEntry)
 
 	// Sync
 	mutex sync.Mutex
@@ -36,14 +41,14 @@ var (
 
 // Public Methods
 
-// RegisterValidator registers a client to the PKI infrastructure
+// RegisterValidator registers a validator to the PKI infrastructure
 func RegisterValidator(name string, pwd []byte, enrollID, enrollPWD string) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	log.Info("Registering validator [%s] with name [%s]...", enrollID, name)
 
-	if validators[name] != nil {
+	if _, ok := validators[name]; ok {
 		log.Info("Registering validator [%s] with name [%s]...done. Already initialized.", enrollID, name)
 
 		return nil
@@ -68,17 +73,19 @@ func RegisterValidator(name string, pwd []byte, enrollID, enrollPWD string) erro
 	return nil
 }
 
-// InitValidator initializes a client named name with password pwd
+// InitValidator initializes a validator named name with password pwd
 func InitValidator(name string, pwd []byte) (Peer, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	log.Info("Initializing validator [%s]...", name)
 
-	if validators[name] != nil {
-		log.Info("Validator already initiliazied [%s].", name)
+	if entry, ok := validators[name]; ok {
+		log.Info("Validator already initiliazied [%s]. Increasing counter from [%d]", name, validators[name].counter)
+		entry.counter++
+		validators[name] = entry
 
-		return validators[name], nil
+		return validators[name].validator, nil
 	}
 
 	validator := new(validatorImpl)
@@ -88,7 +95,7 @@ func InitValidator(name string, pwd []byte) (Peer, error) {
 		return nil, err
 	}
 
-	validators[name] = validator
+	validators[name] = validatorEntry{validator, 1}
 	log.Info("Initializing validator [%s]...done!", name)
 
 	return validator, nil
@@ -99,7 +106,7 @@ func CloseValidator(peer Peer) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	return closeValidatorInternal(peer)
+	return closeValidatorInternal(peer, false)
 }
 
 // CloseAllValidators closes all the validators initialized so far
@@ -111,7 +118,7 @@ func CloseAllValidators() (bool, []error) {
 
 	errs := make([]error, len(validators))
 	for _, value := range validators {
-		err := closeValidatorInternal(value)
+		err := closeValidatorInternal(value.validator, true)
 
 		errs = append(errs, err)
 	}
@@ -123,21 +130,28 @@ func CloseAllValidators() (bool, []error) {
 
 // Private Methods
 
-func closeValidatorInternal(peer Peer) error {
+func closeValidatorInternal(peer Peer, force bool) error {
 	if peer == nil {
 		return utils.ErrNilArgument
 	}
 
 	name := peer.GetName()
 	log.Info("Closing validator [%s]...", name)
-	if _, ok := validators[name]; !ok {
+	entry, ok := validators[name]
+	if !ok {
 		return utils.ErrInvalidReference
 	}
-	defer delete(validators, name)
+	if entry.counter == 1 || force {
+		defer delete(validators, name)
+		err := validators[name].validator.(*validatorImpl).close()
+		log.Info("Closing validator [%s]...done! [%s].", name, utils.ErrToString(err))
+		return err
+	} else {
+		// decrease counter
+		entry.counter--
+		validators[name] = entry
+		log.Info("Closing validator [%s]...decreased counter at [%d].", name, validators[name].counter)
+	}
 
-	err := validators[name].(*validatorImpl).close()
-
-	log.Info("Closing validator [%s]...done! [%s].", name, utils.ErrToString(err))
-
-	return err
+	return nil
 }


### PR DESCRIPTION
This is to address #650. 

The problem is the following: Concurrent calls to devops cause the concurrent initialization and closing of crypto client objects. The crypto layer, to save in resources, use a sort of pool manager which didn't count the number of reference per client object. The result is that in a concurrent env a shared object can be closed by a thread while still used by another thread. The fix consisted in counting the number of opened sessions on a single client object and releasing the resources only when no one is using that object anymore.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
