### PR TITLE
Support openblockchain/baseimage

### DIFF
--- a/examples/chaincode/go/utxo/Dockerfile
+++ b/examples/chaincode/go/utxo/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.6
+from openblockchain/baseimage
 
 RUN apt-get update && apt-get install pkg-config autoconf libtool -y
 RUN cd /tmp && git clone https://github.com/bitcoin/secp256k1.git && cd secp256k1/
@@ -10,7 +10,7 @@ RUN ./tests
 RUN make install
 
 WORKDIR /tmp
-RUN apt-get install libtool libboost-all-dev -y
+RUN apt-get install libtool libboost1.55-all-dev -y
 RUN git clone https://github.com/libbitcoin/libbitcoin-consensus.git
 WORKDIR /tmp/libbitcoin-consensus
 RUN ./autogen.sh


### PR DESCRIPTION
This should be merged after PR #922 is merged. It adds support for the new openblockchain/baseimage to the utxo chaincode.
