### PR TITLE
fix typo in storage attach

### DIFF
--- a/devenv/Vagrantfile
+++ b/devenv/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure('2') do |config|
             end
 
             # Add the disk to the VM
-            vb.customize ['storageattach', :id, '--storagectl', 'SATAController', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', btrfs_disk]
+            vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', btrfs_disk]
             success = true
 
             break


### PR DESCRIPTION
This fixes a typo that causes attaching a btrfs disk to fail.
