### PR TITLE
Fix up a few remaining fabric references. Issue #1131

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -619,7 +619,7 @@ Feature: lanching 3 peers
            |arg1|arg2|arg3|
            | a  | b  | 1  |
        Then I should have received a transactionID
-       Then I wait up to "3" seconds for transaction to be committed to peers:
+       Then I wait up to "10" seconds for transaction to be committed to peers:
            | vp0  | vp1 | vp2 | vp3 |
 
       When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -637,7 +637,7 @@ Feature: lanching 3 peers
          |arg1|arg2|arg3|
          | a  | b  | 1 |
        Then I should have received a transactionID
-       Then I wait up to "3" seconds for transaction to be committed to peers:
+       Then I wait up to "10" seconds for transaction to be committed to peers:
            | vp0  | vp1 | vp3 |
 
       When I query chaincode "example2" function name "query" with value "a" on peers:

--- a/consensus/docker-compose-files/compose-consensus-4-defaults.yml
+++ b/consensus/docker-compose-files/compose-consensus-4-defaults.yml
@@ -11,4 +11,4 @@ vp:
     - CORE_PEER_PKI_ECA_PADDR=membersrvc:50051
     - CORE_PEER_PKI_TCA_PADDR=membersrvc:50051
     - CORE_PEER_PKI_TLSCA_PADDR=membersrvc:50051
-  command: fabric peer
+  command: peer peer

--- a/consensus/docker-compose-files/compose-consensus-4.md
+++ b/consensus/docker-compose-files/compose-consensus-4.md
@@ -12,7 +12,7 @@ Unless otherwise noted, you are at $GOPATH/src/github.com/hyperledger/fabric/con
 
 ### Issues
 This is what is not working right
-* cannot create a directory. Specifically when I run **fabric peer login xxx** . It says *cannot create /var/hyperledger/production/client*. I get around it by creating the directory manually and redoing the command. You might not see this error, especially if you've run **fabric** before. This will be fixed in a separate pull request.
+* cannot create a directory. Specifically when I run **peer peer login xxx** . It says *cannot create /var/hyperledger/production/client*. I get around it by creating the directory manually and redoing the command. You might not see this error, especially if you've run **fabric** before. This will be fixed in a separate pull request.
 
 ### The *infiniteloop.sh* shell script
 We use the cli container as the spot to run the client and issue CLI or REST API calls. In order for the container to stay up until we connect to it, we need to have it start and wait. *infiniteloop.sh* is just an infinite echo/sleep loop that keeps the container up until we can do a `Docker exec` to it.

--- a/consensus/docker-compose-files/compose-defaults.yml
+++ b/consensus/docker-compose-files/compose-defaults.yml
@@ -2,4 +2,4 @@ vp:
   build: .
   environment:
     - CORE_PEER_ADDRESSAUTODETECT=true
-  command: obc-peer peer
+  command: peer peer

--- a/docs/dev-setup/devnet-setup.md
+++ b/docs/dev-setup/devnet-setup.md
@@ -47,13 +47,13 @@ By default, we are using a consensus plugin called `NOOPS`, which doesn't really
 #### Start up the first validating peer:
 
 ```
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true hyperledger-peer fabric peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true hyperledger-peer peer peer
 ```
 
 If started with security, enviroment variables regarding security enabling, CA address and peer's ID and password have to be changed:
 
 ```
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_SECURITY_ENABLED=true -e CORE_SECURITY_PRIVACY=true -e CORE_PEER_PKI_ECA_PADDR=172.17.0.1:50051 -e CORE_PEER_PKI_TCA_PADDR=172.17.0.1:50051 -e CORE_PEER_PKI_TLSCA_PADDR=172.17.0.1:50051 -e CORE_SECURITY_ENROLLID=vp0 -e CORE_SECURITY_ENROLLSECRET=XX  hyperledger-peer fabric peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_SECURITY_ENABLED=true -e CORE_SECURITY_PRIVACY=true -e CORE_PEER_PKI_ECA_PADDR=172.17.0.1:50051 -e CORE_PEER_PKI_TCA_PADDR=172.17.0.1:50051 -e CORE_PEER_PKI_TLSCA_PADDR=172.17.0.1:50051 -e CORE_SECURITY_ENROLLID=vp0 -e CORE_SECURITY_ENROLLSECRET=XX  hyperledger-peer peer peer
 ```
 
 Additionally, validating peer (enrollID vp0 and enrollSecret XX) has to be added to membersrvc.yaml file (in fabric/membersrvc).
@@ -62,7 +62,7 @@ Additionally, validating peer (enrollID vp0 and enrollSecret XX) has to be added
 We need to get the IP address of the first validating peer, which will act as the root node that the new peer will connect to. The address is printed out on the terminal window of the first peer (eg 172.17.0.2). We'll use "vp2" as the ID for the second validating peer.
 
 ```
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp1 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 hyperledger-peer fabric peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:4243 -e CORE_PEER_ID=vp1 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 hyperledger-peer peer peer
 ```
 
 You can start up a few more validating peers in the similar manner as you wish. Remember to change the ID.

--- a/examples/chaincode/go/utxo/README.md
+++ b/examples/chaincode/go/utxo/README.md
@@ -54,7 +54,7 @@ go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 
 Using the Docker image that we just built, start a peer within a container in `chaincodedev` mode.
 ```
-docker run -it -p 30303:30303 -p 31315:31315 hyperledger-peer fabric peer --peer-chaincodedev
+docker run -it -p 30303:30303 -p 31315:31315 hyperledger-peer peer peer --peer-chaincodedev
 ```
 
 


### PR DESCRIPTION
Cleans up a few remaining references to `fabric` that needs to changed to `peer` as that is the default binary name.
