### PR TITLE
Fixes related to issue 699

### DIFF
--- a/openchain/ledger/ledger.go
+++ b/openchain/ledger/ledger.go
@@ -221,12 +221,16 @@ func (ledger *Ledger) DeleteState(chaincodeID string, key string) error {
 // stateSnapshot.Release() once you are done with the snapsnot to free up resources.
 func (ledger *Ledger) GetStateSnapshot() (*state.StateSnapshot, error) {
 	dbSnapshot := db.GetDBHandle().GetSnapshot()
-	blockNumber, err := fetchBlockchainSizeFromSnapshot(dbSnapshot)
+	blockHeight, err := fetchBlockchainSizeFromSnapshot(dbSnapshot)
 	if err != nil {
 		dbSnapshot.Release()
 		return nil, err
 	}
-	return ledger.state.GetSnapshot(blockNumber, dbSnapshot)
+	if 0 == blockHeight {
+		dbSnapshot.Release()
+		return nil, fmt.Errorf("Blockchain has no blocks, cannot determine block number")
+	}
+	return ledger.state.GetSnapshot(blockHeight-1, dbSnapshot)
 }
 
 // GetStateDelta will return the state delta for the specified block if

--- a/openchain/ledger/ledger_test.go
+++ b/openchain/ledger/ledger_test.go
@@ -180,8 +180,8 @@ func TestLedgerStateSnapshot(t *testing.T) {
 		t.Fatalf("Expected 3 keys, but got %d", count)
 	}
 
-	if snapshot.GetBlockNumber() != 1 {
-		t.Fatalf("Expected blocknumber to be 1, but got %d", snapshot.GetBlockNumber())
+	if snapshot.GetBlockNumber() != 0 {
+		t.Fatalf("Expected blocknumber to be 0, but got %d", snapshot.GetBlockNumber())
 	}
 
 }

--- a/openchain/peer/handler.go
+++ b/openchain/peer/handler.go
@@ -564,11 +564,11 @@ func (d *Handler) sendStateSnapshot(syncStateSnapshotRequest *pb.SyncStateSnapsh
 	defer snapshot.Release()
 
 	// Iterate over the state deltas and send to requestor
-	delta := statemgmt.NewStateDelta()
 	currBlockNumber := snapshot.GetBlockNumber()
 	var sequence uint64
 	// Loop through and send the Deltas
 	for i := 0; snapshot.Next(); i++ {
+		delta := statemgmt.NewStateDelta()
 		k, v := snapshot.GetRawKeyValue()
 		cID, kID := statemgmt.DecodeCompositeKey(k)
 		delta.Set(cID, kID, v, nil)


### PR DESCRIPTION
This pull request is intended primarily to address the `SyncStateSnapshot` failures exhibited in issue #699.

The `StateSnapshot` was reporting the block height, rather than the block number as advertised, causing the state to always fail verification.  Fixing this allows the snapshot sync to succeed.

Additionally state transfer had a bug which would cause block validation to loop continuously, even after completion, because a value rather than its corresponding pointer was being overridden. 

Additionally, the state sync snapshot mechanism was operating as follows:

```
Delta 1: key1->value1
Delta 2: key1->value1, key2->value2
Delta 3: key1->value1, key2->value2, key3->value3
```

it has been fixed to operate as

```
Delta 1: key1->value1
Delta 2: key2->value2
Delta 3: key3->value3
```

All go tests pass.

All behave tests pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
Finally, there is some assorted logging improvements.
