### PR TITLE
Implement issue 644

### DIFF
--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -84,6 +84,12 @@ statetransfer:
     # The number of blocks to retrieve per sync request
     blocksperrequest: 20
 
+    # The maximum number of state deltas to attempt to retrieve
+    # If more than this number of deltas is required to play the state up to date
+    # then instead the state will be flagged as invalid, and a full copy of the state
+    # will be retrieved instead
+    maxdeltas: 200
+
     # Timeouts
     timeout:
 

--- a/consensus/obcpbft/obc-executor.go
+++ b/consensus/obcpbft/obc-executor.go
@@ -153,7 +153,7 @@ func (obcex *obcExecutor) Execute(seqNo uint64, txs []*pb.Transaction, execInfo 
 		obcex.drainExecutionQueue()
 		obcex.executionQueue <- &transaction{
 			seqNo: seqNo,
-			// nil txRaw indicates a missed request
+			sync:  true,
 		}
 		obcex.executionQueue <- request // queue request
 	}
@@ -192,7 +192,7 @@ func (obcex *obcExecutor) SkipTo(seqNo uint64, id []byte, peerIDs []*pb.PeerID, 
 
 }
 
-// A channel which only reads when the executor thread is otherwise idle
+// A channel which only reads when the executor thread is otherwise idle, intended to use only for testing
 func (obcex *obcExecutor) IdleChan() <-chan struct{} {
 	return obcex.threadIdle
 }
@@ -263,6 +263,7 @@ func (obcex *obcExecutor) queueThread() {
 				idle = false
 			case obcex.threadIdle <- struct{}{}:
 				logger.Debug("%v responding to idle request", obcex.id)
+				idle = false
 				continue
 
 			}
@@ -403,7 +404,7 @@ func (obcex *obcExecutor) prepareCommit(tx *transaction) error {
 
 // commits the result from prepareCommit
 func (obcex *obcExecutor) commit(tx *transaction) ([]byte, error) {
-	logger.Debug("%v committing transaction %p", obcex.id, tx)
+	logger.Debug("%v committing transaction %p for sequence number %d", obcex.id, tx, tx.seqNo)
 	if block, err := obcex.executorStack.CommitTxBatch(tx, nil); err != nil {
 		obcex.rollback(tx)
 		return nil, fmt.Errorf("Failed to commit transaction batch %p to the ledger: %v", tx, err)

--- a/consensus/obcpbft/obc-executor.go
+++ b/consensus/obcpbft/obc-executor.go
@@ -304,22 +304,17 @@ func (obcex *obcExecutor) queueThread() {
 		}
 
 		if nil != err {
-			logger.Error("%v encountered an error while processing transaction: %v", err)
+			logger.Error("%v encountered an error while processing transaction: %v", obcex.id, err)
 			continue
 		}
 
 		if sync {
-			logger.Debug("%v requested sync while processing transaction: %v", err)
+			logger.Debug("%v requested sync while processing transaction: %v", obcex.id, err)
 			seqNo, id, execInfo = obcex.sync()
 			if nil == id {
 				// id should only be nil during shutdown
 				continue
 			}
-		}
-
-		if nil != err {
-			logger.Error("%v encountered an error while performing state sync: %v", err)
-			continue
 		}
 
 		if execInfo.Checkpoint {

--- a/consensus/obcpbft/obc-executor_test.go
+++ b/consensus/obcpbft/obc-executor_test.go
@@ -167,10 +167,12 @@ func TestExecutorRequestFlood(t *testing.T) {
 	<-obcex.IdleChan()
 
 	obcex.Execute(101, []*pb.Transaction{&pb.Transaction{}}, &ExecutionInfo{})
-	<-obcex.IdleChan()
 
-	if obcex.lastExec != 101 {
-		t.Fatalf("Expected executions")
+	<-obcex.IdleChan()
+	<-obcex.IdleChan() // Two calls guarantees that we have hit the select without the idle channel
+	expectedExecutions := uint64(101)
+	if obcex.lastExec != expectedExecutions {
+		t.Fatalf("Expected %d executions, got %d", expectedExecutions, obcex.lastExec)
 	}
 
 }

--- a/consensus/obcpbft/statetransfer_mock_test.go
+++ b/consensus/obcpbft/statetransfer_mock_test.go
@@ -383,7 +383,7 @@ func (mock *MockLedger) GetRemoteStateSnapshot(peerID *protos.PeerID) (<-chan *p
 		if remoteBlockHeight < 1 {
 			break
 		}
-		rds, err := mock.GetRemoteStateDeltas(peerID, 0, remoteBlockHeight-1)
+		rds, err := mock.getRemoteStateDeltas(peerID, 0, remoteBlockHeight-1, SyncSnapshot)
 		if nil != err {
 			return nil, err
 		}
@@ -427,6 +427,10 @@ func (mock *MockLedger) GetRemoteStateSnapshot(peerID *protos.PeerID) (<-chan *p
 }
 
 func (mock *MockLedger) GetRemoteStateDeltas(peerID *protos.PeerID, start, finish uint64) (<-chan *protos.SyncStateDeltas, error) {
+	return mock.getRemoteStateDeltas(peerID, start, finish, SyncDeltas)
+}
+
+func (mock *MockLedger) getRemoteStateDeltas(peerID *protos.PeerID, start, finish uint64, requestType mockRequest) (<-chan *protos.SyncStateDeltas, error) {
 	rl, ok := mock.remoteLedgers.GetLedgerByPeerID(peerID)
 
 	if !ok {
@@ -441,7 +445,7 @@ func (mock *MockLedger) GetRemoteStateDeltas(peerID *protos.PeerID, start, finis
 	}
 
 	res := make(chan *protos.SyncStateDeltas, size) // Allows the thread to exit even if the consumer doesn't finish
-	ft := mock.filter(SyncDeltas, peerID)
+	ft := mock.filter(requestType, peerID)
 	switch ft {
 	case Corrupt:
 		fallthrough


### PR DESCRIPTION
This is an implementation for issue #644 

In issue #906, state transfer was attempting to retrieve more state deltas than could possibly exist.  The fabric defaults to retaining 400 state deltas.

This changeset creates a configuration parameter `statetransfer.maxdeltas` for state transfer which specifies the max number of state deltas to retrieve.  It defaults to 200 state deltas.  The idea being that it should be set to less than the max deltas retained, as the network may still be making progress while the state transfer is occurring.

As described in issue #644, depending on the characteristics of the workload, this value may be tweaked up or down.

All go tests pass.
No behave tests attempted as they are currently broken.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
