### PR TITLE
Fixed the consensus plugin name in the comment

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -141,7 +141,7 @@ peer:
     validator:
         enabled: true
 
-        # Consensus plugin to use. The value is the name of the plugin, e.g. obcpbft, noops ( this value is case-insensitive)
+        # Consensus plugin to use. The value is the name of the plugin, e.g. pbft, noops ( this value is case-insensitive)
         # if the given value is not recognized, we will default to noops
         consensus: noops
 


### PR DESCRIPTION
obcpbft got renamed to pbft, changed comment above the setting to reflect that change.

Signed-off-by:  rhernan@us.ibm.com
