### PR TITLE
Fix behave consensus tests, closes #646

### DIFF
--- a/openchain/consensus/obcpbft/pbft-core.go
+++ b/openchain/consensus/obcpbft/pbft-core.go
@@ -651,6 +651,10 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 		instance.outstandingReqs[digest] = preprep.Request
 	}
 
+	if !instance.timerActive {
+		instance.startTimer(instance.requestTimeout)
+	}
+
 	if instance.primary(instance.view) != instance.id && instance.prePrepared(preprep.RequestDigest, preprep.View, preprep.SequenceNumber) && !cert.sentPrepare {
 		logger.Debug("Backup %d broadcasting prepare for view=%d/seqNo=%d",
 			instance.id, preprep.View, preprep.SequenceNumber)

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -2,10 +2,10 @@
 # Test openchain Peers
 #
 # Tags that can be used and will affect test internals:
-#   
+#
 #  @doNotDecompose will NOT decompose the named compose_yaml after scenario ends.  Useful for setting up environment and reviewing after scenario.
 #
-#  @chaincodeImagesUpToDate use this if all scenarios chaincode images are up to date, and do NOT require building.  BE SURE!!! 
+#  @chaincodeImagesUpToDate use this if all scenarios chaincode images are up to date, and do NOT require building.  BE SURE!!!
 
 #@chaincodeImagesUpToDate
 Feature: lanching 3 peers
@@ -14,7 +14,7 @@ Feature: lanching 3 peers
 
 #    @doNotDecompose
 #    @wip
-	Scenario: chaincode example 02 single peer 
+	Scenario: chaincode example 02 single peer
 	    Given we compose "docker-compose-1.yml"
 	    And I wait "1" seconds
 	    When requesting "/chain" from "vp0"
@@ -22,9 +22,9 @@ Feature: lanching 3 peers
 	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
-	    Then I should have received a chaincode name 
+	    Then I should have received a chaincode name
 	    Then I wait up to "25" seconds for transaction to be committed to all peers
-	    
+
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "2"
 
@@ -35,19 +35,19 @@ Feature: lanching 3 peers
 
 
         When I invoke chaincode "example2" function name "invoke" on "vp0"
-			|arg1|arg2|arg3| 
+			|arg1|arg2|arg3|
 			| a  | b  | 10 |
 	    Then I should have received a transactionID
 	    Then I wait up to "25" seconds for transaction to be committed to all peers
 
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "3"
-        
+
         When I query chaincode "example2" function name "query" on "vp0":
             |arg1|
             |  a |
 	    Then I should get a JSON response with "OK" = "90"
-        
+
         When I query chaincode "example2" function name "query" on "vp0":
             |arg1|
             |  b |
@@ -55,16 +55,16 @@ Feature: lanching 3 peers
 
 #    @doNotDecompose
 #    @wip
-	Scenario: chaincode example02 with 5 peers, issue #520 
+	Scenario: chaincode example02 with 5 peers, issue #520
 	    Given we compose "docker-compose-5.yml"
 	    And I wait "1" seconds
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
-	    
+
 	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
-	    Then I should have received a chaincode name 
+	    Then I should have received a chaincode name
 	    Then I wait up to "25" seconds for transaction to be committed to all peers
 
         When I query chaincode "example2" function name "query" on all peers:
@@ -73,25 +73,25 @@ Feature: lanching 3 peers
 	    Then I should get a JSON response from all peers with "OK" = "100"
 
         When I invoke chaincode "example2" function name "invoke" on "vp0"
-			|arg1|arg2|arg3| 
+			|arg1|arg2|arg3|
 			| a  | b  | 20 |
 	    Then I should have received a transactionID
 	    Then I wait up to "20" seconds for transaction to be committed to all peers
- 
+
         When I query chaincode "example2" function name "query" on all peers:
             |arg1|
             |  a |
 	    Then I should get a JSON response from all peers with "OK" = "80"
 
 
-#    @doNotDecompose
-#    @wip
-	Scenario Outline: chaincode example02 with 4 peers and 1 obcca, issue #567 
+    @doNotDecompose
+    @wip
+	Scenario Outline: chaincode example02 with 4 peers and 1 obcca, issue #567
 
 	    Given we compose "<ComposeFile>"
 	    And I wait "2" seconds
 	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
-             | vp0  | 
+             | vp0  |
         And I use the following credentials for querying peers:
 		     | peer |   username  |    secret    |
 		     | vp0  |  test_user0 | MS9qrN8hFjlE |
@@ -101,37 +101,37 @@ Feature: lanching 3 peers
 
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
-	    
+
 	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
-	    Then I should have received a chaincode name 
+	    Then I should have received a chaincode name
 	    Then I wait up to "<WaitTime>" seconds for transaction to be committed to peers:
-            | vp0  | vp1 | vp2 | vp3 | 
+            | vp0  | vp1 | vp2 | vp3 |
 
         When I query chaincode "example2" function name "query" with value "a" on peers:
-            | vp0  | vp1 | vp2 | vp3 | 
+            | vp0  | vp1 | vp2 | vp3 |
 	    Then I should get a JSON response from peers with "OK" = "100"
-            | vp0  | vp1 | vp2 | vp3 | 
+            | vp0  | vp1 | vp2 | vp3 |
 
         When I invoke chaincode "example2" function name "invoke" on "vp0"
-			|arg1|arg2|arg3| 
+			|arg1|arg2|arg3|
 			| a  | b  | 20 |
 	    Then I should have received a transactionID
 	    Then I wait up to "10" seconds for transaction to be committed to peers:
-            | vp0  | vp1 | vp2 | vp3 | 
- 
+            | vp0  | vp1 | vp2 | vp3 |
+
         When I query chaincode "example2" function name "query" with value "a" on peers:
-            | vp0  | vp1 | vp2 | vp3 | 
+            | vp0  | vp1 | vp2 | vp3 |
 	    Then I should get a JSON response from peers with "OK" = "80"
-            | vp0  | vp1 | vp2 | vp3 | 
-    
+            | vp0  | vp1 | vp2 | vp3 |
+
     Examples: Consensus Options
         |          ComposeFile                     |   WaitTime   |
-        |   docker-compose-4-consensus-noops.yml   |      60      |
-        |   docker-compose-4-consensus-classic.yml |      30      |
-        |   docker-compose-4-consensus-batch.yml   |      30      |
-        |   docker-compose-4-consensus-sieve.yml   |      10      |
+#        |   docker-compose-4-consensus-noops.yml   |      60      |
+#        |   docker-compose-4-consensus-classic.yml |      20      |
+#        |   docker-compose-4-consensus-batch.yml   |      20      |
+        |   docker-compose-4-consensus-sieve.yml   |      30      |
 
 
 #   @doNotDecompose
@@ -147,5 +147,3 @@ Feature: lanching 3 peers
 	    Given we compose "docker-compose-2-tls-basic.yml"
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
-
-

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -84,8 +84,8 @@ Feature: lanching 3 peers
 	    Then I should get a JSON response from all peers with "OK" = "80"
 
 
-    @doNotDecompose
-    @wip
+#    @doNotDecompose
+#    @wip
 	Scenario Outline: chaincode example02 with 4 peers and 1 obcca, issue #567
 
 	    Given we compose "<ComposeFile>"

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -101,7 +101,7 @@ Feature: lanching 3 peers
 
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
-
+        And I wait "2" seconds
 	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
@@ -128,9 +128,9 @@ Feature: lanching 3 peers
 
     Examples: Consensus Options
         |          ComposeFile                     |   WaitTime   |
-#        |   docker-compose-4-consensus-noops.yml   |      60      |
-#        |   docker-compose-4-consensus-classic.yml |      20      |
-#        |   docker-compose-4-consensus-batch.yml   |      20      |
+        |   docker-compose-4-consensus-noops.yml   |      60      |
+        |   docker-compose-4-consensus-classic.yml |      20      |
+        |   docker-compose-4-consensus-batch.yml   |      20      |
         |   docker-compose-4-consensus-sieve.yml   |      30      |
 
 


### PR DESCRIPTION
Changes:
- Starts timer in `recvPrepare` if not already active so as to cause a view-change if necessary
- Adds 2-sec delay before deploying chaincode in `behave` tests so as to allow the VP network to become fully connected (cc @jeffgarratt to check the code in `peer_basic.feature` for correctness)

For context please read @corecode's and my comments here:
- https://github.com/openblockchain/obc-peer/issues/646#issuecomment-183515391
- https://github.com/openblockchain/obc-peer/issues/646#issuecomment-183710871

Signed-off-by: Kostas Christidis `<kchristidis@us.ibm.com>`
