### PR TITLE
Added target node to list of peers returned by /network/peers

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -12,6 +12,20 @@ Feature: lanching 3 peers
     As a HyperLedger developer
     I want to be able to launch a 3 peers
 
+#    @wip
+  Scenario: Peers list test, single peer issue #827
+    Given we compose "docker-compose-1.yml"
+      And I wait "1" seconds
+      When requesting "/network/peers" from "vp0"
+      Then I should get a JSON response with array "peers" contains "1" elements
+
+#    @wip
+  Scenario: Peers list test,3 peers issue #827
+    Given we compose "docker-compose-3.yml"
+      And I wait "1" seconds
+      When requesting "/network/peers" from "vp0"
+      Then I should get a JSON response with array "peers" contains "3" elements
+
 #    @doNotDecompose
     @wip
    @issue_767

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -114,6 +114,12 @@ def step_impl(context, attribute, expectedValue):
     foundValue = context.response.json()[attribute]
     assert (str(foundValue) == expectedValue), "For attribute %s, expected (%s), instead found (%s)" % (attribute, expectedValue, foundValue)
 
+@then(u'I should get a JSON response with array "{attribute}" contains "{expectedValue}" elements')
+def step_impl(context, attribute, expectedValue):
+    assert attribute in context.response.json(), "Attribute not found in response (%s)" %(attribute)
+    foundValue = context.response.json()[attribute]
+    assert (len(foundValue) == int(expectedValue)), "For attribute %s, expected array of size (%s), instead found (%s)" % (attribute, expectedValue, len(foundValue))
+
 
 @given(u'I wait "{seconds}" seconds')
 def step_impl(context, seconds):

--- a/core/rest/api.go
+++ b/core/rest/api.go
@@ -37,9 +37,10 @@ var (
 	ErrNotFound = errors.New("openchain: resource not found")
 )
 
-// PeerInfo
+// PeerInfo defines API to peer info data
 type PeerInfo interface {
 	GetPeers() (*pb.PeersMessage, error)
+	GetPeerEndpoint() (*pb.PeerEndpoint, error)
 }
 
 // ServerOpenchain defines the Openchain server object, which holds the
@@ -161,4 +162,16 @@ func (s *ServerOpenchain) GetTransactionByUUID(ctx context.Context, txUUID strin
 // GetPeers returns a list of all peer nodes currently connected to the target peer.
 func (s *ServerOpenchain) GetPeers(ctx context.Context, e *google_protobuf1.Empty) (*pb.PeersMessage, error) {
 	return s.peerInfo.GetPeers()
+}
+
+// GetPeerEndpoint returns PeerEndpoint info of target peer.
+func (s *ServerOpenchain) GetPeerEndpoint(ctx context.Context, e *google_protobuf1.Empty) (*pb.PeersMessage, error) {
+	peers := []*pb.PeerEndpoint{}
+	peerEndpoint, err := s.peerInfo.GetPeerEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	peers = append(peers, peerEndpoint)
+	peersMessage := &pb.PeersMessage{Peers: peers}
+	return peersMessage, nil
 }

--- a/core/rest/api_test.go
+++ b/core/rest/api_test.go
@@ -71,6 +71,12 @@ func (p *peerInfo) GetPeers() (*protos.PeersMessage, error) {
 	return peersMessage, nil
 }
 
+func (p *peerInfo) GetPeerEndpoint() (*protos.PeerEndpoint, error) {
+	pe := &protos.PeerEndpoint{ID: &protos.PeerID{Name: viper.GetString("peer.id")}, Address: "localhost:30303", Type: protos.PeerEndpoint_VALIDATOR}
+	return pe, nil
+}
+
+
 func TestServerOpenchain_API_GetBlockchainInfo(t *testing.T) {
 	// Construct a ledger with 0 blocks.
 	ledger := ledger.InitTestLedger(t)


### PR DESCRIPTION
In some cases target node for rest call /network/peers not returned in list of peers - see issue #827. This change fix this.
