### PR TITLE
Fix main cmd name to fabric

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ const undefinedParamValue = ""
 // The main command describes the service and
 // defaults to printing the help message.
 var mainCmd = &cobra.Command{
-	Use: "peer",
+	Use: "fabric",
 }
 
 var peerCmd = &cobra.Command{


### PR DESCRIPTION
The old name peer does not match current executable name.

Signed-off-by: Baohua Yang baohyang@cn.ibm.com
