### PR TITLE
Save container logs if Behave test fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ OBC also has [Behave](http://pythonhosted.org/behave/) tests that will setup net
 cd $GOPATH/src/github.com/openblockchain/obc-peer/openchain/peer/bddtests
 behave
 ```
+Some of the Behave tests run inside Docker containers. If a test fails and you want to have the logs from the Docker containers, run the tests with this option
+```
+behave -D logs=Y
+```
 
 Note, you must run the unit tests first to build the necessary Peer and OBCCA docker images. These images can also be individually built using the commands
 ```

--- a/openchain/peer/bddtests/environment.py
+++ b/openchain/peer/bddtests/environment.py
@@ -3,28 +3,32 @@ import subprocess
 from steps.bdd_test_util import cli_call
 
 def after_scenario(context, scenario):
-    if context.failed:
-        file_suffix = "_" + scenario.name.replace(" ", "_") + ".log"
-        for containerData in context.compose_containers:
-            with open(containerData.containerName + file_suffix, "w+") as logfile:
-                sys_rc = subprocess.call(["docker", "logs", containerData.containerName], stdout=logfile, stderr=logfile)
-                if sys_rc !=0 :
-                    print("****** cannot get logs for {0}. Docker rc = {1}".format(containerData.containerName,sys_rc))
-	if 'doNotDecompose' in scenario.tags:
-		print("Not going to decompose after scenario {0}, with yaml '{1}'".format(scenario.name, context.compose_yaml))
-	else:
-		if 'compose_yaml' in context:
-			print("Decomposing with yaml '{0}' after scenario {1}, ".format(context.compose_yaml, scenario.name))
-			context.compose_output, context.compose_error, context.compose_returncode = \
-        		cli_call(context, ["docker-compose", "-f", context.compose_yaml, "kill"], expect_success=True)
-			context.compose_output, context.compose_error, context.compose_returncode = \
-        		cli_call(context, ["docker-compose", "-f", context.compose_yaml, "rm","-f"], expect_success=True)
+    if scenario.status == "failed":
+        get_logs = context.config.userdata.get("logs", "N")
+        if get_logs.lower() == "y" :
+            print("Scenario {0} failed. Getting container logs".format(scenario.name))
+            file_suffix = "_" + scenario.name.replace(" ", "_") + ".log"
+            for containerData in context.compose_containers:
+                with open(containerData.containerName + file_suffix, "w+") as logfile:
+                    sys_rc = subprocess.call(["docker", "logs", containerData.containerName], stdout=logfile, stderr=logfile)
+                    if sys_rc !=0 :
+                        print("Cannot get logs for {0}. Docker rc = {1}".format(containerData.containerName,sys_rc))
+
+    if 'doNotDecompose' in scenario.tags:
+        print("Not going to decompose after scenario {0}, with yaml '{1}'".format(scenario.name, context.compose_yaml))
+    else:
+        if 'compose_yaml' in context:
+            print("Decomposing with yaml '{0}' after scenario {1}, ".format(context.compose_yaml, scenario.name))
+            context.compose_output, context.compose_error, context.compose_returncode = \
+                cli_call(context, ["docker-compose", "-f", context.compose_yaml, "kill"], expect_success=True)
+            context.compose_output, context.compose_error, context.compose_returncode = \
+                cli_call(context, ["docker-compose", "-f", context.compose_yaml, "rm","-f"], expect_success=True)
             # now remove any other containers (chaincodes)
-			context.compose_output, context.compose_error, context.compose_returncode = \
-        		cli_call(context, ["docker",  "ps",  "-qa"], expect_success=True)
-        	if context.compose_returncode == 0:
-        		# Remove each container
-        		for containerId in context.compose_output.splitlines():
-        			#print("docker rm {0}".format(containerId))
-        			context.compose_output, context.compose_error, context.compose_returncode = \
+            context.compose_output, context.compose_error, context.compose_returncode = \
+                cli_call(context, ["docker",  "ps",  "-qa"], expect_success=True)
+            if context.compose_returncode == 0:
+                # Remove each container
+                for containerId in context.compose_output.splitlines():
+                    #print("docker rm {0}".format(containerId))
+                    context.compose_output, context.compose_error, context.compose_returncode = \
                         cli_call(context, ["docker",  "rm", "-f", containerId], expect_success=True)

--- a/openchain/peer/bddtests/environment.py
+++ b/openchain/peer/bddtests/environment.py
@@ -2,6 +2,11 @@
 from steps.bdd_test_util import cli_call
 
 def after_scenario(context, scenario):
+    if context.failed:
+        filename = scenario.name.replace(" ", "_")
+        for containerData in context.compose_containers:
+            logfile = containerData.containerName + filename
+            print("********** Test failed. Docker container logs written to {0}".format(logfile))
 	if 'doNotDecompose' in scenario.tags:
 		print("Not going to decompose after scenario {0}, with yaml '{1}'".format(scenario.name, context.compose_yaml))
 	else:
@@ -20,6 +25,3 @@ def after_scenario(context, scenario):
         			#print("docker rm {0}".format(containerId))
         			context.compose_output, context.compose_error, context.compose_returncode = \
                         cli_call(context, ["docker",  "rm", containerId], expect_success=True)
-
-
-


### PR DESCRIPTION
If `behave` scenario fails, save the logs from the containers composed for that scenario.
Logs file have names like  `containername_testname.log` and are saved in the directory where `behave` is running.

Also, updated README to show syntax of `behave` call.
