### PR TITLE
Fix off by 1 error which could cause panic in state transfer, closes #676

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -126,7 +126,7 @@ peer:
             # blocks from oppositie Peer Endpoints.
             # NOTE: currently messages are not stored and forwarded, but rather
             # lost if the channel write blocks.
-            channelSize: 1
+            channelSize: 10
         state:
             snapshot:
                 # Channel size for readonly syncStateSnapshot messages channel
@@ -140,7 +140,7 @@ peer:
                 # Peer Endpoints.
                 # NOTE: currently messages are not stored and forwarded,
                 # but rather lost if the channel write blocks.
-                channelSize: 5
+                channelSize: 20
 
     # Validator defines whether this peer is a validating peer or not, and if
     # it is enabled, what consensus plugin to load

--- a/openchain/peer/handler.go
+++ b/openchain/peer/handler.go
@@ -34,7 +34,7 @@ import (
 
 // Handler peer handler implementation.
 type Handler struct {
-	chatMutex	               sync.Mutex
+	chatMutex                     sync.Mutex
 	ToPeerEndpoint                *pb.PeerEndpoint
 	Coordinator                   MessageHandlerCoordinator
 	ChatStream                    ChatStream
@@ -407,7 +407,8 @@ func (d *Handler) beforeSyncBlocks(e *fsm.Event) {
 		e.Cancel(fmt.Errorf("Error unmarshalling SyncBlocks in beforeSyncBlocks: %s", err))
 		return
 	}
-	peerLogger.Debug("TODO: send received syncBlocks for start = %d and end = %d message to channel", syncBlocks.Range.Start, syncBlocks.Range.End)
+
+	peerLogger.Debug("Sending block onto channel for start = %d and end = %d", syncBlocks.Range.Start, syncBlocks.Range.End)
 
 	// Send the message onto the channel, allow for the fact that channel may be closed on send attempt.
 	defer func() {
@@ -703,7 +704,7 @@ func (d *Handler) beforeSyncStateDeltas(e *fsm.Event) {
 		e.Cancel(fmt.Errorf("Error unmarshalling SyncStateDeltas in beforeSyncStateDeltas: %s", err))
 		return
 	}
-	peerLogger.Debug("TODO: send received syncBlocks for start = %d and end = %d message to channel", syncStateDeltas.Range.Start, syncStateDeltas.Range.End)
+	peerLogger.Debug("Received syncStateDeltas for start = %d and end = %d", syncStateDeltas.Range.Start, syncStateDeltas.Range.End)
 
 	// Send the message onto the channel, allow for the fact that channel may be closed on send attempt.
 	defer func() {

--- a/openchain/peer/handler.go
+++ b/openchain/peer/handler.go
@@ -704,7 +704,7 @@ func (d *Handler) beforeSyncStateDeltas(e *fsm.Event) {
 		e.Cancel(fmt.Errorf("Error unmarshalling SyncStateDeltas in beforeSyncStateDeltas: %s", err))
 		return
 	}
-	peerLogger.Debug("Received syncStateDeltas for start = %d and end = %d", syncStateDeltas.Range.Start, syncStateDeltas.Range.End)
+	peerLogger.Debug("Sending state delta onto channel for start = %d and end = %d", syncStateDeltas.Range.Start, syncStateDeltas.Range.End)
 
 	// Send the message onto the channel, allow for the fact that channel may be closed on send attempt.
 	defer func() {


### PR DESCRIPTION
Fixes an off by one error.  The state transfer code checked if the target block number was less than the block height, to determine if this update would require deleting a block, and subsequently panic-ed if so.  This check is incorrect, as the block height is not the highest block number, it is the highest block number + 1.

Added test which generated that panic scenario, which now passes after the fix.

Increases the default channel size for blocks and state deltas from 1 and 5 to 20 and 40 respectively.  This is necessary especially for the behave tests, as the extremely low latency network and constrained CPU of a docker-ized environment can cause blocks and deltas to be discarded.

The combination of these two changes closes #676 

Passes all go tests.

Passes all behave tests, with the exception of

```
Failing scenarios:
  peer_basic.feature:133  chaincode example02 with 4 peers and 1 obcca, issue #567 -- @1.3 Consensus Options
  peer_basic.feature:134  chaincode example02 with 4 peers and 1 obcca, issue #567 -- @1.4 Consensus Options

0 features passed, 1 failed, 0 skipped
6 scenarios passed, 2 failed, 0 skipped
88 steps passed, 2 failed, 14 skipped, 0 undefined
Took 2m7.120s
```

Which are known to be failing due to issue #646 and should be addressed with PR #677 

Signed-off-by: Jason Yellick jyellick@us.ibm.com
