### PR TITLE
Let chaincodeInstallPath read from config

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -113,7 +113,10 @@ func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEn
 	s.ccStartupTimeout = ccstartuptimeout * time.Millisecond
 
 	//TODO I'm not sure if this needs to be on a per chain basis... too lowel and just needs to be a global default ?
-	s.chaincodeInstallPath = chaincodeInstallPathDefault
+	s.chaincodeInstallPath = viper.GetString("chaincode.installpath")
+	if s.chaincodeInstallPath == "" {
+		s.chaincodeInstallPath = chaincodeInstallPathDefault
+	}
 
 	return s
 }


### PR DESCRIPTION
Currently the chaincodeInstallPath directly uses the default hard-coded value. 

Add code to try reading it from config first.

This closes #1102.

Signed-off-by: Baohua Yang baohyang@cn.ibm.com
