### PR TITLE
Fix for issue #680

### DIFF
--- a/openchain/consensus/statetransfer/statetransfer.go
+++ b/openchain/consensus/statetransfer/statetransfer.go
@@ -797,7 +797,7 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 	sts.stateValid = true
 
 	if *currentStateBlockNumber < (*blockHReply).blockNumber {
-		*currentStateBlockNumber, err = sts.playStateUpToCheckpoint(*currentStateBlockNumber+uint64(1), (*blockHReply).blockNumber, (*blockHReply).peerIDs)
+		*currentStateBlockNumber, err = sts.playStateUpToBlockNumber(*currentStateBlockNumber+uint64(1), (*blockHReply).blockNumber, (*blockHReply).peerIDs)
 		if nil != err {
 			// This is unlikely, in the future, we may wish to play transactions forward rather than retry
 			sts.stateValid = false
@@ -872,7 +872,7 @@ func (sts *StateTransferState) informListeners(blockNumber uint64, blockHash []b
 	}
 }
 
-func (sts *StateTransferState) playStateUpToCheckpoint(fromBlockNumber, toBlockNumber uint64, peerIDs []*protos.PeerID) (uint64, error) {
+func (sts *StateTransferState) playStateUpToBlockNumber(fromBlockNumber, toBlockNumber uint64, peerIDs []*protos.PeerID) (uint64, error) {
 	logger.Debug("%v attempting to play state forward from %v to block %d", sts.id, peerIDs, toBlockNumber)
 	currentBlock := fromBlockNumber
 	err := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
@@ -886,10 +886,7 @@ func (sts *StateTransferState) playStateUpToCheckpoint(fromBlockNumber, toBlockN
 			select {
 			case deltaMessage, ok := <-deltaMessages:
 				if !ok {
-					if currentBlock == toBlockNumber+1 {
-						return nil
-					}
-					return fmt.Errorf("%v was only able to recover to block number %d when desired to recover to %d", sts.id, currentBlock, toBlockNumber)
+					return fmt.Errorf("%v was only able to recover to block number %d when desired to recover to %d", sts.id, currentBlock-1, toBlockNumber)
 				}
 
 				if deltaMessage.Range.Start != currentBlock || deltaMessage.Range.End < deltaMessage.Range.Start || deltaMessage.Range.End > toBlockNumber {
@@ -932,20 +929,23 @@ func (sts *StateTransferState) playStateUpToCheckpoint(fromBlockNumber, toBlockN
 						return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, rolled back", sts.id, peerID)
 					}
 
-				} else {
-					currentBlock++
-					if nil != sts.ledger.CommitStateDelta(deltaMessage) {
-						sts.InvalidateState()
-						return fmt.Errorf("%v played state forward according to %v, hashes matched, but failed to commit, invalidated state", sts.id, peerID)
-					}
 				}
+
+				if currentBlock == toBlockNumber {
+					return nil
+				}
+
+				currentBlock++
+				if nil != sts.ledger.CommitStateDelta(deltaMessage) {
+					sts.InvalidateState()
+					return fmt.Errorf("%v played state forward according to %v, hashes matched, but failed to commit, invalidated state", sts.id, peerID)
+				}
+
 			case <-time.After(sts.StateDeltaRequestTimeout):
 				logger.Warning("%v timed out during state delta recovery from %v", sts.id, peerID)
 				return fmt.Errorf("%v timed out during state delta recovery from %v", sts.id, peerID)
 			}
 		}
-
-		return nil
 
 	})
 	return currentBlock, err
@@ -976,6 +976,10 @@ func (sts *StateTransferState) syncStateSnapshot(minBlockNumber uint64, peerIDs 
 			select {
 			case piece, ok := <-stateChan:
 				if !ok {
+					return fmt.Errorf("%v had state snapshot channel close prematurely: %s", sts.id, err)
+				}
+				if 0 == len(piece.Delta) {
+					logger.Debug("%v received final piece of state snapshot from %v", sts.id, peerID)
 					return nil
 				}
 				umDelta := &statemgmt.StateDelta{}

--- a/openchain/consensus/statetransfer/statetransfer.go
+++ b/openchain/consensus/statetransfer/statetransfer.go
@@ -931,15 +931,15 @@ func (sts *StateTransferState) playStateUpToBlockNumber(fromBlockNumber, toBlock
 
 				}
 
-				if currentBlock == toBlockNumber {
-					return nil
-				}
-
-				currentBlock++
 				if nil != sts.ledger.CommitStateDelta(deltaMessage) {
 					sts.InvalidateState()
 					return fmt.Errorf("%v played state forward according to %v, hashes matched, but failed to commit, invalidated state", sts.id, peerID)
 				}
+
+				if currentBlock == toBlockNumber {
+					return nil
+				}
+				currentBlock++
 
 			case <-time.After(sts.StateDeltaRequestTimeout):
 				logger.Warning("%v timed out during state delta recovery from %v", sts.id, peerID)

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -134,123 +134,127 @@ Feature: lanching 3 peers
         |   docker-compose-4-consensus-sieve.yml   |      30      |
 
 
-#    @doNotDecompose
-#    @wip
-#    @skip
-#	Scenario Outline: chaincode example02 with 4 peers and 1 obcca, issue #680 (State transfer)  
-#
-#	    Given we compose "<ComposeFile>"
-#	    And I wait "3" seconds
-#	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
-#             | vp0  | 
-#        And I use the following credentials for querying peers:
-#		     | peer |   username  |    secret    |
-#		     | vp0  |  test_user0 | MS9qrN8hFjlE |
-#		     | vp1  |  test_user1 | jGlNl6ImkuDo |
-#		     | vp2  |  test_user2 | zMflqOKezFiA |
-#		     | vp3  |  test_user3 | vWdLCE00vJy0 |
-#
-#	    When requesting "/chain" from "vp0"
-#	    Then I should get a JSON response with "height" = "1"
-#
-#		# STOPPING vp3!!!!!!!!!!!!!!!!!!!!!!!!!!	    
-#        Given I stop peers:
-#            | vp3  | 
-#
-#	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
-#		     | arg1 |  arg2 | arg3 | arg4 |
-#		     |  a   |  100  |  b   |  200 |
-#	    Then I should have received a chaincode name 
-#	    Then I wait up to "<WaitTime>" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        When I query chaincode "example2" function name "query" with value "a" on peers:
-#            | vp0  | vp1 | vp2 | 
-#	    Then I should get a JSON response from peers with "OK" = "100"
-#            | vp0  | vp1 | vp2 | 
-#
-#        #
-#        # Now start vp3 again and run 4 transactions
-#        #
-#        Given I start peers:
-#            | vp3  | 
-#        
-#        # TX 1
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 2
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 3
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 4
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 1
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 2
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 3
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-#        # TX 4
-#        When I invoke chaincode "example2" function name "invoke" on "vp0"
-#			|arg1|arg2|arg3| 
-#			| a  | b  | 10 |
-#	    Then I should have received a transactionID
-#	    Then I wait up to "10" seconds for transaction to be committed to peers:
-#            | vp0  | vp1 | vp2 | 
-#
-# 
-#	    Given I wait "10" seconds
-#        When I query chaincode "example2" function name "query" with value "a" on peers:
-#            | vp0  | vp1 | vp2 | vp3 | 
-#	    Then I should get a JSON response from peers with "OK" = "20"
-#            | vp0  | vp1 | vp2 | vp3 | 
-#    
-#
-#    Examples: Consensus Options
-#        |          ComposeFile                     |   WaitTime   |
-#        |   docker-compose-4-consensus-classic.yml   |      10      |
-#        |   docker-compose-4-consensus-sieve.yml   |      10      |
+    #@doNotDecompose
+    #@wip
+    #@skip
+	Scenario Outline: chaincode example02 with 4 peers and 1 obcca, issue #680 (State transfer)  
+
+	    Given we compose "<ComposeFile>"
+	    And I wait "3" seconds
+	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
+             | vp0  | 
+        And I use the following credentials for querying peers:
+		     | peer |   username  |    secret    |
+		     | vp0  |  test_user0 | MS9qrN8hFjlE |
+		     | vp1  |  test_user1 | jGlNl6ImkuDo |
+		     | vp2  |  test_user2 | zMflqOKezFiA |
+		     | vp3  |  test_user3 | vWdLCE00vJy0 |
+
+	    When requesting "/chain" from "vp0"
+	    Then I should get a JSON response with "height" = "1"
+
+        # STOPPING vp3!!!!!!!!!!!!!!!!!!!!!!!!!!	    
+        Given I stop peers:
+            | vp3  | 
+
+            # TX 1, deploy
+	    When I deploy chaincode "github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02" with ctor "init" to "vp0"
+		     | arg1 |  arg2 | arg3 | arg4 |
+		     |  a   |  100  |  b   |  200 |
+	    Then I should have received a chaincode name 
+	    Then I wait up to "<WaitTime>" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        #
+        # Now start vp3 again and run 8 more transactions
+        #
+        Given I start peers:
+            | vp3  | 
+        And I wait "2" seconds
+        
+
+        When I query chaincode "example2" function name "query" with value "a" on peers:
+            | vp0  | vp1 | vp2 | 
+	    Then I should get a JSON response from peers with "OK" = "100"
+            | vp0  | vp1 | vp2 | 
+
+        # TX 2 - Checkpoint
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 3
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 4 - Checkpoint
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 5
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 6 - Checkpoint - state transfer triggered
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 7
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 8 - Checkpoint - state transfer given completion target
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+        # TX 9 - Will be invoked by vp3 once state transfer finishes
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3| 
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "10" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 | 
+
+ 
+        Given I wait "5" seconds
+        When I query chaincode "example2" function name "query" with value "a" on peers:
+            | vp0  | vp1 | vp2 | vp3 | 
+	    Then I should get a JSON response from peers with "OK" = "20"
+            | vp0  | vp1 | vp2 | vp3 | 
+    
+
+    Examples: Consensus Options
+        |          ComposeFile                     |   WaitTime   |
+        |   docker-compose-4-consensus-classic.yml   |      10      |
+        |   docker-compose-4-consensus-batch.yml   |      10      |
+        |   docker-compose-4-consensus-sieve.yml   |      10      |
 
 
 #   @doNotDecompose


### PR DESCRIPTION
The state transfer implementation made some incorrect assumptions about the underlying API which allowed this bug to leak through mock testing.  This should fix issue #680.

This PR modifies state transfer to never assume a channel will close, and instead checks for snapshot end by looking for an empty `[]byte` delta, and for state deltas and blocks by looking for the final block number to be transferred.

The backing mock implementation is also updated accordingly.

This also enables a behave test largely crafted by @jeffgarratt with a few minor tweaks to make it pass consistently.  This test is enabled for classic, batch, and sieve pbft.

All go tests pass.

All behave tests pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
