### PR TITLE
Packer v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /var/openchain/db
 RUN mkdir -p /var/openchain/production
 WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
-RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 RUN cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain/consensus/obcpbft/config.yaml $GOPATH/bin
-# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+# RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 # RUN cd obc-ca && go install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-from golang:1.6
-# Install RocksDB
-RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
-ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-RUN apt-get update && apt-get install -y vim
+from openblockchain/baseimage:latest
+
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/openchain/db
 RUN mkdir -p /var/openchain/production
 WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
-RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 RUN cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain/consensus/obcpbft/config.yaml $GOPATH/bin
-# RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 # RUN cd obc-ca && go install

--- a/README.md
+++ b/README.md
@@ -147,11 +147,20 @@ This is not recommended, however some users may wish to build Openchain outside 
 1. Follow all steps required to setup and run a Vagrant image
 - Make you you have [Go 1.6](https://golang.org/) or later installed
 - Set the maximum number of open files to 10000 or greater for your OS
-- Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1
-- Run the following commands replacing `/opt/rocksdb` with the path where you installed RocksDB:
+- Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1 and it's dependencies:
+```
+apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+cd /tmp
+git clone https://github.com/facebook/rocksdb.git
+cd rocksdb
+git checkout tags/v4.1
+PORTABLE=1 make shared_lib
+INSTALL_PATH=/usr/local make install-shared
+```
+- Run the following commands:
 ```
 cd $GOPATH/src/github.com/openblockchain/obc-peer
-CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 ```
 - Make sure that the Docker daemon initialization includes the options
 ```

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ INSTALL_PATH=/usr/local make install-shared
 - Run the following commands:
 ```
 cd $GOPATH/src/github.com/openblockchain/obc-peer
-CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 ```
 - Make sure that the Docker daemon initialization includes the options
 ```

--- a/obc-ca/Dockerfile
+++ b/obc-ca/Dockerfile
@@ -5,5 +5,5 @@ WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
 WORKDIR obc-ca
 RUN pwd
-RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
-# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
+# RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install

--- a/obc-ca/Dockerfile
+++ b/obc-ca/Dockerfile
@@ -1,14 +1,9 @@
-from golang:1.6
-# Install RocksDB
-RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && make shared_lib
-ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-RUN apt-get update && apt-get install -y vim
+from openblockchain/baseimage:latest
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/openchain/db
 WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
 COPY . .
 WORKDIR obc-ca
 RUN pwd
-RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
-# RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/obc-ca/obcca.yaml $GOPATH/bin
+# RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install

--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -62,7 +62,7 @@ peer:
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303

--- a/obc-ca/obcca/obcca_test.yaml
+++ b/obc-ca/obcca/obcca_test.yaml
@@ -57,18 +57,12 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+        from openblockchain/baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303
@@ -245,7 +239,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -258,7 +252,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -97,7 +97,7 @@ peer:
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
 
     # The Address this Peer will listen on

--- a/openchain.yaml
+++ b/openchain.yaml
@@ -92,18 +92,13 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+        from openblockchain/baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303
@@ -286,7 +281,7 @@ chaincode:
         # This is the basis for the Golang Dockerfile.  Additional commands will
         # be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -304,7 +299,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #

--- a/openchain/chaincode/chaincode_support.go
+++ b/openchain/chaincode/chaincode_support.go
@@ -50,7 +50,7 @@ const (
 	// DevModeUserRunsChaincode property allows user to run chaincode in development environment
 	DevModeUserRunsChaincode       string = "dev"
 	chaincodeStartupTimeoutDefault int    = 5000
-	chaincodeInstallPathDefault    string = "/go/bin/"
+	chaincodeInstallPathDefault    string = "/opt/gopath/bin/"
 	peerAddressDefault             string = "0.0.0.0:30303"
 )
 

--- a/openchain/container/vm.go
+++ b/openchain/container/vm.go
@@ -143,7 +143,6 @@ func (vm *VM) buildChaincodeContainerUsingDockerfilePackageBytes(spec *pb.Chainc
 	inputbuf := bytes.NewReader(code)
 	opts := docker.BuildImageOptions{
 		Name:         vmName,
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}
@@ -165,7 +164,6 @@ func (vm *VM) BuildPeerContainer() error {
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         "openchain-peer",
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}
@@ -186,7 +184,6 @@ func (vm *VM) BuildObccaContainer() error {
 	outputbuf := bytes.NewBuffer(nil)
 	opts := docker.BuildImageOptions{
 		Name:         "obcca",
-		Pull:         true,
 		InputStream:  inputbuf,
 		OutputStream: outputbuf,
 	}

--- a/openchain/ledger/genesis/genesis_test.yaml
+++ b/openchain/ledger/genesis/genesis_test.yaml
@@ -46,21 +46,12 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from golang:1.6
-        # Install RocksDB
-        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
-        WORKDIR /opt/rocksdb
-        RUN make shared_lib
-        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
-        RUN apt-get update && apt-get install -y \
-            libsnappy-dev      \
-            zlib1g-dev         \
-            libbz2-dev
+        from openblockchain/baseimage
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will bind to for providing services
     address: 0.0.0.0:30303
@@ -195,7 +186,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from golang:1.6
+            from openblockchain/baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 
@@ -208,7 +199,7 @@ chaincode:
 
     mode: net
 
-    installpath: /go/bin/
+    installpath: /opt/gopath/bin/
 
 ###############################################################################
 #

--- a/openchain/ledger/genesis/genesis_test.yaml
+++ b/openchain/ledger/genesis/genesis_test.yaml
@@ -51,7 +51,7 @@ peer:
         COPY src $GOPATH/src
         RUN mkdir -p /var/openchain/db
         WORKDIR $GOPATH/src/github.com/openblockchain/obc-peer/
-        RUN CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
+        RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/openblockchain/obc-peer/openchain.yaml $GOPATH/bin
 
     # The Address this Peer will bind to for providing services
     address: 0.0.0.0:30303

--- a/openchain/peer/bddtests/docker-compose-4-consensus-batch-1-byzantine.yml
+++ b/openchain/peer/bddtests/docker-compose-4-consensus-batch-1-byzantine.yml
@@ -2,7 +2,6 @@ obcca0:
   extends:
     file: compose-defaults.yml
     service: obcca
-  working_dir: /go/src/github.com/openblockchain/obc-peer/obc-ca
 
 vp0:
   extends:

--- a/openchain/peer/bddtests/docker-compose-4-consensus-classic-1-byzantine.yml
+++ b/openchain/peer/bddtests/docker-compose-4-consensus-classic-1-byzantine.yml
@@ -2,7 +2,6 @@ obcca0:
   extends:
     file: compose-defaults.yml
     service: obcca
-  working_dir: /go/src/github.com/openblockchain/obc-peer/obc-ca
 
 vp0:
   extends:

--- a/openchain/peer/bddtests/docker-compose-4-consensus-sieve-1-byzantine.yml
+++ b/openchain/peer/bddtests/docker-compose-4-consensus-sieve-1-byzantine.yml
@@ -2,7 +2,6 @@ obcca0:
   extends:
     file: compose-defaults.yml
     service: obcca
-  working_dir: /go/src/github.com/openblockchain/obc-peer/obc-ca
 
 vp0:
   extends:


### PR DESCRIPTION
Rebased PR #799 ("packer-v2") on top of the latest obc-peer/master:HEAD.

No functional changes from PR 799.  One notable change from mainline is I omitted the "install vim" directives that were added since vim is already included in the ubuntu-based docker that this patch series introduces.

As with 799, this PR is intended to be accepted together with PR 49 from the obc-dev-env repository.

Test+Behave tests pass

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
