### PR TITLE
System Chaincode Implementation -  v2

### DIFF
--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/container"
 	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/system_chaincode"
 	"github.com/hyperledger/fabric/core/util"
 	pb "github.com/hyperledger/fabric/protos"
 	"github.com/spf13/viper"
@@ -159,14 +160,14 @@ func TestExecuteDeployTransaction(t *testing.T) {
 	_, err = deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
-		GetChain(DefaultChain).StopChaincode(ctxt, spec.ChaincodeID)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec)
 		closeListenerAndSleep(lis)
 		t.Fail()
 		t.Logf("Error deploying <%s>: %s", chaincodeID, err)
 		return
 	}
 
-	GetChain(DefaultChain).StopChaincode(ctxt, spec.ChaincodeID)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec)
 	closeListenerAndSleep(lis)
 }
 
@@ -296,7 +297,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 		t.Logf("Invoke test passed")
 	}
 
-	GetChain(DefaultChain).StopChaincode(ctxt, chaincodeID)
+	GetChain(DefaultChain).StopChaincode(ctxt, &pb.ChaincodeSpec{ChaincodeID: chaincodeID})
 
 	closeListenerAndSleep(lis)
 }
@@ -394,7 +395,7 @@ func TestExecuteQuery(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -425,7 +426,7 @@ func TestExecuteQuery(t *testing.T) {
 	//end := getNowMillis()
 	//fmt.Fprintf(os.Stderr, "Ending: %d\n", end)
 	//fmt.Fprintf(os.Stderr, "Elapsed : %d millis\n", end-start)
-	GetChain(DefaultChain).StopChaincode(ctxt, cID)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec)
 	closeListenerAndSleep(lis)
 }
 
@@ -476,7 +477,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 		errStr := err.Error()
 		t.Logf("Got error %s\n", errStr)
 		t.Logf("InvalidInvoke test passed")
-		GetChain(DefaultChain).StopChaincode(ctxt, chaincodeID)
+		GetChain(DefaultChain).StopChaincode(ctxt, &pb.ChaincodeSpec{ChaincodeID:chaincodeID})
 
 		closeListenerAndSleep(lis)
 		return
@@ -485,7 +486,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 	t.Fail()
 	t.Logf("Error invoking transaction %s", err)
 
-	GetChain(DefaultChain).StopChaincode(ctxt, chaincodeID)
+	GetChain(DefaultChain).StopChaincode(ctxt, &pb.ChaincodeSpec{ChaincodeID:chaincodeID})
 
 	closeListenerAndSleep(lis)
 }
@@ -538,7 +539,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -557,7 +558,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 		t.Logf("This query should not have succeeded as it attempts to put state")
 	}
 
-	GetChain(DefaultChain).StopChaincode(ctxt, cID)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec)
 	closeListenerAndSleep(lis)
 }
 
@@ -610,7 +611,7 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -631,8 +632,8 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -651,8 +652,8 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -662,14 +663,14 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-	GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 	closeListenerAndSleep(lis)
 }
 
@@ -722,7 +723,7 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -743,8 +744,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -764,8 +765,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -775,8 +776,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil || result != 300 {
 		t.Fail()
 		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -793,8 +794,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error querying <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -804,17 +805,72 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil || result != 300 {
 		t.Fail()
 		t.Logf("Incorrect final value after query for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-		GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+		GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).StopChaincode(ctxt, cID1)
-	GetChain(DefaultChain).StopChaincode(ctxt, cID2)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec1)
+	GetChain(DefaultChain).StopChaincode(ctxt, spec2)
 	closeListenerAndSleep(lis)
 }
 
+// Test deploy of a transaction.
+func TestExecuteDeploySysChaincode(t *testing.T) {
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			grpclog.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	//lis, err := net.Listen("tcp", viper.GetString("peer.address"))
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:40303"
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		t.Fail()
+		t.Logf("Error starting peer listener %s", err)
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
+
+	go grpcServer.Serve(lis)
+
+	var ctxt = context.Background()
+
+	system_chaincode.RegisterSysCCs()
+
+	url := "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
+	f := "init"
+	args := []string{"greeting", "hello world"}
+	spec := &pb.ChaincodeSpec{Type: 2, ChaincodeID: &pb.ChaincodeID{Path: url}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	_, err = deploy(ctxt, spec)
+	chaincodeID := spec.ChaincodeID.Name
+	if err != nil {
+		GetChain(DefaultChain).StopChaincode(ctxt, spec)
+		closeListenerAndSleep(lis)
+		t.Fail()
+		t.Logf("Error deploying <%s>: %s", chaincodeID, err)
+		return
+	}
+
+	GetChain(DefaultChain).StopChaincode(ctxt, spec)
+	closeListenerAndSleep(lis)
+}
 func TestMain(m *testing.M) {
 	SetupTestConfig()
 	viper.Set("ledger.blockchain.deploy-system-chaincode", "false")

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -91,8 +91,37 @@ func Start(cc Chaincode) error {
 
 	chaincodeSupportClient := pb.NewChaincodeSupportClient(clientConn)
 
-	err = chatWithPeer(chaincodeSupportClient, cc)
+	// Establish stream with validating peer
+	stream, err := chaincodeSupportClient.Register(context.Background())
+	if err != nil {
+		return fmt.Errorf("Error chatting with leader at address=%s:  %s", getPeerAddress(), err)
+	}
 
+	chaincodename := viper.GetString("chaincode.id.name")
+	err = chatWithPeer(chaincodename, stream, cc)
+
+	return err
+}
+
+// StartInProc entry point for system chaincodes bootstrap.
+func StartInProc(env []string, args []string, cc Chaincode, recv <-chan *pb.ChaincodeMessage, send chan<- *pb.ChaincodeMessage) error {
+	logging.SetLevel(logging.DEBUG, "chaincode")
+	chaincodeLogger.Debug("in proc %v", args)
+
+	var chaincodename string
+	for _, v := range env {
+		if strings.Index(v, "CORE_CHAINCODE_ID_NAME=") == 0 {
+			p := strings.SplitAfter(v, "CORE_CHAINCODE_ID_NAME=")
+			chaincodename = p[1]
+			break
+		}
+	}
+	if chaincodename == "" {
+		return fmt.Errorf("Error chaincode id not provided")
+	}
+	chaincodeLogger.Debug("starting chat with peer using name=%s", chaincodename)
+	stream := newInProcStream(recv, send)
+	err := chatWithPeer(chaincodename, stream, cc)
 	return err
 }
 
@@ -138,25 +167,14 @@ func newPeerClientConnection() (*grpc.ClientConn, error) {
 	return conn, err
 }
 
-func chatWithPeer(chaincodeSupportClient pb.ChaincodeSupportClient, cc Chaincode) error {
-
-	// Establish stream with validating peer
-	stream, err := chaincodeSupportClient.Register(context.Background())
-	if err != nil {
-		return fmt.Errorf("Error chatting with leader at address=%s:  %s", getPeerAddress(), err)
-	}
-
-	// Create the chaincode stub which will be passed to the chaincode
-	//stub := &ChaincodeStub{}
+func chatWithPeer(chaincodename string, stream PeerChaincodeStream, cc Chaincode) error {
 
 	// Create the shim handler responsible for all control logic
-	handler = newChaincodeHandler(getPeerAddress(), stream, cc)
+	handler = newChaincodeHandler(stream, cc)
 
 	defer stream.CloseSend()
 	// Send the ChaincodeID during register.
-	chaincodeID := &pb.ChaincodeID{Name: viper.GetString("chaincode.id.name")}
-	chaincodeLogger.Debug("Chaincode ID: %s", viper.GetString("chaincode.id.name"))
-
+	chaincodeID := &pb.ChaincodeID{Name: chaincodename}
 	payload, err := proto.Marshal(chaincodeID)
 	if err != nil {
 		return fmt.Errorf("Error marshalling chaincodeID during chaincode registration: %s", err)
@@ -235,6 +253,7 @@ func (stub *ChaincodeStub) init(uuid string, secContext *pb.ChaincodeSecurityCon
 //CHAINCODE SEC INTERFACE FUNCS TOBE IMPLEMENTED BY ANGELO
 
 // ------------- Call Chaincode functions ---------------
+
 // InvokeChaincode function can be invoked by a chaincode to execute another chaincode.
 func (stub *ChaincodeStub) InvokeChaincode(chaincodeName string, function string, args []string) ([]byte, error) {
 	return handler.handleInvokeChaincode(chaincodeName, function, args, stub.UUID)
@@ -246,6 +265,7 @@ func (stub *ChaincodeStub) QueryChaincode(chaincodeName string, function string,
 }
 
 // --------- State functions ----------
+
 // GetState function can be invoked by a chaincode to get a state from the ledger.
 func (stub *ChaincodeStub) GetState(key string) ([]byte, error) {
 	return handler.handleGetState(key, stub.UUID)

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -25,14 +25,15 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/looplab/fsm"
 	pb "github.com/hyperledger/fabric/protos"
+	"github.com/looplab/fsm"
 )
 
 // PeerChaincodeStream interface for stream between Peer and chaincode instance.
 type PeerChaincodeStream interface {
 	Send(*pb.ChaincodeMessage) error
 	Recv() (*pb.ChaincodeMessage, error)
+	CloseSend() error
 }
 
 type nextStateInfo struct {
@@ -140,9 +141,8 @@ func (handler *Handler) deleteIsTransaction(uuid string) {
 }
 
 // NewChaincodeHandler returns a new instance of the shim side handler.
-func newChaincodeHandler(to string, peerChatStream PeerChaincodeStream, chaincode Chaincode) *Handler {
+func newChaincodeHandler(peerChatStream PeerChaincodeStream, chaincode Chaincode) *Handler {
 	v := &Handler{
-		To:         to,
 		ChatStream: peerChatStream,
 		cc:         chaincode,
 	}

--- a/core/chaincode/shim/inprocstream.go
+++ b/core/chaincode/shim/inprocstream.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package shim
+
+import (
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+// PeerChaincodeStream interface for stream between Peer and chaincode instance.
+type inProcStream struct {
+	recv <-chan *pb.ChaincodeMessage
+	send chan<- *pb.ChaincodeMessage
+}
+
+func newInProcStream(recv <-chan *pb.ChaincodeMessage, send chan<- *pb.ChaincodeMessage) *inProcStream {
+	return &inProcStream{recv, send}
+}
+
+func (s *inProcStream) Send(msg *pb.ChaincodeMessage) error {
+	s.send <- msg
+	return nil
+}
+
+func (s *inProcStream) Recv() (*pb.ChaincodeMessage, error) {
+	msg := <-s.recv
+	return msg, nil
+}
+
+func (s *inProcStream) CloseSend() error {
+	return nil
+}

--- a/core/container/ccintf/ccintf.go
+++ b/core/container/ccintf/ccintf.go
@@ -1,0 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package ccintf
+
+//This package defines the interfaces that support runtime and
+//communication between chaincode and peer (chaincode support).
+//Currently inproccontroller uses it. dockercontroller does not.
+
+import (
+	pb "github.com/hyperledger/fabric/protos"
+	"golang.org/x/net/context"
+)
+
+// ChaincodeStream interface for stream between Peer and chaincode instance.
+type ChaincodeStream interface {
+	Send(*pb.ChaincodeMessage) error
+	Recv() (*pb.ChaincodeMessage, error)
+}
+
+// CCSupport must be implemented by the chaincode support side in peer
+// (such as chaincode_support)
+type CCSupport interface {
+	HandleChaincodeStream(context.Context, ChaincodeStream) error
+}
+
+// GetCCHandlerKey is used to pass CCSupport via context
+func GetCCHandlerKey() string {
+	return "CCHANDLER"
+}
+
+//CCID encapsulates chaincode ID
+type CCID struct {
+	ChaincodeSpec *pb.ChaincodeSpec
+	NetworkID     string
+	PeerID        string
+}

--- a/core/container/config.go
+++ b/core/container/config.go
@@ -58,7 +58,7 @@ func SetupTestConfig() {
 	flag.Parse()
 
 	// Now set the configuration file
-	viper.SetEnvPrefix("HYPERLEDGER")
+	viper.SetEnvPrefix("CORE")
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)

--- a/core/container/controller.go
+++ b/core/container/controller.go
@@ -20,148 +20,23 @@ under the License.
 package container
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
-	"github.com/fsouza/go-dockerclient"
-	"github.com/spf13/viper"
 	"golang.org/x/net/context"
+
+	"github.com/hyperledger/fabric/core/container/ccintf"
+	"github.com/hyperledger/fabric/core/container/dockercontroller"
+	"github.com/hyperledger/fabric/core/container/inproccontroller"
 )
 
 //abstract virtual image for supporting arbitrary virual machines
 type vm interface {
-	build(ctxt context.Context, id string, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error
-	start(ctxt context.Context, id string, args []string, env []string, attachstdin bool, attachstdout bool) error
-	stop(ctxt context.Context, id string, timeout uint, dontkill bool, dontremove bool) error
-}
-
-//dockerVM is a vm. It is identified by an image id
-type dockerVM struct {
-	id string
-}
-
-//create a docker client given endpoint to communicate with docker host
-func (vm *dockerVM) newClient() (*docker.Client, error) {
-	return newDockerClient()
-}
-
-func (vm *dockerVM) createContainer(ctxt context.Context, client *docker.Client, imageID string, containerID string, args []string, env []string, attachstdin bool, attachstdout bool) error {
-	config := docker.Config{Cmd: args, Image: imageID, Env: env, AttachStdin: attachstdin, AttachStdout: attachstdout}
-	copts := docker.CreateContainerOptions{Name: containerID, Config: &config}
-	vmLogger.Debug("Create container: %s", containerID)
-	_, err := client.CreateContainer(copts)
-	if err != nil {
-		return err
-	}
-	vmLogger.Debug("Created container: %s", imageID)
-	return nil
-}
-
-//for docker inputbuf is tar reader ready for use by docker.Client
-//the stream from end client to peer could directly be this tar stream
-//talk to docker daemon using docker Client and build the image
-func (vm *dockerVM) build(ctxt context.Context, id string, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error {
-	outputbuf := bytes.NewBuffer(nil)
-	opts := docker.BuildImageOptions{
-		Name:         id,
-		Pull:         false,
-		InputStream:  reader,
-		OutputStream: outputbuf,
-	}
-	client, err := vm.newClient()
-	switch err {
-	case nil:
-		if err = client.BuildImage(opts); err != nil {
-			vmLogger.Error(fmt.Sprintf("Error building Peer container: %s", err))
-			return err
-		}
-		vmLogger.Debug("Created image: %s", id)
-	default:
-		return fmt.Errorf("Error creating docker client: %s", err)
-	}
-	return nil
-}
-
-func (vm *dockerVM) start(ctxt context.Context, imageID string, args []string, env []string, attachstdin bool, attachstdout bool) error {
-	client, err := vm.newClient()
-	if err != nil {
-		vmLogger.Debug("start - cannot create client %s", err)
-		return err
-	}
-
-	containerID := strings.Replace(imageID, ":", "_", -1)
-
-	//stop,force remove if necessary
-	vmLogger.Debug("Cleanup container %s", containerID)
-	vm.stopInternal(ctxt, client, containerID, 0, false, false)
-
-	vmLogger.Debug("Start container %s", containerID)
-	err = vm.createContainer(ctxt, client, imageID, containerID, args, env, attachstdin, attachstdout)
-	if err != nil {
-		vmLogger.Error(fmt.Sprintf("start-could not recreate container %s", err))
-		return err
-	}
-	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: "host"})
-	if err != nil {
-		vmLogger.Error(fmt.Sprintf("start-could not start container %s", err))
-		return err
-	}
-
-	vmLogger.Debug("Started container %s", containerID)
-	return nil
-}
-
-func (vm *dockerVM) stop(ctxt context.Context, id string, timeout uint, dontkill bool, dontremove bool) error {
-	client, err := vm.newClient()
-	if err != nil {
-		vmLogger.Debug("start - cannot create client %s", err)
-		return err
-	}
-	id = strings.Replace(id, ":", "_", -1)
-
-	err = vm.stopInternal(ctxt, client, id, timeout, dontkill, dontremove)
-
-	return err
-}
-
-func (vm *dockerVM) stopInternal(ctxt context.Context, client *docker.Client, id string, timeout uint, dontkill bool, dontremove bool) error {
-	err := client.StopContainer(id, timeout)
-	if err != nil {
-		vmLogger.Debug("Stop container %s(%s)", id, err)
-	} else {
-		vmLogger.Debug("Stopped container %s", id)
-	}
-	if !dontkill {
-		err = client.KillContainer(docker.KillContainerOptions{ID: id})
-		if err != nil {
-			vmLogger.Debug("Kill container %s (%s)", id, err)
-		} else {
-			vmLogger.Debug("Killed container %s", id)
-		}
-	}
-	if !dontremove {
-		err = client.RemoveContainer(docker.RemoveContainerOptions{ID: id, Force: true})
-		if err != nil {
-			vmLogger.Debug("Remove container %s (%s)", id, err)
-		} else {
-			vmLogger.Debug("Removed container %s", id)
-		}
-	}
-	return err
-}
-
-//constants for supported containers
-const (
-	DOCKER = "Docker"
-)
-
-type image struct {
-	id   string
-	args []string
-	v    vm
+	Deploy(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error
+	Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool) error
+	Stop(ctxt context.Context, ccid ccintf.CCID, timeout uint, dontkill bool, dontremove bool) error
+	GetVMName(ccID ccintf.CCID) (string, error)
 }
 
 type refCountedLock struct {
@@ -182,6 +57,12 @@ type VMController struct {
 //singleton...acess through NewVMController
 var vmcontroller *VMController
 
+//constants for supported containers
+const (
+	DOCKER = "Docker"
+	SYSTEM = "System"
+)
+
 //NewVMController - creates/returns singleton
 func init() {
 	vmcontroller = new(VMController)
@@ -195,9 +76,11 @@ func (vmc *VMController) newVM(typ string) vm {
 
 	switch typ {
 	case DOCKER:
-		v = &dockerVM{}
-	case "":
-		v = &dockerVM{}
+		v = &dockercontroller.DockerVM{}
+	case SYSTEM:
+		v = &inproccontroller.InprocVM{}
+	default:
+		v = &dockercontroller.DockerVM{}
 	}
 	return v
 }
@@ -243,7 +126,7 @@ func (vmc *VMController) unlockContainer(id string) {
 //take context
 type VMCReqIntf interface {
 	do(ctxt context.Context, v vm) VMCResp
-	getID() string
+	getCCID() ccintf.CCID
 }
 
 //VMCResp - response from requests. resp field is a anon interface.
@@ -255,7 +138,7 @@ type VMCResp struct {
 
 //CreateImageReq - properties for creating an container image
 type CreateImageReq struct {
-	ID           string
+	ccintf.CCID
 	Reader       io.Reader
 	AttachStdin  bool
 	AttachStdout bool
@@ -265,7 +148,8 @@ type CreateImageReq struct {
 
 func (bp CreateImageReq) do(ctxt context.Context, v vm) VMCResp {
 	var resp VMCResp
-	if err := v.build(ctxt, bp.ID, bp.Args, bp.Env, bp.AttachStdin, bp.AttachStdout, bp.Reader); err != nil {
+
+	if err := v.Deploy(ctxt, bp.CCID, bp.Args, bp.Env, bp.AttachStdin, bp.AttachStdout, bp.Reader); err != nil {
 		resp = VMCResp{Err: err}
 	} else {
 		resp = VMCResp{}
@@ -274,13 +158,13 @@ func (bp CreateImageReq) do(ctxt context.Context, v vm) VMCResp {
 	return resp
 }
 
-func (bp CreateImageReq) getID() string {
-	return bp.ID
+func (bp CreateImageReq) getCCID() ccintf.CCID {
+	return bp.CCID
 }
 
 //StartImageReq - properties for starting a container.
 type StartImageReq struct {
-	ID           string
+	ccintf.CCID
 	Args         []string
 	Env          []string
 	AttachStdin  bool
@@ -289,7 +173,8 @@ type StartImageReq struct {
 
 func (si StartImageReq) do(ctxt context.Context, v vm) VMCResp {
 	var resp VMCResp
-	if err := v.start(ctxt, si.ID, si.Args, si.Env, si.AttachStdin, si.AttachStdout); err != nil {
+
+	if err := v.Start(ctxt, si.CCID, si.Args, si.Env, si.AttachStdin, si.AttachStdout); err != nil {
 		resp = VMCResp{Err: err}
 	} else {
 		resp = VMCResp{}
@@ -298,13 +183,13 @@ func (si StartImageReq) do(ctxt context.Context, v vm) VMCResp {
 	return resp
 }
 
-func (si StartImageReq) getID() string {
-	return si.ID
+func (si StartImageReq) getCCID() ccintf.CCID {
+	return si.CCID
 }
 
 //StopImageReq - properties for stopping a container.
 type StopImageReq struct {
-	ID      string
+	ccintf.CCID
 	Timeout uint
 	//by default we will kill the container after stopping
 	Dontkill bool
@@ -314,7 +199,8 @@ type StopImageReq struct {
 
 func (si StopImageReq) do(ctxt context.Context, v vm) VMCResp {
 	var resp VMCResp
-	if err := v.stop(ctxt, si.ID, si.Timeout, si.Dontkill, si.Dontremove); err != nil {
+
+	if err := v.Stop(ctxt, si.CCID, si.Timeout, si.Dontkill, si.Dontremove); err != nil {
 		resp = VMCResp{Err: err}
 	} else {
 		resp = VMCResp{}
@@ -323,8 +209,8 @@ func (si StopImageReq) do(ctxt context.Context, v vm) VMCResp {
 	return resp
 }
 
-func (si StopImageReq) getID() string {
-	return si.ID
+func (si StopImageReq) getCCID() ccintf.CCID {
+	return si.CCID
 }
 
 //VMCProcess should be used as follows
@@ -346,7 +232,12 @@ func VMCProcess(ctxt context.Context, vmtype string, req VMCReqIntf) (interface{
 	var resp interface{}
 	go func() {
 		defer close(c)
-		id := req.getID()
+
+		id,err := v.GetVMName(req.getCCID())
+		if err != nil {
+			resp = VMCResp{Err: err}
+			return
+		}
 		vmcontroller.lockContainer(id)
 		resp = req.do(ctxt, v)
 		vmcontroller.unlockContainer(id)
@@ -361,55 +252,3 @@ func VMCProcess(ctxt context.Context, vmtype string, req VMCReqIntf) (interface{
 		return nil, ctxt.Err()
 	}
 }
-
-//GetVMFromName generates the docker image from peer information given the hashcode. This is needed to
-//keep image name's unique in a single host, multi-peer environment (such as a development environment)
-func GetVMFromName(name string) string {
-	vmName := fmt.Sprintf("%s-%s-%s", viper.GetString("peer.networkId"), viper.GetString("peer.id"), name)
-	return vmName
-}
-
-/*******************
- * OLD ... leavethis here as sample for "client.CreateExec" in case we need it at some point
-func (vm *dockerVM) start(ctxt context.Context, id string, args []string, detach bool, instream io.Reader, outstream io.Writer) error {
-	client, err := vm.newClient()
-	if err != nil {
-		fmt.Printf("start - cannot create client %s\n", err)
-		return err
-	}
-	id = strings.Replace(id, ":", "_", -1)
-	fmt.Printf("starting container %s\n", id)
-	econfig := docker.CreateExecOptions{
-		Container:    id,
-		Cmd:          args,
-		AttachStdout: true,
-	}
-	execObj, err := client.CreateExec(econfig)
-	if err != nil {
-		//perhaps container not started
-		err = client.StartContainer(id, &docker.HostConfig{})
-		if err != nil {
-			fmt.Printf("start-could not start container %s\n", err)
-			return err
-		}
-		execObj, err = client.CreateExec(econfig)
-	}
-
-	if err != nil {
-		fmt.Printf("start-could not create exec %s\n", err)
-		return err
-	}
-	sconfig := docker.StartExecOptions{
-		Detach:       detach,
-		InputStream:  instream,
-		OutputStream: outstream,
-	}
-	err = client.StartExec(execObj.ID, sconfig)
-	if err != nil {
-		fmt.Printf("start-could not start exec %s\n", err)
-		return err
-	}
-	fmt.Printf("start-started and execed container for %s\n", id)
-	return nil
-}
-****************************/

--- a/core/container/controller_test.go
+++ b/core/container/controller_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric/core/container/ccintf"
+	pb "github.com/hyperledger/fabric/protos"
+
 	"golang.org/x/net/context"
 )
 
@@ -120,7 +123,7 @@ func TestVMCBuildImage(t *testing.T) {
 	//creat a CreateImageReq obj and send it to VMCProcess
 	go func() {
 		defer close(c)
-		cir := CreateImageReq{ID: "simple", Reader: tarRdr, AttachStdout: true}
+		cir := CreateImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}, Reader: tarRdr, AttachStdout: true}
 		_, err := VMCProcess(ctxt, "Docker", cir)
 		if err != nil {
 			t.Fail()
@@ -143,7 +146,7 @@ func TestVMCStartContainer(t *testing.T) {
 	//create a StartImageReq obj and send it to VMCProcess
 	go func() {
 		defer close(c)
-		sir := StartImageReq{ID: "simple"}
+		sir := StartImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}}
 		_, err := VMCProcess(ctxt, "Docker", sir)
 		if err != nil {
 			t.Fail()
@@ -155,7 +158,7 @@ func TestVMCStartContainer(t *testing.T) {
 	//wait for VMController to complete.
 	fmt.Println("VMCStartContainer-waiting for response")
 	<-c
-	stopr := StopImageReq{ID: "simple", Timeout: 0, Dontremove: true}
+	stopr := StopImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}, Timeout: 0, Dontremove: true}
 	VMCProcess(ctxt, "Docker", stopr)
 }
 
@@ -170,10 +173,10 @@ func TestVMCCreateAndStartContainer(t *testing.T) {
 		defer close(c)
 
 		//stop and delete the container first (if it exists)
-		stopir := StopImageReq{ID: "simple", Timeout: 0}
+		stopir := StopImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}, Timeout: 0}
 		VMCProcess(ctxt, "Docker", stopir)
 
-		startir := StartImageReq{ID: "simple"}
+		startir := StartImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}}
 		r, err := VMCProcess(ctxt, "Docker", startir)
 		if err != nil {
 			t.Fail()
@@ -202,14 +205,14 @@ func TestVMCSyncStartContainer(t *testing.T) {
 	var ctxt = context.Background()
 
 	//creat a StartImageReq obj and send it to VMCProcess
-	sir := StartImageReq{ID: "simple"}
+	sir := StartImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}}
 	_, err := VMCProcess(ctxt, "Docker", sir)
 	if err != nil {
 		t.Fail()
 		t.Logf("Error starting container: %s", err)
 		return
 	}
-	stopr := StopImageReq{ID: "simple", Timeout: 0, Dontremove: true}
+	stopr := StopImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}, Timeout: 0, Dontremove: true}
 	VMCProcess(ctxt, "Docker", stopr)
 }
 
@@ -221,7 +224,7 @@ func TestVMCStopContainer(t *testing.T) {
 	//creat a StopImageReq obj and send it to VMCProcess
 	go func() {
 		defer close(c)
-		sir := StopImageReq{ID: "simple", Timeout: 0}
+		sir := StopImageReq{CCID: ccintf.CCID{ ChaincodeSpec: &pb.ChaincodeSpec{ ChaincodeID: &pb.ChaincodeID{Name: "simple"}}}, Timeout: 0}
 		_, err := VMCProcess(ctxt, "Docker", sir)
 		if err != nil {
 			t.Fail()

--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -1,0 +1,163 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package dockercontroller
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric/core/container/ccintf"
+	cutil "github.com/hyperledger/fabric/core/container/util"
+	"github.com/op/go-logging"
+	"golang.org/x/net/context"
+)
+
+var dockerLogger = logging.MustGetLogger("dockercontroller")
+
+//DockerVM is a vm. It is identified by an image id
+type DockerVM struct {
+	id string
+}
+
+func (vm *DockerVM) createContainer(ctxt context.Context, client *docker.Client, imageID string, containerID string, args []string, env []string, attachstdin bool, attachstdout bool) error {
+	config := docker.Config{Cmd: args, Image: imageID, Env: env, AttachStdin: attachstdin, AttachStdout: attachstdout}
+	copts := docker.CreateContainerOptions{Name: containerID, Config: &config}
+	dockerLogger.Debug("Create container: %s", containerID)
+	_, err := client.CreateContainer(copts)
+	if err != nil {
+		return err
+	}
+	dockerLogger.Debug("Created container: %s", imageID)
+	return nil
+}
+
+//Deploy use the reader containing targz to create a docker image
+//for docker inputbuf is tar reader ready for use by docker.Client
+//the stream from end client to peer could directly be this tar stream
+//talk to docker daemon using docker Client and build the image
+func (vm *DockerVM) Deploy(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error {
+	id, _ := vm.GetVMName(ccid)
+	outputbuf := bytes.NewBuffer(nil)
+	opts := docker.BuildImageOptions{
+		Name:         id,
+		Pull:         false,
+		InputStream:  reader,
+		OutputStream: outputbuf,
+	}
+	client, err := cutil.NewDockerClient()
+	switch err {
+	case nil:
+		if err = client.BuildImage(opts); err != nil {
+			dockerLogger.Error(fmt.Sprintf("Error building Peer container: %s", err))
+			return err
+		}
+		dockerLogger.Debug("Created image: %s", id)
+	default:
+		return fmt.Errorf("Error creating docker client: %s", err)
+	}
+	return nil
+}
+
+//Start starts a container using a previously created docker image
+func (vm *DockerVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool) error {
+	imageID, _ := vm.GetVMName(ccid)
+	client, err := cutil.NewDockerClient()
+	if err != nil {
+		dockerLogger.Debug("start - cannot create client %s", err)
+		return err
+	}
+
+	containerID := strings.Replace(imageID, ":", "_", -1)
+
+	//stop,force remove if necessary
+	dockerLogger.Debug("Cleanup container %s", containerID)
+	vm.stopInternal(ctxt, client, containerID, 0, false, false)
+
+	dockerLogger.Debug("Start container %s", containerID)
+	err = vm.createContainer(ctxt, client, imageID, containerID, args, env, attachstdin, attachstdout)
+	if err != nil {
+		dockerLogger.Error(fmt.Sprintf("start-could not recreate container %s", err))
+		return err
+	}
+	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: "host"})
+	if err != nil {
+		dockerLogger.Error(fmt.Sprintf("start-could not start container %s", err))
+		return err
+	}
+
+	dockerLogger.Debug("Started container %s", containerID)
+	return nil
+}
+
+//Stop stops a running chaincode
+func (vm *DockerVM) Stop(ctxt context.Context, ccid ccintf.CCID, timeout uint, dontkill bool, dontremove bool) error {
+	id, _ := vm.GetVMName(ccid)
+	client, err := cutil.NewDockerClient()
+	if err != nil {
+		dockerLogger.Debug("start - cannot create client %s", err)
+		return err
+	}
+	id = strings.Replace(id, ":", "_", -1)
+
+	err = vm.stopInternal(ctxt, client, id, timeout, dontkill, dontremove)
+
+	return err
+}
+
+func (vm *DockerVM) stopInternal(ctxt context.Context, client *docker.Client, id string, timeout uint, dontkill bool, dontremove bool) error {
+	err := client.StopContainer(id, timeout)
+	if err != nil {
+		dockerLogger.Debug("Stop container %s(%s)", id, err)
+	} else {
+		dockerLogger.Debug("Stopped container %s", id)
+	}
+	if !dontkill {
+		err = client.KillContainer(docker.KillContainerOptions{ID: id})
+		if err != nil {
+			dockerLogger.Debug("Kill container %s (%s)", id, err)
+		} else {
+			dockerLogger.Debug("Killed container %s", id)
+		}
+	}
+	if !dontremove {
+		err = client.RemoveContainer(docker.RemoveContainerOptions{ID: id, Force: true})
+		if err != nil {
+			dockerLogger.Debug("Remove container %s (%s)", id, err)
+		} else {
+			dockerLogger.Debug("Removed container %s", id)
+		}
+	}
+	return err
+}
+
+//GetVMName generates the docker image from peer information given the hashcode. This is needed to
+//keep image name's unique in a single host, multi-peer environment (such as a development environment)
+func (vm *DockerVM) GetVMName(ccid ccintf.CCID) (string, error) {
+	if ccid.NetworkID != "" {
+		return fmt.Sprintf("%s-%s-%s", ccid.NetworkID, ccid.PeerID, ccid.ChaincodeSpec.ChaincodeID.Name), nil
+	} else if ccid.PeerID != "" {
+		return fmt.Sprintf("%s-%s", ccid.PeerID, ccid.ChaincodeSpec.ChaincodeID.Name), nil
+	} else {
+		return ccid.ChaincodeSpec.ChaincodeID.Name, nil
+	}
+}

--- a/core/container/inproccontroller/inproccontroller.go
+++ b/core/container/inproccontroller/inproccontroller.go
@@ -1,0 +1,218 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package inproccontroller
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/container/ccintf"
+	pb "github.com/hyperledger/fabric/protos"
+	"github.com/op/go-logging"
+
+	"golang.org/x/net/context"
+)
+
+type inprocContainer struct {
+	chaincode shim.Chaincode
+	running   bool
+	args      []string
+	env       []string
+	stopChan  chan struct{}
+}
+
+var (
+	inprocLogger = logging.MustGetLogger("inproccontroller")
+	typeRegistry = make(map[string]*inprocContainer)
+	instRegistry = make(map[string]*inprocContainer)
+)
+
+//Register registers system chaincode with given path. The deploy should be called to initialize
+func Register(path string, cc shim.Chaincode) error {
+	tmp := typeRegistry[path]
+	if tmp != nil {
+		return fmt.Errorf(fmt.Sprintf("%s is registered", path))
+	}
+
+	typeRegistry[path] = &inprocContainer{chaincode: cc}
+	return nil
+}
+
+//InprocVM is a vm. It is identified by a executable name
+type InprocVM struct {
+	id string
+}
+
+func (vm *InprocVM) getInstance(ctxt context.Context, ipctemplate *inprocContainer, ccid ccintf.CCID, args []string, env []string) (*inprocContainer, error) {
+	ipc := instRegistry[ccid.ChaincodeSpec.ChaincodeID.Name]
+	if ipc != nil {
+		inprocLogger.Warning(fmt.Sprintf("chaincode instance exists for %s", ccid.ChaincodeSpec.ChaincodeID.Name))
+		return ipc, nil
+	}
+	ipc = &inprocContainer{args: args, env: env, chaincode: ipctemplate.chaincode, stopChan: make(chan struct{})}
+	instRegistry[ccid.ChaincodeSpec.ChaincodeID.Name] = ipc
+	inprocLogger.Debug("chaincode instance created for %s", ccid.ChaincodeSpec.ChaincodeID.Name)
+	return ipc, nil
+}
+
+//Deploy verifies chaincode is registered and creates an instance for it. Currently only one instance can be created
+func (vm *InprocVM) Deploy(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error {
+	path := ccid.ChaincodeSpec.ChaincodeID.Path
+
+	ipctemplate := typeRegistry[path]
+	if ipctemplate == nil {
+		return fmt.Errorf(fmt.Sprintf("%s not registered. Please register the system chaincode in inprocinstances.go", path))
+	}
+
+	if ipctemplate.chaincode == nil {
+		return fmt.Errorf(fmt.Sprintf("%s system chaincode does not contain chaincode instance", path))
+	}
+
+	_, err := vm.getInstance(ctxt, ipctemplate, ccid, args, env)
+
+	//FUTURE ... here is where we might check code for safety
+	inprocLogger.Debug("registered : %s", path)
+
+	return err
+}
+
+func (ipc *inprocContainer) launchInProc(ctxt context.Context, id string, args []string, env []string, ccSupport ccintf.CCSupport) error {
+	peerRcvCCSend := make(chan *pb.ChaincodeMessage)
+	ccRcvPeerSend := make(chan *pb.ChaincodeMessage)
+	var err error
+	ccchan := make(chan struct{}, 1)
+	ccsupportchan := make(chan struct{}, 1)
+	go func() {
+		defer close(ccchan)
+		inprocLogger.Debug("chaincode started for %s", id)
+		if args == nil {
+			args = ipc.args
+		}
+		if env == nil {
+			env = ipc.env
+		}
+		err := shim.StartInProc(env, args, ipc.chaincode, ccRcvPeerSend, peerRcvCCSend)
+		if err != nil {
+			err = fmt.Errorf("chaincode-support ended with err: %s", err)
+			inprocLogger.Error(fmt.Sprintf("%s", err))
+		}
+		inprocLogger.Debug("chaincode ended with for  %s with err: %s", id, err)
+	}()
+
+	go func() {
+		defer close(ccsupportchan)
+		inprocStream := newInProcStream(peerRcvCCSend, ccRcvPeerSend)
+		inprocLogger.Debug("chaincode-support started for  %s", id)
+		err := ccSupport.HandleChaincodeStream(ctxt, inprocStream)
+		if err != nil {
+			err = fmt.Errorf("chaincode ended with err: %s", err)
+			inprocLogger.Error(fmt.Sprintf("%s", err))
+		}
+		inprocLogger.Debug("chaincode-support ended with for  %s with err: %s", id, err)
+	}()
+
+	select {
+	case <-ccchan:
+		close(peerRcvCCSend)
+		inprocLogger.Debug("chaincode %s quit", id)
+	case <-ccsupportchan:
+		close(ccRcvPeerSend)
+		inprocLogger.Debug("chaincode support %s quit", id)
+	case <-ipc.stopChan:
+		close(ccRcvPeerSend)
+		close(peerRcvCCSend)
+		inprocLogger.Debug("chaincode %s stopped", id)
+	}
+
+	return err
+}
+
+//Start starts a previously registered system codechain
+func (vm *InprocVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool) error {
+	path := ccid.ChaincodeSpec.ChaincodeID.Path
+
+	ipctemplate := typeRegistry[path]
+
+	if ipctemplate == nil {
+		return fmt.Errorf(fmt.Sprintf("%s not registered", path))
+	}
+
+	ipc, err := vm.getInstance(ctxt, ipctemplate, ccid, args, env)
+
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("could not create instance for %s", ccid.ChaincodeSpec.ChaincodeID.Name))
+	}
+
+	if ipc.running {
+		return fmt.Errorf(fmt.Sprintf("chaincode running %s", path))
+	}
+
+	//TODO VALIDITY CHECKS ?
+
+	ccSupport, ok := ctxt.Value(ccintf.GetCCHandlerKey()).(ccintf.CCSupport)
+	if !ok || ccSupport == nil {
+		return fmt.Errorf("in-process communication generator not supplied")
+	}
+
+	ipc.running = true
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				inprocLogger.Critical("caught panic from chaincode  %s", ccid.ChaincodeSpec.ChaincodeID.Name)
+			}
+		}()
+		ipc.launchInProc(ctxt, ccid.ChaincodeSpec.ChaincodeID.Name, args, env, ccSupport)
+	}()
+
+	return nil
+}
+
+//Stop stops a system codechain
+func (vm *InprocVM) Stop(ctxt context.Context, ccid ccintf.CCID, timeout uint, dontkill bool, dontremove bool) error {
+	path := ccid.ChaincodeSpec.ChaincodeID.Path
+
+	ipctemplate := typeRegistry[path]
+	if ipctemplate == nil {
+		return fmt.Errorf("%s not registered", path)
+	}
+
+	ipc := instRegistry[ccid.ChaincodeSpec.ChaincodeID.Name]
+
+	if ipc == nil {
+		return fmt.Errorf("%s not found", ccid.ChaincodeSpec.ChaincodeID.Name)
+	}
+
+	if !ipc.running {
+		return fmt.Errorf("%s not running", ccid.ChaincodeSpec.ChaincodeID.Name)
+	}
+
+	ipc.stopChan <- struct{}{}
+
+	delete(instRegistry, ccid.ChaincodeSpec.ChaincodeID.Name)
+	//TODO stop
+	return nil
+}
+
+//GetVMName ignores the peer and network name as it just needs to be unique in process
+func (vm *InprocVM) GetVMName(ccid ccintf.CCID) (string, error) {
+	return ccid.ChaincodeSpec.ChaincodeID.Name, nil
+}

--- a/core/container/inproccontroller/inprocstream.go
+++ b/core/container/inproccontroller/inprocstream.go
@@ -1,0 +1,44 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package inproccontroller
+
+import (
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+// PeerChaincodeStream interface for stream between Peer and chaincode instance.
+type inProcStream struct {
+	recv <-chan *pb.ChaincodeMessage
+	send chan<- *pb.ChaincodeMessage
+}
+
+func newInProcStream(recv <-chan *pb.ChaincodeMessage, send chan<- *pb.ChaincodeMessage) *inProcStream {
+	return &inProcStream{recv, send}
+}
+
+func (s *inProcStream) Send(msg *pb.ChaincodeMessage) error {
+	s.send <- msg
+	return nil
+}
+
+func (s *inProcStream) Recv() (*pb.ChaincodeMessage, error) {
+	msg := <-s.recv
+	return msg, nil
+}

--- a/core/container/util/dockerutil.go
+++ b/core/container/util/dockerutil.go
@@ -1,0 +1,40 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package util
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"github.com/spf13/viper"
+)
+
+//NewDockerClient creates a docker client
+func NewDockerClient() (client *docker.Client, err error) {
+	endpoint := viper.GetString("vm.endpoint")
+	tlsenabled := viper.GetBool("vm.docker.tls.enabled")
+	if tlsenabled {
+		cert := viper.GetString("vm.docker.tls.cert.file")
+		key := viper.GetString("vm.docker.tls.key.file")
+		ca := viper.GetString("vm.docker.tls.ca.file")
+		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
+	} else {
+		client, err = docker.NewClient(endpoint)
+	}
+	return
+}

--- a/core/container/util/write.go
+++ b/core/container/util/write.go
@@ -14,16 +14,17 @@ import (
 
 var vmLogger = logging.MustGetLogger("container")
 
+//WriteGopathSrc tars up files under gopath src
 func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 	gopath := os.Getenv("GOPATH")
-	if strings.LastIndex(gopath, "/") == len(gopath) - 1 {
+	if strings.LastIndex(gopath, "/") == len(gopath)-1 {
 		gopath = gopath[:len(gopath)]
 	}
 	rootDirectory := fmt.Sprintf("%s%s%s", os.Getenv("GOPATH"), string(os.PathSeparator), "src")
 	vmLogger.Info("rootDirectory = %s", rootDirectory)
 
 	//append "/" if necessary
-	if excludeDir != "" && strings.LastIndex(excludeDir, "/") < len(excludeDir) - 1 {
+	if excludeDir != "" && strings.LastIndex(excludeDir, "/") < len(excludeDir)-1 {
 		excludeDir = excludeDir + "/"
 	}
 
@@ -40,7 +41,7 @@ func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 		}
 
 		//exclude any files with excludeDir prefix. They should already be in the tar
-		if excludeDir != "" && strings.Index(path, excludeDir) == rootDirLen + 1 {
+		if excludeDir != "" && strings.Index(path, excludeDir) == rootDirLen+1 {
 			//1 for "/"
 			return nil
 		}
@@ -71,6 +72,7 @@ func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 	return nil
 }
 
+//WriteFileToPackage writes a file to the tarball
 func WriteFileToPackage(localpath string, packagepath string, tw *tar.Writer) error {
 	fd, err := os.Open(localpath)
 	if err != nil {
@@ -83,6 +85,7 @@ func WriteFileToPackage(localpath string, packagepath string, tw *tar.Writer) er
 
 }
 
+//WriteStreamToPackage writes bytes (from a file reader) to the tarball
 func WriteStreamToPackage(is io.Reader, localpath string, packagepath string, tw *tar.Writer) error {
 	info, err := os.Stat(localpath)
 	if err != nil {

--- a/core/container/vm.go
+++ b/core/container/vm.go
@@ -38,21 +38,6 @@ import (
 	"github.com/op/go-logging"
 )
 
-func newDockerClient() (client *docker.Client, err error) {
-	//QQ: is this ok using config properties here so deep ? ie, should we read these in main and stow them away ?
-	endpoint := viper.GetString("vm.endpoint")
-	vmLogger.Info("Creating VM with endpoint: %s", endpoint)
-	if viper.GetBool("vm.docker.tls.enabled") {
-		cert := viper.GetString("vm.docker.tls.cert.file")
-		key := viper.GetString("vm.docker.tls.key.file")
-		ca := viper.GetString("vm.docker.tls.ca.file")
-		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
-	} else {
-		client, err = docker.NewClient(endpoint)
-	}
-	return
-}
-
 // VM implemenation of VM management functionality.
 type VM struct {
 	Client *docker.Client
@@ -60,7 +45,7 @@ type VM struct {
 
 // NewVM creates a new VM instance.
 func NewVM() (*VM, error) {
-	client, err := newDockerClient()
+	client, err := cutil.NewDockerClient()
 	if err != nil {
 		return nil, err
 	}
@@ -105,9 +90,6 @@ func (vm *VM) BuildChaincodeContainer(spec *pb.ChaincodeSpec) ([]byte, error) {
 func GetChaincodePackageBytes(spec *pb.ChaincodeSpec) ([]byte, error) {
 	if spec == nil || spec.ChaincodeID == nil {
 		return nil, fmt.Errorf("invalid chaincode spec")
-	}
-	if spec.ChaincodeID.Name != "" {
-		return nil, fmt.Errorf("chaincode name exists")
 	}
 
 	inputbuf := bytes.NewBuffer(nil)

--- a/core/ledger/genesis/genesis.go
+++ b/core/ledger/genesis/genesis.go
@@ -25,9 +25,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/hyperledger/fabric/core"
 	"github.com/hyperledger/fabric/core/chaincode"
-	"github.com/hyperledger/fabric/core/container"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
@@ -48,21 +46,28 @@ func MakeGenesis() error {
 			return
 		}
 
-		if ledger.GetBlockchainSize() > 0 {
-			// genesis block already exists
-			return
+		var genesisBlockExists bool 
+		if ledger.GetBlockchainSize() == 0 {
+			genesisLogger.Info("Creating genesis block.")
+			ledger.BeginTxBatch(0)
+		} else {
+			genesisBlockExists = true
 		}
 
-		genesisLogger.Info("Creating genesis block.")
-
-		ledger.BeginTxBatch(0)
 		var genesisTransactions []*protos.Transaction
+		
+		defer func() {
+			if !genesisBlockExists && makeGenesisError == nil {
+				genesisLogger.Info("Adding %d system chaincodes to the genesis block.", len(genesisTransactions))
+				ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
+			}
+		}()
 
 		//We are disabling the validity period deployment for now, we shouldn't even allow it if it's enabled in the configuration
 		allowDeployValidityPeriod := false
 
 		if isDeploySystemChaincodeEnabled() && allowDeployValidityPeriod {
-			vpTransaction, deployErr := deployUpdateValidityPeriodChaincode()
+			vpTransaction, deployErr := deployUpdateValidityPeriodChaincode(genesisBlockExists)
 
 			if deployErr != nil {
 				genesisLogger.Error("Error deploying validity period system chaincode for genesis block.", deployErr)
@@ -76,8 +81,8 @@ func MakeGenesis() error {
 		if getGenesis() == nil {
 			genesisLogger.Info("No genesis block chaincodes defined.")
 		} else {
-
-			chaincodes, chaincodesOK := genesis["chaincode"].([]interface{})
+			
+			chaincodes, chaincodesOK := genesis["chaincodes"].(map[interface{}]interface{})
 			if !chaincodesOK {
 				genesisLogger.Info("No genesis block chaincodes defined.")
 				ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
@@ -86,13 +91,15 @@ func MakeGenesis() error {
 
 			genesisLogger.Debug("Genesis chaincodes are %s", chaincodes)
 
-			for i := 0; i < len(chaincodes); i++ {
-				genesisLogger.Debug("Chaincode %d is %s", i, chaincodes[i])
-
-				chaincodeMap, chaincodeMapOK := chaincodes[i].(map[interface{}]interface{})
+			for i := range chaincodes {
+				name := i.(string)
+				genesisLogger.Debug("Chaincode %s", name)
+	
+				chaincode := chaincodes[name]
+				chaincodeMap, chaincodeMapOK := chaincode.(map[interface{}]interface{})
 				if !chaincodeMapOK {
-					genesisLogger.Error("Invalid chaincode defined in genesis configuration:", chaincodes[i])
-					makeGenesisError = fmt.Errorf("Invalid chaincode defined in genesis configuration: %s", chaincodes[i])
+					genesisLogger.Error("Invalid chaincode defined in genesis configuration:", chaincode)
+					makeGenesisError = fmt.Errorf("Invalid chaincode defined in genesis configuration: %s", chaincode)
 					return
 				}
 
@@ -110,10 +117,13 @@ func MakeGenesis() error {
 					return
 				}
 
-				chaincodeID := &protos.ChaincodeID{Path: path, Name: ""}
+				if chaincodeType == "" {
+					chaincodeType = "GOLANG"
+				}
+
+				chaincodeID := &protos.ChaincodeID{Path: path, Name: name}
 
 				genesisLogger.Debug("Genesis chaincodeID %s", chaincodeID)
-				genesisLogger.Debug("Genesis chaincode type %s", chaincodeType)
 
 				constructorMap, constructorMapOK := chaincodeMap["constructor"].(map[interface{}]interface{})
 				if !constructorMapOK {
@@ -128,31 +138,25 @@ func MakeGenesis() error {
 					spec = protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value[chaincodeType]), ChaincodeID: chaincodeID}
 				} else {
 
-					ctorFunc, ctorFuncOK := constructorMap["func"].(string)
-					if !ctorFuncOK {
-						genesisLogger.Error("Invalid chaincode constructor function defined in genesis configuration:", constructorMap["func"])
-						makeGenesisError = fmt.Errorf("Invalid chaincode constructor function args defined in genesis configuration: %s", constructorMap["func"])
-						return
-					}
-
-					ctorArgs, ctorArgsOK := constructorMap["args"].([]interface{})
+					_, ctorArgsOK := constructorMap["args"]
 					if !ctorArgsOK {
 						genesisLogger.Error("Invalid chaincode constructor args defined in genesis configuration:", constructorMap["args"])
 						makeGenesisError = fmt.Errorf("Invalid chaincode constructor args defined in genesis configuration: %s", constructorMap["args"])
 						return
 					}
 
-					genesisLogger.Debug("Genesis chaincode constructor func %s", ctorFunc)
-					genesisLogger.Debug("Genesis chaincode constructor args %s", ctorArgs)
+					ctorArgs, ctorArgsOK := constructorMap["args"].([]interface{})
 					var ctorArgsStringArray []string
-					for j := 0; j < len(ctorArgs); j++ {
-						ctorArgsStringArray = append(ctorArgsStringArray, ctorArgs[j].(string))
+					if ctorArgsOK {
+						genesisLogger.Debug("Genesis chaincode constructor args %s", ctorArgs)
+						for j := 0; j < len(ctorArgs); j++ {
+							ctorArgsStringArray = append(ctorArgsStringArray, ctorArgs[j].(string))
+						}
 					}
-
-					spec = protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value[chaincodeType]), ChaincodeID: chaincodeID, CtorMsg: &protos.ChaincodeInput{Function: ctorFunc, Args: ctorArgsStringArray}}
+					spec = protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value[chaincodeType]), ChaincodeID: chaincodeID, CtorMsg: &protos.ChaincodeInput{Args: ctorArgsStringArray}}
 				}
 
-				transaction, _, deployErr := DeployLocal(context.Background(), &spec)
+				transaction, _, deployErr := DeployLocal(context.Background(), &spec, genesisBlockExists)
 				if deployErr != nil {
 					genesisLogger.Error("Error deploying chaincode for genesis block.", deployErr)
 					makeGenesisError = deployErr
@@ -164,10 +168,6 @@ func MakeGenesis() error {
 			} //for
 
 		} //else
-
-		genesisLogger.Info("Adding %d system chaincodes to the genesis block.", len(genesisTransactions))
-		ledger.CommitTxBatch(0, genesisTransactions, nil, nil)
-
 	})
 	return makeGenesisError
 }
@@ -176,6 +176,7 @@ func MakeGenesis() error {
 func BuildLocal(context context.Context, spec *protos.ChaincodeSpec) (*protos.ChaincodeDeploymentSpec, error) {
 	genesisLogger.Debug("Received build request for chaincode spec: %v", spec)
 	var codePackageBytes []byte
+	/*****  We will need this only when we support non-go SYSTEM chaincode ****
 	if getMode() != chaincode.DevModeUserRunsChaincode {
 		if err := core.CheckSpec(spec); err != nil {
 			genesisLogger.Debug("check spec failed: %s", err)
@@ -189,12 +190,13 @@ func BuildLocal(context context.Context, spec *protos.ChaincodeSpec) (*protos.Ch
 			return nil, err
 		}
 	}
-	chaincodeDeploymentSpec := &protos.ChaincodeDeploymentSpec{ChaincodeSpec: spec, CodePackage: codePackageBytes}
+	*********/
+	chaincodeDeploymentSpec := &protos.ChaincodeDeploymentSpec{ExeEnv: protos.ChaincodeDeploymentSpec_SYSTEM, ChaincodeSpec: spec, CodePackage: codePackageBytes}
 	return chaincodeDeploymentSpec, nil
 }
 
 // DeployLocal deploys the supplied chaincode image to the local peer
-func DeployLocal(ctx context.Context, spec *protos.ChaincodeSpec) (*protos.Transaction, []byte, error) {
+func DeployLocal(ctx context.Context, spec *protos.ChaincodeSpec, gbexists bool) (*protos.Transaction, []byte, error) {
 	// First build and get the deployment spec
 	chaincodeDeploymentSpec, err := BuildLocal(ctx, spec)
 
@@ -203,10 +205,28 @@ func DeployLocal(ctx context.Context, spec *protos.ChaincodeSpec) (*protos.Trans
 		return nil, nil, err
 	}
 
-	transaction, err := protos.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name)
-	if err != nil {
-		return nil, nil, fmt.Errorf("Error deploying chaincode: %s ", err)
+	var transaction *protos.Transaction
+	if gbexists {
+		ledger, err := ledger.GetLedger()
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed to get handle to ledger (%s)", err)
+		}
+		transaction, err = ledger.GetTransactionByUUID(chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name)
+		if err != nil {
+			genesisLogger.Warning(fmt.Sprintf("cannot get deployment transaction for %s - %s", chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name, err))
+			transaction = nil
+		} else {
+			genesisLogger.Debug("deployment transaction for %s exists", chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name)
+		}
 	}
+
+	if transaction == nil {
+		transaction, err = protos.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error deploying chaincode: %s ", err)
+		}
+	}
+
 	//chaincode.NewChaincodeSupport(chaincode.DefaultChain, peer.GetPeerEndpoint, false, 120000)
 	// The secHelper is set during creat ChaincodeSupport, so we don't need this step
 	//ctx = context.WithValue(ctx, "security", secCxt)
@@ -214,7 +234,7 @@ func DeployLocal(ctx context.Context, spec *protos.ChaincodeSpec) (*protos.Trans
 	return transaction, result, err
 }
 
-func deployUpdateValidityPeriodChaincode() (*protos.Transaction, error) {
+func deployUpdateValidityPeriodChaincode(gbexists bool) (*protos.Transaction, error) {
 	//TODO It should be configurable, not hardcoded
 	vpChaincodePath := "github.com/hyperledger/fabric/core/system_chaincode/validity_period_update"
 	vpFunction := "init"
@@ -236,7 +256,7 @@ func deployUpdateValidityPeriodChaincode() (*protos.Transaction, error) {
 
 	validityPeriodSpec.SecureContext = string(vpToken)
 
-	vpTransaction, _, deployErr := DeployLocal(context.Background(), validityPeriodSpec)
+	vpTransaction, _, deployErr := DeployLocal(context.Background(), validityPeriodSpec, gbexists)
 
 	if deployErr != nil {
 		genesisLogger.Error("Error deploying validity period chaincode for genesis block.", deployErr)

--- a/core/system_chaincode/api/sysccapi.go
+++ b/core/system_chaincode/api/sysccapi.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"github.com/op/go-logging"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	inproc "github.com/hyperledger/fabric/core/container/inproccontroller"
+)
+
+var sysccLogger = logging.MustGetLogger("sysccapi")
+
+func RegisterSysCC(path string, o interface{}) error {
+	syscc := o.(shim.Chaincode)
+	if syscc == nil {
+		sysccLogger.Warning(fmt.Sprintf("invalid chaincode %v", o))
+		return fmt.Errorf(fmt.Sprintf("invalid chaincode %v", o))
+	}
+	err := inproc.Register(path, syscc)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("could not register (%s,%v): %s", path, syscc, err))
+	}
+	sysccLogger.Debug("system chaincode %s registered", path)
+	return err
+}

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -1,0 +1,32 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package system_chaincode
+
+import (
+	//import system chain codes here
+	"github.com/hyperledger/fabric/core/system_chaincode/api"
+	"github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
+)
+
+//RegisterSysCCs is the hook for system chaincodes where system chaincodes are registered with the fabric
+//note the chaincode must still be deployed and launched like a user chaincode will be
+func RegisterSysCCs() {
+	api.RegisterSysCC("github.com/hyperledger/fabric/core/system_chaincode/sample_syscc", &sample_syscc.SampleSysCC{})
+}

--- a/core/system_chaincode/sample_syscc/sample_syscc.go
+++ b/core/system_chaincode/sample_syscc/sample_syscc.go
@@ -1,0 +1,104 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package sample_syscc
+
+import (
+	"errors"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+// SampleSysCC example simple Chaincode implementation
+type SampleSysCC struct {
+}
+
+func (t *SampleSysCC) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	var key, val string    // Entities
+
+	if len(args) != 2 {
+		return nil, errors.New("need 2 args (key and a value).")
+	}
+
+	// Initialize the chaincode
+	key = args[0]
+	val = args[1]
+	// Write the state to the ledger
+	err := stub.PutState(key, []byte(val))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Transaction makes payment of X units from A to B
+func (t *SampleSysCC) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	var key, val string    // Entities
+
+	if len(args) != 2 {
+		return nil, errors.New("need 2 args (key and a value).")
+	}
+
+	// Initialize the chaincode
+	key = args[0]
+	val = args[1]
+
+	_, err := stub.GetState(key)
+	if err != nil {
+		jsonResp := "{\"Error\":\"Failed to get val for " + key + "\"}"
+		return nil, errors.New(jsonResp)
+	}
+
+	// Write the state to the ledger
+	err = stub.PutState(key, []byte(val))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Query callback representing the query of a chaincode
+func (t *SampleSysCC) Query(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	if function != "getval" {
+		return nil, errors.New("Invalid query function name. Expecting \"getval\"")
+	}
+	var key string // Entities
+	var err error
+
+	if len(args) != 1 {
+		return nil, errors.New("Incorrect number of arguments. Expecting key to query")
+	}
+
+	key = args[0]
+
+	// Get the state from the ledger
+	valbytes, err := stub.GetState(key)
+	if err != nil {
+		jsonResp := "{\"Error\":\"Failed to get state for " + key + "\"}"
+		return nil, errors.New(jsonResp)
+	}
+
+	if valbytes == nil {
+		jsonResp := "{\"Error\":\"Nil val for " + key + "\"}"
+		return nil, errors.New(jsonResp)
+	}
+
+	return valbytes, nil
+}

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -320,16 +320,15 @@ ledger:
     genesisBlock:
 
       # Deploy chaincodes into the genesis block
-      # chaincode:
-      #     path: github.com/hyperledger/fabric/core/example/chaincode/chaincode_example01
-      #     type: GOLANG
-      #     constructor:
-      #       func: init
-      #       args:
-      #         - alice
-      #         - "4"
-      #         - bob
-      #         - "10"
+      chaincodes:
+
+        #sample_syscc:
+        #  path: github.com/hyperledger/fabric/core/system_chaincode/sample_syscc
+        #  type: GOLANG
+        #  constructor:
+        #    args:
+        #      - greetings
+        #      - hello world
 
     # Setting the deploy-system-chaincode property to false will prevent the
     # deploying of system chaincode at genesis time.

--- a/peer/main.go
+++ b/peer/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/genesis"
 	"github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/core/rest"
+	"github.com/hyperledger/fabric/core/system_chaincode"
 	"github.com/hyperledger/fabric/events/producer"
 	pb "github.com/hyperledger/fabric/protos"
 	"net/http"
@@ -325,6 +326,9 @@ func createEventHubServer() (net.Listener, *grpc.Server, error) {
 }
 
 func serve(args []string) error {
+	//register all system chaincodes. This just registers chaincodes, they must be 
+	//still be deployed and launched
+	system_chaincode.RegisterSysCCs()
 	peerEndpoint, err := peer.GetPeerEndpoint()
 	if err != nil {
 		err = fmt.Errorf("Failed to get Peer Endpoint: %s", err)

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -63,6 +63,26 @@ func (x ChaincodeSpec_Type) String() string {
 	return proto.EnumName(ChaincodeSpec_Type_name, int32(x))
 }
 
+type ChaincodeDeploymentSpec_ExeEnv int32
+
+const (
+	ChaincodeDeploymentSpec_DOCKER ChaincodeDeploymentSpec_ExeEnv = 0
+	ChaincodeDeploymentSpec_SYSTEM ChaincodeDeploymentSpec_ExeEnv = 1
+)
+
+var ChaincodeDeploymentSpec_ExeEnv_name = map[int32]string{
+	0: "DOCKER",
+	1: "SYSTEM",
+}
+var ChaincodeDeploymentSpec_ExeEnv_value = map[string]int32{
+	"DOCKER": 0,
+	"SYSTEM": 1,
+}
+
+func (x ChaincodeDeploymentSpec_ExeEnv) String() string {
+	return proto.EnumName(ChaincodeDeploymentSpec_ExeEnv_name, int32(x))
+}
+
 type ChaincodeMessage_Type int32
 
 const (
@@ -201,8 +221,9 @@ func (m *ChaincodeSpec) GetCtorMsg() *ChaincodeInput {
 type ChaincodeDeploymentSpec struct {
 	ChaincodeSpec *ChaincodeSpec `protobuf:"bytes,1,opt,name=chaincodeSpec" json:"chaincodeSpec,omitempty"`
 	// Controls when the chaincode becomes executable.
-	EffectiveDate *google_protobuf.Timestamp `protobuf:"bytes,2,opt,name=effectiveDate" json:"effectiveDate,omitempty"`
-	CodePackage   []byte                     `protobuf:"bytes,3,opt,name=codePackage,proto3" json:"codePackage,omitempty"`
+	EffectiveDate *google_protobuf.Timestamp     `protobuf:"bytes,2,opt,name=effectiveDate" json:"effectiveDate,omitempty"`
+	CodePackage   []byte                         `protobuf:"bytes,3,opt,name=codePackage,proto3" json:"codePackage,omitempty"`
+	ExeEnv        ChaincodeDeploymentSpec_ExeEnv `protobuf:"varint,4,opt,name=exeEnv,enum=protos.ChaincodeDeploymentSpec_ExeEnv" json:"exeEnv,omitempty"`
 }
 
 func (m *ChaincodeDeploymentSpec) Reset()         { *m = ChaincodeDeploymentSpec{} }
@@ -341,6 +362,7 @@ func (m *RangeQueryStateResponse) GetKeysAndValues() []*RangeQueryStateKeyValue 
 func init() {
 	proto.RegisterEnum("protos.ConfidentialityLevel", ConfidentialityLevel_name, ConfidentialityLevel_value)
 	proto.RegisterEnum("protos.ChaincodeSpec_Type", ChaincodeSpec_Type_name, ChaincodeSpec_Type_value)
+	proto.RegisterEnum("protos.ChaincodeDeploymentSpec_ExeEnv", ChaincodeDeploymentSpec_ExeEnv_name, ChaincodeDeploymentSpec_ExeEnv_value)
 	proto.RegisterEnum("protos.ChaincodeMessage_Type", ChaincodeMessage_Type_name, ChaincodeMessage_Type_value)
 }
 

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -78,10 +78,16 @@ message ChaincodeSpec {
 // TODO: Define `codePackage`.
 message ChaincodeDeploymentSpec {
 
+    enum ExeEnv {
+        DOCKER = 0;
+        SYSTEM = 1;
+    }
+
     ChaincodeSpec chaincodeSpec = 1;
     // Controls when the chaincode becomes executable.
     google.protobuf.Timestamp effectiveDate = 2;
     bytes codePackage = 3;
+    ExeEnv exeEnv=  4;
 
 }
 

--- a/protos/server_admin.pb.go
+++ b/protos/server_admin.pb.go
@@ -106,7 +106,6 @@ func (c *adminClient) StopServer(ctx context.Context, in *google_protobuf1.Empty
 	out := new(ServerStatus)
 	err := grpc.Invoke(ctx, "/protos.Admin/StopServer", in, out, c.cc, opts...)
 	if err != nil {
-		logger.Debug("Returned error %s, code %i", grpc.ErrorDesc(err), grpc.Code(err))
 		return nil, err
 	}
 	return out, nil


### PR DESCRIPTION
**This PR is for convenience of review only. Not for merging.**

The PR implements https://github.com/hyperledger/fabric/wiki/System-Chaincode-Specification.

NOTE - The difference between v1 and current version is moving SYSTEM type from protos.ChaincodeSpec to protos.ChaincodeDeploymentSpec. This keeps the separation between language and execution environment (in addition to keeping deployment time properties to deployment spec).

Hopefully the logical progression of commits in the PR will make it a bit easier to follow the implementation.

A few points
- the implementation takes advantage of the opportunity to crete a new execution environment for the chaincode to abstract out key areas such as VM and Communication stream, so writing a new execution env (say plugging in a a new container technology) is not too difficult
- These chaincode execution environments can co-exist. You can have a mixture of these chaincodes 
- the system chaincode currently can be accessed via Invoke and Query just like the docker chaincodes. The Deploy has a twist. It still needs to be deployed by the user, but the developer has to hook it in to the fabric via a Register call.
- a sample system chaincode _github.com/hyperledger/fabric/core/system_chaincode/sample_syscc_ is included

We will begin writing specific system chaincodes (such as timers) using this framework.

Comments, review, welcome.
