### PR TITLE
make check of consensus plugin case-insensitive

### DIFF
--- a/openchain.yaml
+++ b/openchain.yaml
@@ -147,7 +147,7 @@ peer:
     validator:
         enabled: true
 
-        # Consensus plugin to use. The value is the name of the plugin, e.g. obcpbft, noops
+        # Consensus plugin to use. The value is the name of the plugin, e.g. obcpbft, noops ( this value is case-insensitive)
         # if the given value is not recognized, we will default to noops
         consensus: noops
 

--- a/openchain/consensus/controller/controller.go
+++ b/openchain/consensus/controller/controller.go
@@ -22,6 +22,7 @@ package controller
 import (
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
+	"strings"
 
 	"github.com/openblockchain/obc-peer/openchain/consensus"
 	"github.com/openblockchain/obc-peer/openchain/consensus/noops"
@@ -36,7 +37,7 @@ func init() {
 
 // NewConsenter constructs a Consenter object
 func NewConsenter(stack consensus.Stack) (consenter consensus.Consenter) {
-	plugin := viper.GetString("peer.validator.consensus")
+	plugin := strings.ToLower(viper.GetString("peer.validator.consensus"))
 	if plugin == "obcpbft" {
 		//logger.Info("Running with consensus plugin %s", plugin)
 		consenter = obcpbft.GetPlugin(stack)

--- a/openchain/consensus/obcpbft/config.yaml
+++ b/openchain/consensus/obcpbft/config.yaml
@@ -9,7 +9,7 @@
 ################################################################################
 general:
 
-    # Operational mode: batch, classic, or sieve
+    # Operational mode: batch, classic, or sieve ( this value is case-insensitive)
     mode: classic
 
     # Maximum number of validators/replicas we expect in the network

--- a/openchain/consensus/obcpbft/obc-pbft.go
+++ b/openchain/consensus/obcpbft/obc-pbft.go
@@ -53,7 +53,7 @@ func New(stack consensus.Stack) consensus.Consenter {
 	handle, _, _ := stack.GetNetworkHandles()
 	id, _ := getValidatorID(handle)
 
-	switch config.GetString("general.mode") {
+	switch strings.ToLower(config.GetString("general.mode")) {
 	case "classic":
 		return newObcClassic(id, config, stack)
 	case "batch":


### PR DESCRIPTION
handles issue #815 

Comparison of OPENCHAIN_PEER_VALIDATOR_CONSENSUS and OPENCHAIN_OBCPBFT_GENERAL_MODE is now case-insensitive

unit tests run.
behave tests run.
