### PR TITLE
Fix view change deadlock, caused by confusion of S and S prime

### DIFF
--- a/consensus/obcpbft/obc-executor.go
+++ b/consensus/obcpbft/obc-executor.go
@@ -320,7 +320,9 @@ func (obcex *obcExecutor) queueThread() {
 		if execInfo.Checkpoint {
 			idAsBytes, _ := obcex.createID(id)
 			logger.Debug("%v sending checkpoint: %x", obcex.id, idAsBytes)
-			obcex.orderer.Checkpoint(seqNo, idAsBytes)
+			go func() {
+				obcex.orderer.Checkpoint(seqNo, idAsBytes)
+			}()
 		}
 	}
 }

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -755,7 +755,7 @@ func (instance *pbftCore) Checkpoint(seqNo uint64, id []byte) {
 		ReplicaId:      instance.id,
 		Id:             idAsString,
 	}
-	instance.chkpts[instance.lastExec] = idAsString
+	instance.chkpts[seqNo] = idAsString
 
 	instance.innerBroadcast(&Message{&Message_Checkpoint{chkpt}}, true)
 }
@@ -938,6 +938,7 @@ func (instance *pbftCore) witnessCheckpointWeakCert(chkpt *Checkpoint) {
 		instance.skipInProgress = false
 		instance.moveWatermarks(chkpt.SequenceNumber)
 		instance.lastExec = chkpt.SequenceNumber
+		instance.activeView = true // TODO, verify this with experts
 		instance.consumer.skipTo(chkpt.SequenceNumber, snapshotID, checkpointMembers, &ExecutionInfo{Checkpoint: true})
 	} else {
 		logger.Debug("Replica %d witnessed a weak certificate for checkpoint %d, weak cert attested to by %d of %d (%v)",

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -42,9 +42,9 @@ func init() {
 func TestEnvOverride(t *testing.T) {
 	config := loadConfig()
 
-	key := "general.mode"                  // for a key that exists
+	key := "general.mode"               // for a key that exists
 	envName := "CORE_PBFT_GENERAL_MODE" // env override name
-	overrideValue := "overide_test"        // value to override default value with
+	overrideValue := "overide_test"     // value to override default value with
 
 	// test key
 	if ok := config.IsSet("general.mode"); !ok {
@@ -371,6 +371,61 @@ func TestInconsistentPrePrepare(t *testing.T) {
 			t.Errorf("Expected no execution")
 			continue
 		}
+	}
+}
+
+// This test is designed to detect a conflation of S and S' from the paper in the view change
+func TestViewChangeCheckpointSelection(t *testing.T) {
+	instance := &pbftCore{
+		f:  1,
+		N:  4,
+		id: 0,
+	}
+
+	vset := make([]*ViewChange, 3)
+
+	// Replica 0 sent checkpoints for 5
+	vset[0] = &ViewChange{
+		H: 5,
+		Cset: []*ViewChange_C{
+			&ViewChange_C{
+				SequenceNumber: 10,
+				Id:             "ten",
+			},
+		},
+	}
+
+	// Replica 1 sent checkpoints for 5
+	vset[1] = &ViewChange{
+		H: 5,
+		Cset: []*ViewChange_C{
+			&ViewChange_C{
+				SequenceNumber: 10,
+				Id:             "ten",
+			},
+		},
+	}
+
+	// Replica 2 sent checkpoints for 15
+	vset[2] = &ViewChange{
+		H: 10,
+		Cset: []*ViewChange_C{
+			&ViewChange_C{
+				SequenceNumber: 15,
+				Id:             "fifteen",
+			},
+		},
+	}
+
+	checkpoint, ok, _ := instance.selectInitialCheckpoint(vset)
+
+	if !ok {
+		t.Fatalf("Failed to pick correct a checkpoint for view change")
+	}
+
+	expected := uint64(10)
+	if checkpoint.SequenceNumber != expected {
+		t.Fatalf("Expected to pick checkpoint %d, but picked %d", expected, checkpoint.SequenceNumber)
 	}
 }
 


### PR DESCRIPTION
In the view change code, the matching checkpoint sets S' was being used instead of the view change set S.

Because of this, view change was requiring 2f+1 low watermarks at or below the sequence number within the checkpoint set, when this needs to be considered over the whole view change set.  This could lead to a scenario where view change never completes, and the network locks up, view changing indefinitely.

This changeset fixes this behavior, and includes a test which verifies its correctness.

It also includes a fix for another observed deadlock in which the executor thread attempts to deliver a checkpoint while the pbft message thread attempts to initiate state transfer.

Finally, this changeset also causes the 'fall behind' recovery to mark the current view as active.  The correctness fo this should be verified with PBFT protocol experts, and it is flagged as such in the code, but otherwise could cause a replica to fail to rejoin a network if its view change timer expires before realizing it is behind.

All of these fixes have been verified to help address the stress related problems observed in #920, #917, #793, and #699 

Passes all go tests.
Passes all behave tests.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
