### PR TITLE
Update name of listenAddress property

### DIFF
--- a/main.go
+++ b/main.go
@@ -311,7 +311,7 @@ func serve(args []string) error {
 		return err
 	}
 
-	listenAddr := viper.GetString("peer.listenaddress")
+	listenAddr := viper.GetString("peer.listenAddress")
 
 	if "" == listenAddr {
 		logger.Debug("Listen address not specified, using peer endpoint address")


### PR DESCRIPTION
The listenAddress property in core.yaml was not being recognized because the code was looking for listenaddress with a lower case "a". This caused problems because I need to manually set the listen address to be a specific interface on my host and the "address" property to a different interface. There is a firewall in between two of my peers and they need to know the external address of each other, not the internal address.
