### PR TITLE
Correct variable name mistake of chaincode example 02

### DIFF
--- a/openchain/example/chaincode/chaincode_example02/chaincode_example02.go
+++ b/openchain/example/chaincode/chaincode_example02/chaincode_example02.go
@@ -96,7 +96,7 @@ func (t *SimpleChaincode) invoke(stub *shim.ChaincodeStub, args []string) ([]byt
 	if err != nil {
 		return nil, errors.New("Failed to get state")
 	}
-	if Avalbytes == nil {
+	if Bvalbytes == nil {
 		return nil, errors.New("Entity not found")
 	}
 	Bval, _ = strconv.Atoi(string(Bvalbytes))


### PR DESCRIPTION
It's a spelling mistake.in the chaincode example 02. Change "Avalbytes" to "Bvalbytes".to verify B's state value.

Signed-off-by: Boliang Chen shblchen@cn.ibm.com
