### PR TITLE
Support additional types in Go shim table. Issue #477

### DIFF
--- a/openchain/behave_chaincode/go/table/table.go
+++ b/openchain/behave_chaincode/go/table/table.go
@@ -107,6 +107,67 @@ func (t *SimpleChaincode) Run(stub *shim.ChaincodeStub, function string, args []
 			return nil, errors.New("insertRowTableTwo operation failed. Row with given key already exists")
 		}
 
+	case "insertRowTableThree":
+		if len(args) < 7 {
+			return nil, errors.New("insertRowTableThree failed. Must include 7 column values")
+		}
+
+		col1Val := args[0]
+
+		col2Int, err := strconv.ParseInt(args[1], 10, 32)
+		if err != nil {
+			return nil, errors.New("insertRowTableThree failed. arg[1] must be convertable to int32")
+		}
+		col2Val := int32(col2Int)
+
+		col3Val, err := strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			return nil, errors.New("insertRowTableThree failed. arg[2] must be convertable to int64")
+		}
+
+		col4Uint, err := strconv.ParseUint(args[3], 10, 32)
+		if err != nil {
+			return nil, errors.New("insertRowTableThree failed. arg[3] must be convertable to uint32")
+		}
+		col4Val := uint32(col4Uint)
+
+		col5Val, err := strconv.ParseUint(args[4], 10, 64)
+		if err != nil {
+			return nil, errors.New("insertRowTableThree failed. arg[4] must be convertable to uint64")
+		}
+
+		col6Val := []byte(args[5])
+
+		col7Val, err := strconv.ParseBool(args[6])
+		if err != nil {
+			return nil, errors.New("insertRowTableThree failed. arg[6] must be convertable to bool")
+		}
+
+		var columns []*shim.Column
+		col1 := shim.Column{Value: &shim.Column_String_{String_: col1Val}}
+		col2 := shim.Column{Value: &shim.Column_Int32{Int32: col2Val}}
+		col3 := shim.Column{Value: &shim.Column_Int64{Int64: col3Val}}
+		col4 := shim.Column{Value: &shim.Column_Uint32{Uint32: col4Val}}
+		col5 := shim.Column{Value: &shim.Column_Uint64{Uint64: col5Val}}
+		col6 := shim.Column{Value: &shim.Column_Bytes{Bytes: col6Val}}
+		col7 := shim.Column{Value: &shim.Column_Bool{Bool: col7Val}}
+		columns = append(columns, &col1)
+		columns = append(columns, &col2)
+		columns = append(columns, &col3)
+		columns = append(columns, &col4)
+		columns = append(columns, &col5)
+		columns = append(columns, &col6)
+		columns = append(columns, &col7)
+
+		row := shim.Row{columns}
+		ok, err := stub.InsertRow("tableThree", row)
+		if err != nil {
+			return nil, fmt.Errorf("insertRowTableThree operation failed. %s", err)
+		}
+		if !ok {
+			return nil, errors.New("insertRowTableThree operation failed. Row with given key already exists")
+		}
+
 	case "deleteRowTableOne":
 		if len(args) < 1 {
 			return nil, errors.New("deleteRowTableOne failed. Must include 1 key value")
@@ -184,6 +245,12 @@ func (t *SimpleChaincode) Run(stub *shim.ChaincodeStub, function string, args []
 			return nil, fmt.Errorf("Error creating table two during init. %s", err)
 		}
 
+		// Create table three
+		err = createTableThree(stub)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating table three during init. %s", err)
+		}
+
 	default:
 		return nil, errors.New("Unsupported operation")
 	}
@@ -235,6 +302,25 @@ func (t *SimpleChaincode) Query(stub *shim.ChaincodeStub, function string, args 
 		row, err := stub.GetRow("tableTwo", columns)
 		if err != nil {
 			return nil, fmt.Errorf("getRowTableTwo operation failed. %s", err)
+		}
+
+		rowString := fmt.Sprintf("%s", row)
+		return []byte(rowString), nil
+
+	case "getRowTableThree":
+		if len(args) < 1 {
+			return nil, errors.New("getRowTableThree failed. Must include 1 key value")
+		}
+
+		col1Val := args[0]
+
+		var columns []shim.Column
+		col1 := shim.Column{Value: &shim.Column_String_{String_: col1Val}}
+		columns = append(columns, col1)
+
+		row, err := stub.GetRow("tableThree", columns)
+		if err != nil {
+			return nil, fmt.Errorf("getRowTableThree operation failed. %s", err)
 		}
 
 		rowString := fmt.Sprintf("%s", row)
@@ -330,4 +416,30 @@ func createTableTwo(stub *shim.ChaincodeStub) error {
 	columnDefsTableTwo = append(columnDefsTableTwo, &columnThreeTableTwoDef)
 	columnDefsTableTwo = append(columnDefsTableTwo, &columnFourTableTwoDef)
 	return stub.CreateTable("tableTwo", columnDefsTableTwo)
+}
+
+func createTableThree(stub *shim.ChaincodeStub) error {
+	var columnDefsTableThree []*shim.ColumnDefinition
+	columnOneTableThreeDef := shim.ColumnDefinition{Name: "colOneTableThree",
+		Type: shim.ColumnDefinition_STRING, Key: true}
+	columnTwoTableThreeDef := shim.ColumnDefinition{Name: "colTwoTableThree",
+		Type: shim.ColumnDefinition_INT32, Key: false}
+	columnThreeTableThreeDef := shim.ColumnDefinition{Name: "colThreeTableThree",
+		Type: shim.ColumnDefinition_INT64, Key: false}
+	columnFourTableThreeDef := shim.ColumnDefinition{Name: "colFourTableFour",
+		Type: shim.ColumnDefinition_UINT32, Key: false}
+	columnFiveTableThreeDef := shim.ColumnDefinition{Name: "colFourTableFive",
+		Type: shim.ColumnDefinition_UINT64, Key: false}
+	columnSixTableThreeDef := shim.ColumnDefinition{Name: "colFourTableSix",
+		Type: shim.ColumnDefinition_BYTES, Key: false}
+	columnSevenTableThreeDef := shim.ColumnDefinition{Name: "colFourTableSeven",
+		Type: shim.ColumnDefinition_BOOL, Key: false}
+	columnDefsTableThree = append(columnDefsTableThree, &columnOneTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnTwoTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnThreeTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnFourTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnFiveTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnSixTableThreeDef)
+	columnDefsTableThree = append(columnDefsTableThree, &columnSevenTableThreeDef)
+	return stub.CreateTable("tableThree", columnDefsTableThree)
 }

--- a/openchain/chaincode/shim/chaincode.go
+++ b/openchain/chaincode/shim/chaincode.go
@@ -350,6 +350,11 @@ func (stub *ChaincodeStub) CreateTable(name string, columnDefinitions []*ColumnD
 		switch definition.Type {
 		case ColumnDefinition_STRING:
 		case ColumnDefinition_INT32:
+		case ColumnDefinition_INT64:
+		case ColumnDefinition_UINT32:
+		case ColumnDefinition_UINT64:
+		case ColumnDefinition_BYTES:
+		case ColumnDefinition_BOOL:
 		default:
 			return fmt.Errorf("Column definition %s does not have a valid type.", definition.Name)
 		}
@@ -577,7 +582,17 @@ func buildKeyString(tableName string, keys []Column) (string, error) {
 			// b := make([]byte, 4)
 			// binary.LittleEndian.PutUint32(b, uint32(key.GetInt32()))
 			// keyBuffer.Write(b)
-			keyString = strconv.Itoa(int(key.GetInt32()))
+			keyString = strconv.FormatInt(int64(key.GetInt32()), 10)
+		case *Column_Int64:
+			keyString = strconv.FormatInt(key.GetInt64(), 10)
+		case *Column_Uint32:
+			keyString = strconv.FormatUint(uint64(key.GetInt32()), 10)
+		case *Column_Uint64:
+			keyString = strconv.FormatUint(key.GetUint64(), 10)
+		case *Column_Bytes:
+			keyString = string(key.GetBytes())
+		case *Column_Bool:
+			keyString = strconv.FormatBool(key.GetBool())
 		}
 
 		keyBuffer.WriteString(strconv.Itoa(len(keyString)))
@@ -605,6 +620,16 @@ func getKeyAndVerifyRow(table Table, row Row) ([]Column, error) {
 			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_STRING
 		case *Column_Int32:
 			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_INT32
+		case *Column_Int64:
+			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_INT64
+		case *Column_Uint32:
+			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_UINT32
+		case *Column_Uint64:
+			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_UINT64
+		case *Column_Bytes:
+			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_BYTES
+		case *Column_Bool:
+			expectedType = table.ColumnDefinitions[i].Type == ColumnDefinition_BOOL
 		default:
 			expectedType = false
 		}

--- a/openchain/chaincode/shim/chaincode.pb.go
+++ b/openchain/chaincode/shim/chaincode.pb.go
@@ -30,15 +30,30 @@ type ColumnDefinition_Type int32
 const (
 	ColumnDefinition_STRING ColumnDefinition_Type = 0
 	ColumnDefinition_INT32  ColumnDefinition_Type = 1
+	ColumnDefinition_INT64  ColumnDefinition_Type = 2
+	ColumnDefinition_UINT32 ColumnDefinition_Type = 3
+	ColumnDefinition_UINT64 ColumnDefinition_Type = 4
+	ColumnDefinition_BYTES  ColumnDefinition_Type = 5
+	ColumnDefinition_BOOL   ColumnDefinition_Type = 6
 )
 
 var ColumnDefinition_Type_name = map[int32]string{
 	0: "STRING",
 	1: "INT32",
+	2: "INT64",
+	3: "UINT32",
+	4: "UINT64",
+	5: "BYTES",
+	6: "BOOL",
 }
 var ColumnDefinition_Type_value = map[string]int32{
 	"STRING": 0,
 	"INT32":  1,
+	"INT64":  2,
+	"UINT32": 3,
+	"UINT64": 4,
+	"BYTES":  5,
+	"BOOL":   6,
 }
 
 func (x ColumnDefinition_Type) String() string {
@@ -75,6 +90,11 @@ type Column struct {
 	// Types that are valid to be assigned to Value:
 	//	*Column_String_
 	//	*Column_Int32
+	//	*Column_Int64
+	//	*Column_Uint32
+	//	*Column_Uint64
+	//	*Column_Bytes
+	//	*Column_Bool
 	Value isColumn_Value `protobuf_oneof:"value"`
 }
 
@@ -92,9 +112,29 @@ type Column_String_ struct {
 type Column_Int32 struct {
 	Int32 int32 `protobuf:"varint,2,opt,name=int32,oneof"`
 }
+type Column_Int64 struct {
+	Int64 int64 `protobuf:"varint,3,opt,name=int64,oneof"`
+}
+type Column_Uint32 struct {
+	Uint32 uint32 `protobuf:"varint,4,opt,name=uint32,oneof"`
+}
+type Column_Uint64 struct {
+	Uint64 uint64 `protobuf:"varint,5,opt,name=uint64,oneof"`
+}
+type Column_Bytes struct {
+	Bytes []byte `protobuf:"bytes,6,opt,name=bytes,proto3,oneof"`
+}
+type Column_Bool struct {
+	Bool bool `protobuf:"varint,7,opt,name=bool,oneof"`
+}
 
 func (*Column_String_) isColumn_Value() {}
 func (*Column_Int32) isColumn_Value()   {}
+func (*Column_Int64) isColumn_Value()   {}
+func (*Column_Uint32) isColumn_Value()  {}
+func (*Column_Uint64) isColumn_Value()  {}
+func (*Column_Bytes) isColumn_Value()   {}
+func (*Column_Bool) isColumn_Value()    {}
 
 func (m *Column) GetValue() isColumn_Value {
 	if m != nil {
@@ -117,11 +157,51 @@ func (m *Column) GetInt32() int32 {
 	return 0
 }
 
+func (m *Column) GetInt64() int64 {
+	if x, ok := m.GetValue().(*Column_Int64); ok {
+		return x.Int64
+	}
+	return 0
+}
+
+func (m *Column) GetUint32() uint32 {
+	if x, ok := m.GetValue().(*Column_Uint32); ok {
+		return x.Uint32
+	}
+	return 0
+}
+
+func (m *Column) GetUint64() uint64 {
+	if x, ok := m.GetValue().(*Column_Uint64); ok {
+		return x.Uint64
+	}
+	return 0
+}
+
+func (m *Column) GetBytes() []byte {
+	if x, ok := m.GetValue().(*Column_Bytes); ok {
+		return x.Bytes
+	}
+	return nil
+}
+
+func (m *Column) GetBool() bool {
+	if x, ok := m.GetValue().(*Column_Bool); ok {
+		return x.Bool
+	}
+	return false
+}
+
 // XXX_OneofFuncs is for the internal use of the proto package.
 func (*Column) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), []interface{}) {
 	return _Column_OneofMarshaler, _Column_OneofUnmarshaler, []interface{}{
 		(*Column_String_)(nil),
 		(*Column_Int32)(nil),
+		(*Column_Int64)(nil),
+		(*Column_Uint32)(nil),
+		(*Column_Uint64)(nil),
+		(*Column_Bytes)(nil),
+		(*Column_Bool)(nil),
 	}
 }
 
@@ -135,6 +215,25 @@ func _Column_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 	case *Column_Int32:
 		b.EncodeVarint(2<<3 | proto.WireVarint)
 		b.EncodeVarint(uint64(x.Int32))
+	case *Column_Int64:
+		b.EncodeVarint(3<<3 | proto.WireVarint)
+		b.EncodeVarint(uint64(x.Int64))
+	case *Column_Uint32:
+		b.EncodeVarint(4<<3 | proto.WireVarint)
+		b.EncodeVarint(uint64(x.Uint32))
+	case *Column_Uint64:
+		b.EncodeVarint(5<<3 | proto.WireVarint)
+		b.EncodeVarint(uint64(x.Uint64))
+	case *Column_Bytes:
+		b.EncodeVarint(6<<3 | proto.WireBytes)
+		b.EncodeRawBytes(x.Bytes)
+	case *Column_Bool:
+		t := uint64(0)
+		if x.Bool {
+			t = 1
+		}
+		b.EncodeVarint(7<<3 | proto.WireVarint)
+		b.EncodeVarint(t)
 	case nil:
 	default:
 		return fmt.Errorf("Column.Value has unexpected type %T", x)
@@ -158,6 +257,41 @@ func _Column_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer)
 		}
 		x, err := b.DecodeVarint()
 		m.Value = &Column_Int32{int32(x)}
+		return true, err
+	case 3: // value.int64
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Value = &Column_Int64{int64(x)}
+		return true, err
+	case 4: // value.uint32
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Value = &Column_Uint32{uint32(x)}
+		return true, err
+	case 5: // value.uint64
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Value = &Column_Uint64{x}
+		return true, err
+	case 6: // value.bytes
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeRawBytes(true)
+		m.Value = &Column_Bytes{x}
+		return true, err
+	case 7: // value.bool
+		if wire != proto.WireVarint {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeVarint()
+		m.Value = &Column_Bool{x != 0}
 		return true, err
 	default:
 		return false, nil

--- a/openchain/chaincode/shim/chaincode.proto
+++ b/openchain/chaincode/shim/chaincode.proto
@@ -26,6 +26,11 @@ message ColumnDefinition {
 	enum Type {
     STRING = 0;
 		INT32 = 1;
+		INT64 = 2;
+		UINT32 = 3;
+		UINT64 = 4;
+		BYTES = 5;
+		BOOL = 6;
   }
 	Type type = 2;
 	bool key = 3;
@@ -40,6 +45,11 @@ message Column {
 	oneof value {
     string string = 1;
     int32 int32 = 2;
+		int64 int64 = 3;
+		uint32 uint32 = 4;
+		uint64 uint64 = 5;
+		bytes bytes = 6;
+		bool bool = 7;
   }
 }
 

--- a/openchain/peer/bddtests/peer_basic.feature
+++ b/openchain/peer/bddtests/peer_basic.feature
@@ -235,7 +235,7 @@ Feature: lanching 3 peers
       When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0":
         | arg1 |
         | foo2 |
-      Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]}]"
+      Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]}]"
 
       When I invoke chaincode "table_test" function name "deleteAndRecreateTableOne" on "vp0"
         ||
@@ -269,6 +269,19 @@ Feature: lanching 3 peers
         | arg1 | arg2 | arg3 |
         | foo2 | 65   | bar8 |
       Then I should get a JSON response with "OK" = "{[string:"foo2"  int32:34  int32:65  string:"bar8" ]}"
+
+      When I invoke chaincode "table_test" function name "insertRowTableThree" on "vp0"
+        | arg1 | arg2 | arg3 | arg4 | arg5 | arg6 | arg7 |
+        | foo2 | -38  | -66  | 77   | 88   | hello| true |
+      Then I should have received a transactionID
+      Then I wait up to "25" seconds for transaction to be committed to all peers
+      When requesting "/chain" from "vp0"
+      Then I should get a JSON response with "height" = "16"
+
+      When I query chaincode "table_test" function name "getRowTableThree" on "vp0":
+        | arg1 |
+        | foo2 |
+      Then I should get a JSON response with "OK" = "{[string:"foo2"  int32:-38  int64:-66  uint32:77  uint64:88  bytes:"hello"  bool:true ]}"
 
 
 #    @doNotDecompose


### PR DESCRIPTION
This adds many more types to the table API available in the Go chaincode shim. Supported types are now

```
string
int32
int64
uint32
uint64
bytes
bool
```
