### PR TITLE
Migrate UTXO chaincode to new API and hyperledger name

### DIFF
--- a/examples/chaincode/go/utxo/README.md
+++ b/examples/chaincode/go/utxo/README.md
@@ -20,7 +20,7 @@ cd $GOPATH/src/github.com/hyperledger/fabric/examples/chaincode/go/utxo/
 docker build -t utxo:0.1.0 .
 ```
 
-Next, modify the `core.yaml` file in the obc-peer project to point to the local Docker image that was built in the previous step. In the core.yaml file find `chaincode.golang.Dockerfile` and change it from from `golang:1.6` to `utxo:0.1.0`
+Next, modify the `core.yaml` file in the obc-peer project to point to the local Docker image that was built in the previous step. In the core.yaml file find `chaincode.golang.Dockerfile` and change it from from `openblockchain/baseimage` to `utxo:0.1.0`
 
 Start the peer using the following commands
 ```
@@ -31,7 +31,7 @@ cd $GOPATH/src/github.com/hyperledger/fabric
 In a second window, deploy the example UTXO chaincode
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric
-OPENCHAIN_PEER_ADDRESS=localhost:30303 ./obc-peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/utxo -c '{"Function":"init", "Args": []}'
+OPENCHAIN_PEER_ADDRESS=localhost:30303 ./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/utxo -c '{"Function":"init", "Args": []}'
 ```
 Wait about 30 seconds for the chaincode to be deployed. Output from the window where the peer is running will indicate that this is successful.
 
@@ -54,7 +54,7 @@ go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 
 Using the Docker image that we just built, start a peer within a container in `chaincodedev` mode.
 ```
-docker run -it -p 30303:30303 openchain-peer peer peer --peer-chaincodedev
+docker run -it -p 30303:30303 hyperledger-peer fabric peer --peer-chaincodedev
 ```
 
 
@@ -67,13 +67,13 @@ Build the UTXO chaincode.
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric/examples/chaincode/go/utxo/
 go build
-OPENCHAIN_PEER_ADDRESS=172.17.0.2:30303 OPENCHAIN_CHAINCODE_ID_NAME=utxo ./utxo
+CORE_PEER_ADDRESS=172.17.0.2:30303 CORE_CHAINCODE_ID_NAME=utxo ./utxo
 ```
 
 In another window, deploy the chaincode
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric/
-./obc-peer chaincode deploy -n utxo -c '{"Function":"init", "Args": []}'
+./peer chaincode deploy -n utxo -c '{"Function":"init", "Args": []}'
 ```
 
 The chaincode is now deployed and ready to accept transactions.

--- a/examples/chaincode/go/utxo/chaincode.go
+++ b/examples/chaincode/go/utxo/chaincode.go
@@ -22,8 +22,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hyperledger/fabric/examples/chaincode/go/utxo/util"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/examples/chaincode/go/utxo/util"
 )
 
 // The UTXO example chaincode contains a single invocation function named execute. This function accepts BASE64
@@ -37,13 +37,15 @@ import (
 type SimpleChaincode struct {
 }
 
-// Run callback representing the invocation of a chaincode
-func (t *SimpleChaincode) Run(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+// Init does nothing in the UTXO chaincode
+func (t *SimpleChaincode) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	return nil, nil
+}
+
+// Invoke callback representing the invocation of a chaincode
+func (t *SimpleChaincode) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
 
 	switch function {
-
-	case "init":
-		// Do nothing
 
 	case "execute":
 		utxo := util.MakeUTXO(MakeChaincodeStore(stub))
@@ -75,7 +77,6 @@ func (t *SimpleChaincode) Run(stub *shim.ChaincodeStub, function string, args []
 		return nil, errors.New("Unsupported operation")
 	}
 
-	return nil, nil
 }
 
 // Query callback representing the query of a chaincode


### PR DESCRIPTION
This makes changes to
1. The UTXO chaincode to support the new API
2. The UTXO chaincode README so that the instructions match the new hyperledger name

@noamher With these fixes, I was able to deploy the UTXO chaincode.
