### PR TITLE
Fix: Performance Degradation #811

### DIFF
--- a/obc-ca/obcca/eca.go
+++ b/obc-ca/obcca/eca.go
@@ -39,7 +39,6 @@ import (
 
 	ecies "github.com/openblockchain/obc-peer/openchain/crypto/ecies/generic"
 
-	"fmt"
 	"github.com/golang/protobuf/proto"
 	pb "github.com/openblockchain/obc-peer/obc-ca/protos"
 	"github.com/openblockchain/obc-peer/openchain/crypto/conf"

--- a/obc-ca/obcca/eca.go
+++ b/obc-ca/obcca/eca.go
@@ -286,7 +286,6 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 		} else {
 			obcECKey = ecap.eca.obcPub
 		}
-		fmt.Printf("obcECKey % x\n", obcECKey)
 
 		return &pb.ECertCreateResp{&pb.CertPair{sraw, eraw}, &pb.Token{ecap.eca.obcKey}, obcECKey, nil}, nil
 	}

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -61,7 +61,7 @@ logging:
     #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
     #   chaincode=info:main=debug:db=debug:warning - Same as above
     peer:      debug
-    crypto:    debug
+    crypto:    info
     status:    warning
     stop:      warning
     login:     warning

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -111,8 +111,8 @@ logging:
     #   info                                       - Set default to INFO
     #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
     #   chaincode=info:main=debug:db=debug:warning - Same as above
-    peer:      info
-    crypto:    info
+    peer:      debug
+    crypto:    debug
     status:    warning
     stop:      warning
     login:     warning

--- a/openchain/crypto/crypto_test.yaml
+++ b/openchain/crypto/crypto_test.yaml
@@ -111,8 +111,8 @@ logging:
     #   info                                       - Set default to INFO
     #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
     #   chaincode=info:main=debug:db=debug:warning - Same as above
-    peer:      debug
-    crypto:    debug
+    peer:      info
+    crypto:    info
     status:    warning
     stop:      warning
     login:     warning

--- a/openchain/crypto/ecies/generic/engine.go
+++ b/openchain/crypto/ecies/generic/engine.go
@@ -25,7 +25,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/hmac"
-	rand "crypto/rand"
+	"crypto/rand"
 	"errors"
 	"io"
 
@@ -74,7 +74,7 @@ func eciesGenerateKey(rand io.Reader, curve elliptic.Curve, params *Params) (*ec
 }
 
 func eciesEncrypt(rand io.Reader, pub *ecdsa.PublicKey, s1, s2 []byte, plain []byte) ([]byte, error) {
-	params := pub.Curve.Params()
+	params := pub.Curve
 
 	// Select an ephemeral elliptic curve key pair associated with
 	// elliptic curve domain parameters params
@@ -132,7 +132,7 @@ func eciesEncrypt(rand io.Reader, pub *ecdsa.PublicKey, s1, s2 []byte, plain []b
 }
 
 func eciesDecrypt(priv *ecdsa.PrivateKey, s1, s2 []byte, ciphertext []byte) ([]byte, error) {
-	params := priv.Curve.Params()
+	params := priv.Curve
 
 	var (
 		rLen   int

--- a/openchain/crypto/utils/keys.go
+++ b/openchain/crypto/utils/keys.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 )
 
 // PrivateKeyToDER marshals a private key to der

--- a/openchain/crypto/utils/keys.go
+++ b/openchain/crypto/utils/keys.go
@@ -254,7 +254,6 @@ func PublicKeyToEncryptedPEM(publicKey interface{}, pwd []byte) ([]byte, error) 
 // PEMtoPublicKey unmarshals a pem to public key
 func PEMtoPublicKey(raw []byte, pwd []byte) (interface{}, error) {
 	block, _ := pem.Decode(raw)
-	fmt.Printf("block % x\n", raw)
 	// TODO: derive from header the type of the key
 
 	if x509.IsEncryptedPEMBlock(block) {


### PR DESCRIPTION
EC usage: ScalarMult (and related methods) must be invoked directly on Curve and not on Params. This is in order to take advantage of the speedup introduced by go1.6.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
