### PR TITLE
Fix for issue #920

### DIFF
--- a/consensus/obcpbft/obc-executor.go
+++ b/consensus/obcpbft/obc-executor.go
@@ -279,8 +279,9 @@ func (obcex *obcExecutor) queueThread() {
 
 		var err error
 		var id *BlockInfo
-		var seqNo uint64
 		var sync bool
+
+		seqNo := transaction.seqNo
 
 		if nil == transaction.execInfo {
 			transaction.execInfo = &ExecutionInfo{}
@@ -293,7 +294,6 @@ func (obcex *obcExecutor) queueThread() {
 			logger.Info("%v executor queue apparently has a gap in it, initiating state transfer", obcex.id)
 			sync = true
 		case execInfo.Null:
-			seqNo = transaction.seqNo
 			id, err = obcex.getCurrentInfo()
 			if nil != err {
 				logger.Critical("Requested to send a checkpoint for a Null request, but could not create one: %v", err)

--- a/consensus/obcpbft/obc-executor.go
+++ b/consensus/obcpbft/obc-executor.go
@@ -149,7 +149,7 @@ func (obcex *obcExecutor) Execute(seqNo uint64, txs []*pb.Transaction, execInfo 
 	case obcex.executionQueue <- request:
 		logger.Debug("%v queued request for sequence number %d", obcex.id, seqNo)
 	default:
-		logger.Error("%v error queueing request (queue full) for sequence number %d", obcex.id, seqNo)
+		logger.Warning("%v error queueing request (queue full) for sequence number %d", obcex.id, seqNo)
 		obcex.drainExecutionQueue()
 		obcex.executionQueue <- &transaction{
 			seqNo: seqNo,

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -748,10 +748,10 @@ func (instance *pbftCore) Checkpoint(seqNo uint64, id []byte) {
 	idAsString := base64.StdEncoding.EncodeToString(id)
 
 	logger.Debug("Replica %d preparing checkpoint for view=%d/seqNo=%d and b64 id of %s",
-		instance.id, instance.view, instance.lastExec, idAsString)
+		instance.id, instance.view, seqNo, idAsString)
 
 	chkpt := &Checkpoint{
-		SequenceNumber: instance.lastExec,
+		SequenceNumber: seqNo,
 		ReplicaId:      instance.id,
 		Id:             idAsString,
 	}


### PR DESCRIPTION
This is designed to address issue #920, but likely also fixes #917, #793, and #699 

There was a bug that was introduced when splitting out the executor service.  PBFT would send its checkpoints based on the last executed sequence number.  This assumption used to be correct when executions were synchronous, but no longer.  Under low load environments, typically this problem would never be observed, but when message processing begins to occur faster than executions, the problem occurs.

This changeset causes checkpoints to use the sequence number provided by the executor, not the one stored internally by pbft and fixes some sequence number accounting that was incorrect in the executor.

This changeset also reduces the severity of the queue full message to warning.

Passes all go tests.
Passes all behave tests.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
