### PR TITLE
Ability to pull local images for chaincode. Issue #776

### DIFF
--- a/openchain/container/controller.go
+++ b/openchain/container/controller.go
@@ -67,7 +67,7 @@ func (vm *dockerVM) build(ctxt context.Context, id string, args []string, env []
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         id,
-		Pull:         true,
+		Pull:         false,
 		InputStream:  reader,
 		OutputStream: outputbuf,
 	}
@@ -152,6 +152,7 @@ func (vm *dockerVM) stopInternal(ctxt context.Context, client *docker.Client, id
 	}
 	return err
 }
+
 //constants for supported containers
 const (
 	DOCKER = "Docker"


### PR DESCRIPTION
Signed-off-by: sheehan@us.ibm.com

As part of deploying the UTXO example chaincode with a C library, we need the ability to pull local docker images.

Discussed this change with @jeffgarratt and @muralisrini
