### PR TITLE
Move to Go 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-from golang:1.5.1
-ENV GO15VENDOREXPERIMENT=1
+from golang:1.6
 # Install RocksDB
 RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
 ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you modify any .proto files, run the following command to generate new .pb.go
 ```
 
 ## Adding or updating a Go packages
-Openchain uses the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/edit) for package management. This means that all required packages reside in the /vendor folder within the obc-peer project. This is enabled because the GO15VENDOREXPERIMENT environment variable is set to 1 in the Vagrant environment. Go will use packages in this folder instead of the GOPATH when `go install` or `go build` is run. To manage the packages in the /vendor folder, we use [Govendor](https://github.com/kardianos/govendor). This is installed in the Vagrant environment. The following commands can be used for package management.
+Openchain uses Go 1.6 vendoring for package management. This means that all required packages reside in the /vendor folder within the obc-peer project. Go will use packages in this folder instead of the GOPATH when `go install` or `go build` is run. To manage the packages in the /vendor folder, we use [Govendor](https://github.com/kardianos/govendor). This is installed in the Vagrant environment. The following commands can be used for package management.
 ```
 # Add external packages.
 govendor add +external
@@ -141,8 +141,7 @@ govendor list
 This is not recommended, however some users may wish to build Openchain outside of Vagrant if they use an editor with built in Go tooling. The instructions are
 
 1. Follow all steps required to setup and run a Vagrant image
-- Make you you have [Go 1.5.1](https://golang.org/) or later installed
-- Set the GO15VENDOREXPERIMENT environmental variable to 1. `export GO15VENDOREXPERIMENT=1`
+- Make you you have [Go 1.6](https://golang.org/) or later installed
 - Set the maximum number of open files to 10000 or greater for your OS
 - Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1
 - Run the following commands replacing `/opt/rocksdb` with the path where you installed RocksDB:

--- a/obc-ca/Dockerfile
+++ b/obc-ca/Dockerfile
@@ -1,5 +1,4 @@
-from golang:1.5.1
-ENV GO15VENDOREXPERIMENT=1
+from golang:1.6
 # Install RocksDB
 RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
 ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH

--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -4,7 +4,7 @@ server:
         rootpath: "."
         cadir: ".obcca"
         port: ":50951"
-        
+
         tls:
                 certfile: ".obcca/tlsca.cert"
                 keyfile: ".obcca/tlsca.priv"
@@ -57,8 +57,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.5.1
-        ENV GO15VENDOREXPERIMENT=1
+        from golang:1.6
         # Install RocksDB
         RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
         WORKDIR /opt/rocksdb
@@ -126,7 +125,7 @@ peer:
             # if 0, if buffer full, will block and guarantee the event will be sent out
             # if > 0, if buffer full, blocks till timeout
             timeout: 10
-        validity-period: 
+        validity-period:
             verification: false
 
     # TLS Settings for p2p communications
@@ -246,8 +245,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.5.1
-            ENV GO15VENDOREXPERIMENT=1
+            from golang:1.6
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -261,7 +259,7 @@ chaincode:
     mode: net
 
     installpath: /go/bin/
-    
+
 ###############################################################################
 #
 #    Ledger section - ledger configuration encompases both the blockchain
@@ -343,7 +341,7 @@ pki:
                     enabled: false
                     cert:
                             file: testdata/server1.pem
-                    key:    
+                    key:
                             file: testdata/server1.key
 
-            devops-address: 0.0.0.0:30303 
+            devops-address: 0.0.0.0:30303

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -91,8 +91,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.5.1
-        ENV GO15VENDOREXPERIMENT=1
+        from golang:1.6
         # Install RocksDB
         RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
         WORKDIR /opt/rocksdb
@@ -285,8 +284,7 @@ chaincode:
         # This is the basis for the Golang Dockerfile.  Additional commands will
         # be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.5.1
-            ENV GO15VENDOREXPERIMENT=1
+            from golang:1.6
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 

--- a/openchain/ledger/genesis/genesis_test.yaml
+++ b/openchain/ledger/genesis/genesis_test.yaml
@@ -46,8 +46,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.5.1
-        ENV GO15VENDOREXPERIMENT=1
+        from golang:1.6
         # Install RocksDB
         RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
         WORKDIR /opt/rocksdb
@@ -196,8 +195,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.5.1
-            ENV GO15VENDOREXPERIMENT=1
+            from golang:1.6
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 


### PR DESCRIPTION
This PR moves the peer to Go 1.6. For issue https://github.com/openblockchain/obc-dev-env/issues/37
