### PR TITLE
Get-Set Multiple keys and Copy chaincode state

### DIFF
--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -216,6 +216,23 @@ func (ledger *Ledger) DeleteState(chaincodeID string, key string) error {
 	return ledger.state.Delete(chaincodeID, key)
 }
 
+// CopyState copies all the key-values from sourceChaincodeID to destChaincodeID
+func (ledger *Ledger) CopyState(sourceChaincodeID string, destChaincodeID string) error {
+	return ledger.state.CopyState(sourceChaincodeID, destChaincodeID)
+}
+
+// GetStateMultipleKeys returns the values for the multiple keys.
+// This method is mainly to amortize the cost of grpc communication between chaincode shim peer
+func (ledger *Ledger) GetStateMultipleKeys(chaincodeID string, keys []string, committed bool) ([][]byte, error) {
+	return ledger.state.GetMultipleKeys(chaincodeID, keys, committed)
+}
+
+// SetStateMultipleKeys sets the values for the multiple keys.
+// This method is mainly to amortize the cost of grpc communication between chaincode shim peer
+func (ledger *Ledger) SetStateMultipleKeys(chaincodeID string, kvs map[string][]byte) error {
+	return ledger.state.SetMultipleKeys(chaincodeID, kvs)
+}
+
 // GetStateSnapshot returns a point-in-time view of the global state for the current block. This
 // should be used when transfering the state from one peer to another peer. You must call
 // stateSnapshot.Release() once you are done with the snapsnot to free up resources.

--- a/core/ledger/statemgmt/state/state.go
+++ b/core/ledger/statemgmt/state/state.go
@@ -187,6 +187,47 @@ func (state *State) Delete(chaincodeID string, key string) error {
 	return nil
 }
 
+// CopyState copies all the key-values from sourceChaincodeID to destChaincodeID
+func (state *State) CopyState(sourceChaincodeID string, destChaincodeID string) error {
+	itr, err := state.GetRangeScanIterator(sourceChaincodeID, "", "", true)
+	defer itr.Close()
+	if err != nil {
+		return err
+	}
+	for itr.Next() {
+		k, v := itr.GetKeyValue()
+		err := state.Set(destChaincodeID, k, v)
+		if err != nil{
+			return err
+		}
+	}
+	return nil
+}
+
+// GetMultipleKeys returns the values for the multiple keys.
+func (state *State) GetMultipleKeys(chaincodeID string, keys []string, committed bool) ([][]byte, error) {
+	var values [][]byte
+	for _,k := range keys{
+		v, err := state.Get(chaincodeID, k, committed)
+		if err != nil{
+			return nil, err
+		}
+		values = append(values, v)
+	}
+	return values, nil
+}
+
+// SetMultipleKeys sets the values for the multiple keys.
+func (state *State) SetMultipleKeys(chaincodeID string, kvs map[string][]byte) error {
+	for k,v := range kvs{
+		err := state.Set(chaincodeID, k, v)
+		if err != nil{
+			return err
+		}
+	}
+	return nil
+}
+
 // GetHash computes new state hash if the stateDelta is to be applied.
 // Recomputes only if stateDelta has changed after most recent call to this function
 func (state *State) GetHash() ([]byte, error) {


### PR DESCRIPTION
This PR include changes for 
1) get and set multiple keys to amortize the cost of grpc communication between shim and peer
2) copying state from one chaincode to another for supporting the scenario of upgrading of a chaincode
