### PR TITLE
Fix deprecated DOCKER_OPTS

### DIFF
--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -70,7 +70,7 @@ esac
 apt-get install -y linux-image-extra-$(uname -r) apparmor docker-engine
 
 # Configure docker
-echo "DOCKER_OPTS=\"-s=${DOCKER_STORAGE_BACKEND_STRING} -r=true --api-enable-cors=true -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock ${DOCKER_OPTS}\"" > /etc/default/docker
+echo "DOCKER_OPTS=\"-s=${DOCKER_STORAGE_BACKEND_STRING} -r=true --api-cors-header='*' -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock ${DOCKER_OPTS}\"" > /etc/default/docker
 
 curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
The option `--api-enable-cors=true` was deprecated at Docker 1.9+.

Use `--api-cors-header='*'` instead as recommended style.

Signed-off-by: Baohua Yang baohyang@cn.ibm.com
