### PR TITLE
Support partial key queries in Go shim. Issue #477

### DIFF
--- a/openchain/behave_chaincode/go/table/table.go
+++ b/openchain/behave_chaincode/go/table/table.go
@@ -18,6 +18,7 @@ under the License.
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -238,6 +239,54 @@ func (t *SimpleChaincode) Query(stub *shim.ChaincodeStub, function string, args 
 
 		rowString := fmt.Sprintf("%s", row)
 		return []byte(rowString), nil
+
+	case "getRowsTableTwo":
+		if len(args) < 1 {
+			return nil, errors.New("getRowsTableTwo failed. Must include at least key values")
+		}
+
+		var columns []shim.Column
+
+		col1Val := args[0]
+		col1 := shim.Column{Value: &shim.Column_String_{String_: col1Val}}
+		columns = append(columns, col1)
+
+		if len(args) > 1 {
+			col2Int, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil {
+				return nil, errors.New("getRowsTableTwo failed. arg[1] must be convertable to int32")
+			}
+			col2Val := int32(col2Int)
+			col2 := shim.Column{Value: &shim.Column_Int32{Int32: col2Val}}
+			columns = append(columns, col2)
+		}
+
+		rowChannel, err := stub.GetRows("tableTwo", columns)
+		if err != nil {
+			return nil, fmt.Errorf("getRowsTableTwo operation failed. %s", err)
+		}
+
+		var rows []shim.Row
+		for {
+			select {
+			case row, ok := <-rowChannel:
+				if !ok {
+					rowChannel = nil
+				} else {
+					rows = append(rows, row)
+				}
+			}
+			if rowChannel == nil {
+				break
+			}
+		}
+
+		jsonRows, err := json.Marshal(rows)
+		if err != nil {
+			return nil, fmt.Errorf("getRowsTableTwo operation failed. Error marshaling JSON: %s", err)
+		}
+
+		return jsonRows, nil
 
 	default:
 		return nil, errors.New("Unsupported operation")

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -190,13 +190,60 @@ Feature: lanching 3 peers
         | test5|
       Then I should get a JSON response with "OK" = "{[string:"test5"  int32:10  int32:20 ]}"
 
+      When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"
+        | arg1 | arg2 | arg3 | arg3 |
+        | foo2 | 35   | 65   | bar10 |
+      Then I should have received a transactionID
+      Then I wait up to "25" seconds for transaction to be committed to all peers
+      When requesting "/chain" from "vp0"
+      Then I should get a JSON response with "height" = "11"
+
+      When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"
+        | arg1 | arg2 | arg3 | arg3 |
+        | foo2 | 36   | 65   | bar11 |
+      Then I should have received a transactionID
+      Then I wait up to "25" seconds for transaction to be committed to all peers
+      When requesting "/chain" from "vp0"
+      Then I should get a JSON response with "height" = "12"
+
+      When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"
+        | arg1 | arg2 | arg3 | arg3 |
+        | foo2 | 37   | 65   | bar12 |
+      Then I should have received a transactionID
+      Then I wait up to "25" seconds for transaction to be committed to all peers
+      When requesting "/chain" from "vp0"
+      Then I should get a JSON response with "height" = "13"
+
+      When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"
+        | arg1 | arg2 | arg3 | arg3 |
+        | foo2 | 38   | 66   | bar10 |
+      Then I should have received a transactionID
+      Then I wait up to "25" seconds for transaction to be committed to all peers
+      When requesting "/chain" from "vp0"
+      Then I should get a JSON response with "height" = "14"
+
+      When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0":
+        | arg1 | arg2 |
+        | foo2 | 65   |
+      Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]}]"
+
+      When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0":
+        | arg1 | arg2 |
+        | foo2 | 66   |
+      Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]}]"
+
+      When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0":
+        | arg1 |
+        | foo2 |
+      Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]}]"
+
       When I invoke chaincode "table_test" function name "deleteAndRecreateTableOne" on "vp0"
         ||
         ||
       Then I should have received a transactionID
       Then I wait up to "25" seconds for transaction to be committed to all peers
       When requesting "/chain" from "vp0"
-      Then I should get a JSON response with "height" = "11"
+      Then I should get a JSON response with "height" = "15"
 
       When I query chaincode "table_test" function name "getRowTableOne" on "vp0":
         | arg1 |


### PR DESCRIPTION
This adds support for partial key queries in the Go shim table API.

The API is
`GetRows(tableName string, key []Column) (<-chan Row, error)`

There is a behave test demonstrating usage, `chaincode shim table API, issue 477`

Signed-off-by: sheehan@us.ibm.com
