### PR TITLE
Fix nil pointer dereference in sendStateDeltas

### DIFF
--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -27,11 +27,11 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/op/go-logging"
-	"github.com/hyperledger/fabric/events/producer"
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt/state"
+	"github.com/hyperledger/fabric/events/producer"
+	"github.com/op/go-logging"
 	"github.com/tecbot/gorocksdb"
 
 	"github.com/hyperledger/fabric/protos"
@@ -234,7 +234,7 @@ func (ledger *Ledger) GetStateSnapshot() (*state.StateSnapshot, error) {
 }
 
 // GetStateDelta will return the state delta for the specified block if
-// available.
+// available.  If not available because it has been discarded, returns nil,nil.
 func (ledger *Ledger) GetStateDelta(blockNumber uint64) (*statemgmt.StateDelta, error) {
 	if blockNumber >= ledger.GetBlockchainSize() {
 		return nil, ErrOutOfBounds

--- a/core/peer/handler.go
+++ b/core/peer/handler.go
@@ -676,6 +676,10 @@ func (d *Handler) sendStateDeltas(syncStateDeltasRequest *pb.SyncStateDeltasRequ
 			peerLogger.Error(fmt.Sprintf("Error sending stateDelta for blockNum %d: %s", currBlockNum, err))
 			break
 		}
+		if stateDelta == nil {
+			peerLogger.Warning(fmt.Sprintf("Requested to send a stateDelta for blockNum %d which has been discarded", currBlockNum))
+			break
+		}
 		// Encode a SyncStateDeltas into the payload
 		stateDeltaBytes := stateDelta.Marshal()
 		syncStateDeltas := &pb.SyncStateDeltas{Range: &pb.SyncBlockRange{Start: currBlockNum, End: currBlockNum}, Deltas: [][]byte{stateDeltaBytes}}


### PR DESCRIPTION
This is a fix for issue #906 

It was not clear from the documentation, but `GetStateDelta` could return a `nil` state delta while also returning a `nil` error.  Because of this, `sendStateDeltas` was attempting to Marshal a `nil` state delta which was resulting in the crash seen in #906 

All go tests pass.
No behave tests attempted as they are currently broken.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
