### PR TITLE
Restructuring /fabric/core/rest directory

### DIFF
--- a/core/rest/api.go
+++ b/core/rest/api.go
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package core
+package rest
 
 import (
 	"errors"

--- a/core/rest/api_test.go
+++ b/core/rest/api_test.go
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package core
+package rest
 
 import (
 	"bytes"
@@ -40,11 +40,12 @@ func TestMain(m *testing.M) {
 }
 
 func setupTestConfig() {
-	viper.SetConfigName("core") // name of config file (without extension)
-	viper.AddConfigPath("./")        // path to look for the config file in
-	viper.AddConfigPath("./..")      // path to look for the config file in
-	err := viper.ReadInConfig()      // Find and read the config file
-	if err != nil {                  // Handle errors reading the config file
+	viper.SetConfigName("core")    // name of config file (without extension)
+	viper.AddConfigPath("./")      // path to look for the config file in
+	viper.AddConfigPath("./..")    // path to look for the config file in
+	viper.AddConfigPath("./../..") // path to look for the config file in
+	err := viper.ReadInConfig()    // Find and read the config file
+	if err != nil {                // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
 	}
 }

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -38,7 +38,7 @@ import (
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 
-	oc "github.com/hyperledger/fabric/core"
+	core "github.com/hyperledger/fabric/core"
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/crypto/utils"
@@ -51,15 +51,15 @@ var restLogger = logging.MustGetLogger("rest")
 // underlying ServerOpenchain object. serverDevops is a variable that holds
 // the pointer to the underlying Devops object. This is necessary due to
 // how the gocraft/web package implements context initialization.
-var serverOpenchain *oc.ServerOpenchain
-var serverDevops *oc.Devops
+var serverOpenchain *ServerOpenchain
+var serverDevops *core.Devops
 
 // ServerOpenchainREST defines the Openchain REST service object. It exposes
 // the methods available on the ServerOpenchain service and the Devops service
 // through a REST API.
 type ServerOpenchainREST struct {
-	server *oc.ServerOpenchain
-	devops *oc.Devops
+	server *ServerOpenchain
+	devops *core.Devops
 }
 
 // restResult defines the response payload for a general REST interface request.
@@ -601,7 +601,7 @@ func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.R
 		if err != nil {
 			// Failure
 			switch err {
-			case oc.ErrNotFound:
+			case ErrNotFound:
 				rw.WriteHeader(http.StatusNotFound)
 			default:
 				rw.WriteHeader(http.StatusInternalServerError)
@@ -627,7 +627,7 @@ func (s *ServerOpenchainREST) GetTransactionByUUID(rw web.ResponseWriter, req *w
 	// Check for Error
 	if err != nil {
 		switch err {
-		case oc.ErrNotFound:
+		case ErrNotFound:
 			rw.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(rw, "{\"Error\": \"Transaction %s is not found.\"}", txUUID)
 		default:
@@ -1649,7 +1649,7 @@ func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
 
 // StartOpenchainRESTServer initializes the REST service and adds the required
 // middleware and routes.
-func StartOpenchainRESTServer(server *oc.ServerOpenchain, devops *oc.Devops) {
+func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
 	// Initialize the REST service object
 	restLogger.Info("Initializing the REST service...")
 	router := web.New(ServerOpenchainREST{})

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 
+	"github.com/hyperledger/fabric/consensus/helper"
 	"github.com/hyperledger/fabric/core"
 	"github.com/hyperledger/fabric/core/chaincode"
-	"github.com/hyperledger/fabric/consensus/helper"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger/genesis"
 	"github.com/hyperledger/fabric/core/peer"
@@ -397,7 +397,7 @@ func serve(args []string) error {
 	pb.RegisterDevopsServer(grpcServer, serverDevops)
 
 	// Register the ServerOpenchain server
-	serverOpenchain, err := core.NewOpenchainServerWithPeerInfo(peerServer)
+	serverOpenchain, err := rest.NewOpenchainServerWithPeerInfo(peerServer)
 	if err != nil {
 		err = fmt.Errorf("Error creating OpenchainServer: %s", err)
 		return err

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -36,9 +36,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
 
+	"github.com/hyperledger/fabric/consensus/helper"
 	"github.com/hyperledger/fabric/core"
 	"github.com/hyperledger/fabric/core/chaincode"
-	"github.com/hyperledger/fabric/consensus/helper"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/genesis"
@@ -66,10 +66,10 @@ func TestMain(m *testing.M) {
 func setupTestConfig() {
 	viper.AutomaticEnv()
 	viper.SetConfigName("ca_test") // name of config file (without extension)
-	viper.AddConfigPath("./")         // path to look for the config file in
-	viper.AddConfigPath("./..")       // path to look for the config file in
-	err := viper.ReadInConfig()       // Find and read the config file
-	if err != nil {                   // Handle errors reading the config file
+	viper.AddConfigPath("./")      // path to look for the config file in
+	viper.AddConfigPath("./..")    // path to look for the config file in
+	err := viper.ReadInConfig()    // Find and read the config file
+	if err != nil {                // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
 	}
 }
@@ -337,7 +337,7 @@ func startOpenchain(t *testing.T) error {
 	pb.RegisterDevopsServer(grpcServer, serverDevops)
 
 	// Register the ServerOpenchain server
-	serverOpenchain, err := core.NewOpenchainServer()
+	serverOpenchain, err := rest.NewOpenchainServer()
 	if err != nil {
 		return fmt.Errorf("Error creating OpenchainServer: %s", err)
 	}


### PR DESCRIPTION
Moving api.go and api_test.go into the /fabric/core/rest directory.

Fixes #954

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
