### PR TITLE
An id field in JSON-RPC request: allow to be both string or numeric

### DIFF
--- a/core/rest/rest_util.go
+++ b/core/rest/rest_util.go
@@ -44,7 +44,7 @@ func formatRPCOK(msg string) rpcResult {
 
 // formatRPCResponse consumes either an RPC ERROR or OK rpcResult and formats it
 // in accordance with the JSON RPC 2.0 specification.
-func formatRPCResponse(res rpcResult, id *int64) rpcResponse {
+func formatRPCResponse(res rpcResult, id *rpcID) rpcResponse {
 	var response rpcResponse
 
 	// Format a successful response


### PR DESCRIPTION
As for JSON-RPC spec **id** field in a request may be a string:

```
An identifier established by the Client that MUST contain a String, Number, or NULL value if included.
```

and some clients actually do send strings as IDs. This patch allows to unmarshal both int64 and string IDs. What do you think about it?

Signed-off-by: Maksim Zhylinski maksim.zhylinski@altoros.com
