### PR TITLE
clarify default consensus=noops in yaml file

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -148,6 +148,7 @@ peer:
         enabled: true
 
         # Consensus plugin to use. The value is the name of the plugin, e.g. obcpbft, noops
+        # if the given value is not recognized, we will default to noops
         consensus: noops
 
         events:

--- a/openchain/consensus/noops/noops.go
+++ b/openchain/consensus/noops/noops.go
@@ -79,6 +79,7 @@ func newNoops(c consensus.Stack) consensus.Consenter {
 		panic(fmt.Errorf("Cannot parse block timeout: %s", err))
 	}
 
+	logger.Info("NOOPS consensus type = %T", i)
 	logger.Info("NOOPS block size = %v", blockSize)
 	logger.Info("NOOPS block timeout = %v", i.duration)
 


### PR DESCRIPTION
Update validator.consensus description to indicate default .

Log consensus type in when creating noops plugin

All unit tests run.

One behave test fails due to #739
