### PR TITLE
Implement issue #1119

### DIFF
--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -25,9 +25,11 @@ general:
     # overall throughput in normal case operation.
     K: 10
 
-   # Affects the log size which is K * logmultiplier
-   # For high volume/high latency environments, a higher log size may increase throughput
-    logmultiplier: 2
+    # Affects the receive log size which is K * logmultiplier
+    # The primary will only send sequence numbers which fall within K * logmultiplier/2 of
+    # its high watermark, so this cannot be set to less than 2
+    # For high volume/high latency environments, a higher log size may increase throughput
+    logmultiplier: 4
 
     # How many requests should the primary send per pre-prepare when in "batch" mode
     batchsize: 2


### PR DESCRIPTION
This is a simple implementation of the enhancement suggested in #1119 

In short, view changes were unnecessarily occurring because of network ordering guarantees that are assumed in the PBFT paper, but which are not present in reality.  Although the absence of these guarantees does not affect the 'correctness' it has been observed to decrease the throughput.

This changeset increases the default log multiplier from 2, to 4.  Simultaneously, it reduces the sequence number at which the primary will pause sending requests from the high water mark `H = h + logMultiplier * K` to `H = h + logMultiplier * K / 2`.  This has the effect of in a sense keeping our 'send buffer' the same size, but doubling our 'receive buffer'.  In high volume testing, this has been shown to reduce the incidence of unnecessary view changes and increase the throughput of the network.

A test case is included to confirm the new primary request sending behavior.

If there are objections from @kchristidis @corecode or @tuand27613 I'd be open to making this configurable, but there was not an obvious way to make the configuration expressive (Is it a multiple of the checkpoint interval? Is it an absolute value?) and the potential for mis-configuring things in a way that would break seemed high.

This changeset also forces the `logMultiplier` to be at least 2, otherwise things would break.

All behave tests pass.
All go tests pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
