### PR TITLE
Do not set request timers during a view change

### DIFF
--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -510,7 +510,7 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 
 	instance.reqStore[digest] = req
 	instance.outstandingReqs[digest] = req
-	if !instance.timerActive {
+	if !instance.timerActive && instance.activeView {
 		instance.startTimer(instance.requestTimeout)
 	}
 

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -42,9 +42,9 @@ func init() {
 func TestEnvOverride(t *testing.T) {
 	config := loadConfig()
 
-	key := "general.mode"                       // for a key that exists
+	key := "general.mode"                         // for a key that exists
 	envName := "HYPERLEDGER_OBCPBFT_GENERAL_MODE" // env override name
-	overrideValue := "overide_test"             // value to override default value with
+	overrideValue := "overide_test"               // value to override default value with
 
 	// test key
 	if ok := config.IsSet("general.mode"); !ok {
@@ -866,4 +866,37 @@ func TestPbftF0(t *testing.T) {
 				pep.id, pep.sc.lastExecution, txPacked)
 		}
 	}
+}
+
+// Make sure the request timer doesn't inflate the view timeout by firing during view change
+func TestRequestTimerDuringViewChange(t *testing.T) {
+	mock := &omniProto{
+		validateImpl: func(txRaw []byte) error { return nil },
+		signImpl:     func(msg []byte) ([]byte, error) { return msg, nil },
+		verifyImpl:   func(senderID uint64, signature []byte, message []byte) error { return nil },
+		broadcastImpl: func(msg []byte) {
+			t.Errorf("Should not send the view change message during a view change")
+		},
+	}
+	instance := newPbftCore(1, loadConfig(), mock, []byte("GENESIS"))
+	instance.f = 1
+	instance.K = 2
+	instance.L = 4
+	instance.requestTimeout = time.Millisecond
+	instance.activeView = false
+	defer instance.close()
+
+	txTime := &gp.Timestamp{Seconds: 1, Nanos: 0}
+	tx := &pb.Transaction{Type: pb.Transaction_CHAINCODE_NEW, Timestamp: txTime}
+	txPacked, _ := proto.Marshal(tx)
+
+	req := &Request{
+		Timestamp: &gp.Timestamp{Seconds: 1, Nanos: 0},
+		Payload:   txPacked,
+		ReplicaId: 1, // Not the primary
+	}
+
+	instance.recvRequest(req)
+
+	time.Sleep(100 * time.Millisecond)
 }


### PR DESCRIPTION
Potential fix for issue #699 

This may also improve any issues associated with stressing PBFT.

When PBFT is under stress because it is receiving a large number of requests, a view change can be triggered.  As more requests come in, the request timer is reset and expires again, and again.  This artificially inflates the view timer, as each time a view change is sent, the view change timer doubles in size.  Consequently, by the time the denial of service stops, the view change timer can be very high.

The system cannot be expected to process new requests while a view change is in progress, so in addition to the negative effects on the view change timer, this timer makes no sense.  At the end of a view change, a call to process outstanding requests is made, which should start the timer then.

This changeset simply disables setting the request time when a view change is already in progress.

Passes all go tests.
No behave tests attempted as they are not currently working.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
