### PR TITLE
Added missing Chaincode name for the deploy api

### DIFF
--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -201,7 +201,7 @@ POST host:port/chaincode
   "params": {
       "type": 1,
       "chaincodeID":{
-          "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
+          "name":"mycc"
       },
       "ctorMsg": {
          "function":"invoke",
@@ -238,7 +238,7 @@ POST host:port/chaincode
   "params": {
       "type": 1,
       "chaincodeID":{
-          "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
+          "name":"mycc"
       },
       "ctorMsg": {
          "function":"invoke",
@@ -281,7 +281,7 @@ POST host:port/chaincode
   "params": {
       "type": 1,
       "chaincodeID":{
-          "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
+          "name":"mycc"
       },
       "ctorMsg": {
          "function":"query",
@@ -318,7 +318,7 @@ POST host:port/chaincode
   "params": {
       "type": 1,
       "chaincodeID":{
-          "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
+          "name":"mycc"
       },
       "ctorMsg": {
          "function":"query",

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -127,7 +127,6 @@ POST host:port/chaincode
   "params": {
     "type": 1,
     "chaincodeID":{
-        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02",
         "name": "mycc"
     },
     "ctorMsg": {
@@ -145,7 +144,7 @@ POST host:port/chaincode
     "jsonrpc": "2.0",
     "result": {
         "status": "OK",
-        "message": "52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
+        "message": "mycc"
     },
     "id": 1
 }
@@ -165,7 +164,6 @@ POST host:port/chaincode
   "params": {
     "type": 1,
     "chaincodeID":{
-        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02",
         "name": "mycc"
     },
     "ctorMsg": {
@@ -298,7 +296,7 @@ POST host:port/chaincode
     "jsonrpc": "2.0",
     "result": {
         "status": "OK",
-        "message": "70"
+        "message": "90"
     },
     "id": 5
 }

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -127,7 +127,8 @@ POST host:port/chaincode
   "params": {
     "type": 1,
     "chaincodeID":{
-        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
+        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02",
+        "name": "mycc"
     },
     "ctorMsg": {
         "function":"init",

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -165,7 +165,8 @@ POST host:port/chaincode
   "params": {
     "type": 1,
     "chaincodeID":{
-        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
+        "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02",
+        "name": "mycc"
     },
     "ctorMsg": {
         "function":"init",


### PR DESCRIPTION
Without the `name` attribute deploy API fails with https://github.com/hyperledger/fabric/blob/95d2b1ac230bc5abffa12929315053a5e1df04fa/core/rest/rest_api.go#L695
