### PR TITLE
Make config environment variable naming consistent

### DIFF
--- a/consensus/noops/config.yaml
+++ b/consensus/noops/config.yaml
@@ -4,9 +4,9 @@
 #   NOOPS PROPERTIES
 #
 # These properties may be passed as environment variables when starting up
-# a validating peer with prefix  HYPERLEDGER_NOOPS. For example:
-#    HYPERLEDGER_NOOPS_BLOCK_SIZE=1000
-#    HYPERLEDGER_NOOPS_BLOCK_TIMEOUT=2
+# a validating peer with prefix  CORE_NOOPS. For example:
+#    CORE_NOOPS_BLOCK_SIZE=1000
+#    CORE_NOOPS_BLOCK_TIMEOUT=2
 #
 ###############################################################################
 

--- a/consensus/noops/configutil.go
+++ b/consensus/noops/configutil.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const configPrefix = "HYPERLEDGER_NOOPS"
+const configPrefix = "CORE_NOOPS"
 
 func loadConfig() (config *viper.Viper) {
 	config = viper.New()

--- a/consensus/obcpbft/obc-executor_test.go
+++ b/consensus/obcpbft/obc-executor_test.go
@@ -162,9 +162,16 @@ func TestExecutorRequestFlood(t *testing.T) {
 		BlockHash:   SimpleGetBlockHash(100),
 	}
 
-	biAsBytes, _ := proto.Marshal(bi)
-	obcex.ValidState(100, biAsBytes, nil, &ExecutionInfo{})
-	<-obcex.IdleChan()
+outer:
+	for {
+		select {
+		case <-obcex.IdleChan():
+			break outer
+		default:
+			biAsBytes, _ := proto.Marshal(bi)
+			obcex.ValidState(100, biAsBytes, nil, &ExecutionInfo{})
+		}
+	}
 
 	obcex.Execute(101, []*pb.Transaction{&pb.Transaction{}}, &ExecutionInfo{})
 

--- a/consensus/obcpbft/obc-pbft.go
+++ b/consensus/obcpbft/obc-pbft.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const configPrefix = "HYPERLEDGER_OBCPBFT"
+const configPrefix = "CORE_OBCPBFT"
 
 var pluginInstance consensus.Consenter // singleton service
 var config *viper.Viper

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -42,9 +42,9 @@ func init() {
 func TestEnvOverride(t *testing.T) {
 	config := loadConfig()
 
-	key := "general.mode"                         // for a key that exists
-	envName := "HYPERLEDGER_OBCPBFT_GENERAL_MODE" // env override name
-	overrideValue := "overide_test"               // value to override default value with
+	key := "general.mode"                  // for a key that exists
+	envName := "CORE_OBCPBFT_GENERAL_MODE" // env override name
+	overrideValue := "overide_test"        // value to override default value with
 
 	// test key
 	if ok := config.IsSet("general.mode"); !ok {

--- a/core.yaml
+++ b/core.yaml
@@ -45,7 +45,7 @@ logging:
     # commands. For commands that have subcommands, the defaults also apply to
     # all subcommands of the command. These logging levels can be overridden
     # on the command line using the --logging-level command-line option, or by
-    # setting the HYPERLEDGER_LOGGING_LEVEL environment variable.
+    # setting the CORE_LOGGING_LEVEL environment variable.
 
     # The logging level specification is of the form
 

--- a/core/crypto/crypto_test.yaml
+++ b/core/crypto/crypto_test.yaml
@@ -97,7 +97,7 @@ logging:
     # commands. For commands that have subcommands, the defaults also apply to
     # all subcommands of the command. These logging levels can be overridden
     # on the command line using the --logging-level command-line option, or by
-    # setting the HYPERLEDGER_LOGGING_LEVEL environment variable.
+    # setting the CORE_LOGGING_LEVEL environment variable.
 
     # The logging level specification is of the form
 

--- a/examples/chaincode/go/asset_management/core.yaml
+++ b/examples/chaincode/go/asset_management/core.yaml
@@ -138,7 +138,7 @@ logging:
     # commands. For commands that have subcommands, the defaults also apply to
     # all subcommands of the command. These logging levels can be overridden
     # on the command line using the --logging-level command-line option, or by
-    # setting the HYPERLEDGER_LOGGING_LEVEL environment variable.
+    # setting the CORE_LOGGING_LEVEL environment variable.
 
     # The logging level specification is of the form
 


### PR DESCRIPTION
Per comments from @jeffgarratt all environment variables should be prefixed with `CORE_` not `HYPERLEDGER_`. 

The obcpbft and noops consensus plugins had their config prefix set to `HYPERLEDGER_` which was breaking the state transfer behave test.

All go tests except for 'github.com/hyperledger/fabric/core/chaincode' pass, which periodically fails, but also periodically fails in master.

All behave tests pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
