### PR TITLE
create a hook to allow mounting external directories

### DIFF
--- a/devenv/Vagrantfile
+++ b/devenv/Vagrantfile
@@ -15,6 +15,7 @@
 
 # This is the mount point for the sync_folders of the source
 SRCMOUNT = "/hyperledger"
+LOCALDEV = "/local-dev"
 
 $script = <<SCRIPT
 set -x
@@ -35,6 +36,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.synced_folder "..", "#{SRCMOUNT}"
   config.vm.synced_folder "..", "/opt/gopath/src/github.com/hyperledger/fabric"
+  config.vm.synced_folder ENV.fetch('LOCALDEVDIR', ".."), "#{LOCALDEV}"
 
   config.vm.provider :virtualbox do |vb|
     vb.name = "hyperledger"


### PR DESCRIPTION
This creates an environment hook to allow the user to mount an
external directory.  In the OBC workflow, the user could mount
an arbitrary directory into /openblockchain, however this is now
different as devenv has been merged with the fabric tree.  This
commit allows the user to add an external directory which
could have extra dev tools or test chaincode.

Signed-off-by: Joseph C Wang joequant@gmail.com
