### PR TITLE
Fix viewchange watermark movement

### DIFF
--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -300,8 +300,11 @@ func (instance *pbftCore) processNewView() error {
 	}
 
 	if instance.h < cp.SequenceNumber {
-		logger.Warning("Replica %d missing base checkpoint %d (%x)", instance.id, cp.SequenceNumber, cp.Id)
 		instance.moveWatermarks(cp.SequenceNumber)
+	}
+
+	if instance.lastExec < cp.SequenceNumber {
+		logger.Warning("Replica %d missing base checkpoint %d (%s)", instance.id, cp.SequenceNumber, cp.Id)
 
 		snapshotID, err := base64.StdEncoding.DecodeString(cp.Id)
 		if nil != err {
@@ -404,7 +407,7 @@ func (instance *pbftCore) selectInitialCheckpoint(vset []*ViewChange) (checkpoin
 	for _, vc := range vset {
 		for _, c := range vc.Cset { // TODO, verify that we strip duplicate checkpoints from this set
 			checkpoints[*c] = append(checkpoints[*c], vc)
-			logger.Debug("Replica %d appending checkpoint with sequence number %d, and checkpoint digest %s", instance.id, c.SequenceNumber, c.Id)
+			logger.Debug("Replica %d appending checkpoint from replica %d with seqNo=%d, h=%d, and checkpoint digest %s", instance.id, vc.ReplicaId, vc.H, c.SequenceNumber, c.Id)
 		}
 	}
 


### PR DESCRIPTION
The previous code was checking the low watermark against the selected checkpoint, and if they differed, would move the watermarks, reset its `lastExec` and kick off state transfer.

If the replica had already processed beyond this point, but had not yet seen a stable checkpoint to move its watermarks, then its `lastExec` was lowered, causing it to re-execute transactions which had already occurred, and state transfer was requested, even though it was unnecessary.

This changeset corrects this behavior by moving the watermarks based on the checkpoint, but not necessarily performing state transfer or resetting `lastExec`.  Then, based on `lastExec` the view change determines whether state transfer is needed, and only then modified `lastExec`.

Included is a changeset which tests for this behavior.  It also tests for the inverse bad behavior (of moving the watermarks based on the `lastExec` rather than the checkpoint).

@kchristidis Could you review this logic?

All go tests pass.
All behave tests pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
