### PR TITLE
Increase bddtest query timeout to 30; Fixes issue 1080

### DIFF
--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -402,7 +402,7 @@ def step_impl(context, chaincodeName, functionName, value):
         print("Container {0} enrollID = {1}".format(container.containerName, container.getEnv("CORE_SECURITY_ENROLLID")))
         request_url = buildUrl(context, container.ipAddress, "/devops/{0}".format(functionName))
         print("POSTing path = {0}".format(request_url))
-        resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeInvocationSpec), timeout=3, verify=False)
+        resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeInvocationSpec), timeout=30, verify=False)
         assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
         print("RESULT from {0} of chaincode from peer {1}".format(functionName, container.containerName))
         print(json.dumps(resp.json(), indent = 4))


### PR DESCRIPTION
@gongsu832 and I were seeing lots of timeouts while running queries during bddtests. See #1080. Simply increasing the timeout from "3" to "30" fixes these errors (I tried "10" - didn't work). This change does not increase the time required to run the bddtest suite from inside Vagrant.

Speaking for myself, I was seeing these issues in a standalone (non-Vagrant) system. I'm running on a beefy X86 server, and the bddtest suits takes about 4x the time required within Vagrant for some reason. So there may be some other issue at play, but this change seems to do no harm inside Vagrant, and seems to be required outside.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
