### PR TITLE
Two tests need longer timeouts to pass

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -473,7 +473,7 @@ Feature: lanching 3 peers
                     |arg1|arg2|arg3|
                     | b  | a  | 1  |
 	        Then I should have received a transactionID
-	        Then I wait up to "10" seconds for transaction to be committed to peers:
+	        Then I wait up to "15" seconds for transaction to be committed to peers:
                     | vp0  | vp1 | vp2 | vp3 |
 
             When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -744,7 +744,7 @@ Feature: lanching 3 peers
               |arg1|arg2|arg3|
               | a  | b  | 1  |
           Then I should have received a transactionID
-          Then I wait up to "5" seconds for transaction to be committed to peers:
+          Then I wait up to "15" seconds for transaction to be committed to peers:
               | vp0  | vp1 | vp2 |
 
          When I query chaincode "example2" function name "query" with value "a" on peers:


### PR DESCRIPTION
Small update to increase timeouts on two behave tests which do not pass consistently on my system with current timeouts.

Signed-off-by: sheehan@us.ibm.com
