### PR TITLE
peer modifications to support new packer-based dev-env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-from golang:1.6
-# Install RocksDB
-RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
-ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+from openblockchain/baseimage:latest
+
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/openchain/db
 RUN mkdir -p /var/openchain/production
 WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
-RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 RUN cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain/consensus/obcpbft/config.yaml $GOPATH/bin
-# RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 # RUN cd obc-ca && go install

--- a/README.md
+++ b/README.md
@@ -143,11 +143,16 @@ This is not recommended, however some users may wish to build Openchain outside 
 1. Follow all steps required to setup and run a Vagrant image
 - Make you you have [Go 1.6](https://golang.org/) or later installed
 - Set the maximum number of open files to 10000 or greater for your OS
-- Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1
-- Run the following commands replacing `/opt/rocksdb` with the path where you installed RocksDB:
+- Install [RocksDB](http://rocksdb.org) version 4.1 and its deps using the OBC PPA and upstream respositories
+```
+sudo add-apt-repository ppa:openblockchain/third-party
+sudo apt-get update
+sudo apt-get install librocksdb4.1 libsnappy-dev zlib1g-dev libbz2-dev
+```
+- Run the following commands to build the obc-peer
 ```
 cd $GOPATH/src/github.com/openblockchain/obc-peer
-CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 ```
 - Make sure that the Docker daemon initialization includes the options
 ```

--- a/obc-ca/Dockerfile
+++ b/obc-ca/Dockerfile
@@ -1,13 +1,9 @@
-from golang:1.6
-# Install RocksDB
-RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
-ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+from openblockchain/baseimage:latest
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/openchain/db
 WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
 WORKDIR obc-ca
 RUN pwd
-RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
-# RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
+# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install

--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -57,18 +57,12 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+        from openblockchain/baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303
@@ -245,7 +239,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -258,7 +252,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -92,18 +92,13 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+        from openblockchain/baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303
@@ -285,7 +280,7 @@ chaincode:
         # This is the basis for the Golang Dockerfile.  Additional commands will
         # be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -303,7 +298,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #

--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -50,7 +50,7 @@ const (
 	// DevModeUserRunsChaincode property allows user to run chaincode in development environment
 	DevModeUserRunsChaincode       string = "dev"
 	chaincodeStartupTimeoutDefault int    = 5000
-	chaincodeInstallPathDefault    string = "/go/bin/"
+	chaincodeInstallPathDefault    string = "/opt/gopath/bin/"
 	peerAddressDefault             string = "0.0.0.0:30303"
 )
 

--- a/openchain/container/controller.go
+++ b/openchain/container/controller.go
@@ -67,7 +67,6 @@ func (vm *dockerVM) build(ctxt context.Context, id string, args []string, env []
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         id,
-		Pull:         true,
 		InputStream:  reader,
 		OutputStream: outputbuf,
 	}

--- a/openchain/container/vm.go
+++ b/openchain/container/vm.go
@@ -144,7 +144,6 @@ func (vm *VM) buildChaincodeContainerUsingDockerfilePackageBytes(spec *pb.Chainc
 	inputbuf := bytes.NewReader(code)
 	opts := docker.BuildImageOptions{
 		Name:         vmName,
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}
@@ -166,7 +165,6 @@ func (vm *VM) BuildPeerContainer() error {
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         "openchain-peer",
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}
@@ -187,7 +185,6 @@ func (vm *VM) BuildObccaContainer() error {
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         "obcca",
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}

--- a/openchain/ledger/genesis/genesis_test.yaml
+++ b/openchain/ledger/genesis/genesis_test.yaml
@@ -46,21 +46,12 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y \
-            libsnappy-dev      \
-            zlib1g-dev         \
-            libbz2-dev
+        from openblockchain/baseimage
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will bind to for providing services
     address: 0.0.0.0:30303
@@ -195,7 +186,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -208,7 +199,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #


### PR DESCRIPTION
This patch addresses #741 and works in conjunction with https://github.com/openblockchain/obc-dev-env/pull/48 to unify the development and runtime environments behind a singular definition based on ubuntu:trusty.  There are two primary benefits to this patch to consider:

1) We now are using prebuilt and/or pre-installed binaries for everything such that it is now inexpensive to create a new environment (e.g. vagrant up + BuildImage_Peer).  In my testing, building a new docker image takes about 1 minute, down from over 15 previously.

2) We have a system in place (via packer) where one definition is used to build both our development environment and the docker environments, which should encourage a more stable environment going forward.

I have tested this patch in conjunction with https://github.com/openblockchain/obc-dev-env/pull/48 and it passes all unit tests.  I also ran behave, and everything passed with one exception:

```
Failing scenarios:
  peer_basic.feature:218  chaincode example02 with 4 peers and 1 obcca, issue #680 (State transfer) -- @1.3 Consensus Options

0 features passed, 1 failed, 0 skipped
16 scenarios passed, 1 failed, 1 skipped
310 steps passed, 1 failed, 19 skipped, 0 undefined
```

It is my understanding that this failure is an outstanding issue not related to this patch.

Signed-off-by: Gregory Haskins gregory.haskins@gmail.com
