### PR TITLE
Phase 1 of solving issue 1128

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -62,11 +62,11 @@ func SetupTestConfig() {
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
-	viper.SetConfigName("core") // name of config file (without extension)
-	viper.AddConfigPath("./")        // path to look for the config file in
-	viper.AddConfigPath("./../")     // path to look for the config file in
-	err := viper.ReadInConfig()      // Find and read the config file
-	if err != nil {                  // Handle errors reading the config file
+	viper.SetConfigName("core")  // name of config file (without extension)
+	viper.AddConfigPath("./")    // path to look for the config file in
+	viper.AddConfigPath("./../") // path to look for the config file in
+	err := viper.ReadInConfig()  // Find and read the config file
+	if err != nil {              // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
 	}
 
@@ -76,4 +76,31 @@ func SetupTestConfig() {
 	var numProcsDesired = viper.GetInt("peer.gomaxprocs")
 	log.Debug("setting Number of procs to %d, was %d\n", numProcsDesired, runtime.GOMAXPROCS(2))
 
+}
+
+// See fabric/core/peer/config.go for comments on the configuration caching
+// methodology.
+
+var coreLogger = logging.MustGetLogger("core")
+
+var configurationCached bool
+var securityEnabled bool
+
+func CacheConfiguration() error {
+	securityEnabled = viper.GetBool("security.enabled")
+	configurationCached = true
+	return nil
+}
+
+func cacheConfiguration() {
+	if err := CacheConfiguration(); err != nil {
+		coreLogger.Error("Execution continues after CacheConfiguration() failure : $s", err)
+	}
+}
+
+func SecurityEnabled() bool {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return securityEnabled
 }

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -1,0 +1,200 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+// The 'viper' package for configuration handling is very flexible, but has
+// been found to have extremely poor performance when configuration values are
+// accessed repeatedly. The function CacheConfiguration() defined here caches
+// all configuration values that are accessed frequently.  These parameters
+// are now presented as function calls that access local configuration
+// variables.  This seems to be the most robust way to represent these
+// parameters in the face of the numerous ways that configuration files are
+// loaded and used (e.g, normal usage vs. test cases).
+
+// The CacheConfiguration() function is allowed to be called globally to
+// ensure that the correct values are always cached; See for example how
+// certain parameters are forced in 'ChaincodeDevMode' in main.go.
+
+package peer
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/spf13/viper"
+
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+// Is the configuration cached?
+var configurationCached = false
+
+// Cached values and error values of the computed constants getLocalAddress(),
+// getValidatorStreamAddress(), and getPeerEndpoint()
+var localAddress string
+var localAddressError error
+var validatorStreamAddress string
+var peerEndpoint *pb.PeerEndpoint
+var peerEndpointError error
+
+// Cached values of commonly used configuration constants.
+var syncStateSnapshotChannelSize int
+var syncStateDeltasChannelSize int
+var validatorEnabled bool
+var tlsEnabled bool
+
+// Note: There is some kind of circular import issue that prevents us from
+// importing the "core" package into the "peer" package. The
+// 'peer.SecurityEnabled' bit is a duplicate of the 'core.SecurityEnabled'
+// bit.
+var securityEnabled bool
+
+// CacheConfiguration() computes and caches commonly-used constants and
+// computed constants as package variables. Routines which were previously
+// global have been embedded here to preserve the original abstraction.
+func CacheConfiguration() (err error) {
+
+	// getLocalAddress returns the address:port the local peer is operating on.  Affected by env:peer.addressAutoDetect
+	getLocalAddress := func() (peerAddress string, err error) {
+		if viper.GetBool("peer.addressAutoDetect") {
+			// Need to get the port from the peer.address setting, and append to the determined host IP
+			_, port, err := net.SplitHostPort(viper.GetString("peer.address"))
+			if err != nil {
+				err = fmt.Errorf("Error auto detecting Peer's address: %s", err)
+				return "", err
+			}
+			peerAddress = net.JoinHostPort(GetLocalIP(), port)
+			peerLogger.Info("Auto detected peer address: %s", peerAddress)
+		} else {
+			peerAddress = viper.GetString("peer.address")
+		}
+		return
+	}
+
+	// getValidatorStreamAddress returns the address to stream requests to
+	getValidatorStreamAddress := func() string {
+		localaddr, _ := getLocalAddress()
+		if viper.GetBool("peer.validator.enabled") { // in validator mode, send your own address
+			return localaddr
+		} else if valaddr := viper.GetString("peer.discovery.rootnode"); valaddr != "" {
+			return valaddr
+		}
+		return localaddr
+	}
+
+	// getPeerEndpoint returns the PeerEndpoint for this Peer instance.  Affected by env:peer.addressAutoDetect
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		var peerAddress string
+		var peerType pb.PeerEndpoint_Type
+		peerAddress, err := getLocalAddress()
+		if err != nil {
+			return nil, err
+		}
+		if viper.GetBool("peer.validator.enabled") {
+			peerType = pb.PeerEndpoint_VALIDATOR
+		} else {
+			peerType = pb.PeerEndpoint_NON_VALIDATOR
+		}
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: viper.GetString("peer.id")}, Address: peerAddress, Type: peerType}, nil
+	}
+
+	localAddress, localAddressError = getLocalAddress()
+	peerEndpoint, peerEndpointError = getPeerEndpoint()
+	validatorStreamAddress = getValidatorStreamAddress()
+
+	syncStateSnapshotChannelSize = viper.GetInt("peer.sync.state.snapshot.channelSize")
+	syncStateDeltasChannelSize = viper.GetInt("peer.sync.state.deltas.channelSize")
+	validatorEnabled = viper.GetBool("peer.validator.enabled")
+	tlsEnabled = viper.GetBool("peer.tls.enabled")
+
+	securityEnabled = viper.GetBool("security.enabled")
+
+	configurationCached = true
+
+	if localAddressError != nil {
+		return localAddressError
+	} else if peerEndpointError != nil {
+		return peerEndpointError
+	}
+	return
+}
+
+// cacheConfiguration logs an error if error checks have failed.
+func cacheConfiguration() {
+	if err := CacheConfiguration(); err != nil {
+		peerLogger.Error("Execution continues after CacheConfiguration() failure : $s", err)
+	}
+}
+
+//Functional forms
+
+func GetLocalAddress() (string, error) {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return localAddress, localAddressError
+}
+
+func getValidatorStreamAddress() string {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return validatorStreamAddress
+}
+
+func GetPeerEndpoint() (*pb.PeerEndpoint, error) {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return peerEndpoint, peerEndpointError
+}
+
+func SyncStateSnapshotChannelSize() int {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return syncStateSnapshotChannelSize
+}
+
+func SyncStateDeltasChannelSize() int {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return syncStateDeltasChannelSize
+}
+
+func ValidatorEnabled() bool {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return validatorEnabled
+}
+
+func TlsEnabled() bool {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return tlsEnabled
+}
+
+func SecurityEnabled() bool {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return securityEnabled
+}

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -141,39 +141,6 @@ func GetLocalIP() string {
 	return ""
 }
 
-// GetLocalAddress returns the address:port the local peer is operating on.  Affected by env:peer.addressAutoDetect
-func GetLocalAddress() (peerAddress string, err error) {
-	if viper.GetBool("peer.addressAutoDetect") {
-		// Need to get the port from the peer.address setting, and append to the determined host IP
-		_, port, err := net.SplitHostPort(viper.GetString("peer.address"))
-		if err != nil {
-			err = fmt.Errorf("Error auto detecting Peer's address: %s", err)
-			return "", err
-		}
-		peerAddress = net.JoinHostPort(GetLocalIP(), port)
-		//peerLogger.Info("Auto detected peer address: %s", peerAddress)
-	} else {
-		peerAddress = viper.GetString("peer.address")
-	}
-	return
-}
-
-// GetPeerEndpoint returns the PeerEndpoint for this Peer instance.  Affected by env:peer.addressAutoDetect
-func GetPeerEndpoint() (*pb.PeerEndpoint, error) {
-	var peerAddress string
-	var peerType pb.PeerEndpoint_Type
-	peerAddress, err := GetLocalAddress()
-	if err != nil {
-		return nil, err
-	}
-	if viper.GetBool("peer.validator.enabled") {
-		peerType = pb.PeerEndpoint_VALIDATOR
-	} else {
-		peerType = pb.PeerEndpoint_NON_VALIDATOR
-	}
-	return &pb.PeerEndpoint{ID: &pb.PeerID{Name: viper.GetString("peer.id")}, Address: peerAddress, Type: peerType}, nil
-}
-
 // NewPeerClientConnectionWithAddress Returns a new grpc.ClientConn to the configured local PEER.
 func NewPeerClientConnectionWithAddress(peerAddress string) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
@@ -300,7 +267,6 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
 	return peer, nil
 }
-
 
 // Chat implementation of the the Chat bidi streaming RPC function
 func (p *PeerImpl) Chat(stream pb.Peer_ChatServer) error {
@@ -535,7 +501,7 @@ func (p *PeerImpl) SendTransactionsToPeer(peerAddress string, transaction *pb.Tr
 }
 
 // sendTransactionsToLocalEngine send the transaction to the local engine (This Peer is a validator)
-func (p * PeerImpl) sendTransactionsToLocalEngine(transaction *pb.Transaction) *pb.Response {
+func (p *PeerImpl) sendTransactionsToLocalEngine(transaction *pb.Transaction) *pb.Response {
 
 	peerLogger.Debug("Marshalling transaction %s to send to local engine", transaction.Type)
 	data, err := proto.Marshal(transaction)
@@ -605,17 +571,6 @@ func (p *PeerImpl) handleChat(ctx context.Context, stream ChatStream, initiatedS
 			//return err
 		}
 	}
-}
-
-// The address to stream requests to
-func getValidatorStreamAddress() string {
-	localaddr, _ := GetLocalAddress()
-	if viper.GetBool("peer.validator.enabled") { // in validator mode, send your own address
-		return localaddr
-	} else if valaddr := viper.GetString("peer.discovery.rootnode"); valaddr != "" {
-		return valaddr
-	}
-	return localaddr
 }
 
 //ExecuteTransaction executes transactions decides to do execute in dev or prod mode


### PR DESCRIPTION
I need to stage the commits for solving #1128 into several phases, that
is caching commonly used configuratioin parameters. If I try to do a single
monolithic change I've already seen that I'll never be able to simultaneously
resolve all of the conflicts that will arise.

Phase 1 sets up the infrastructure, and redefines the peer-package functions
GetLocalAddress(), GetValidatorStreamAddress() and GetpeerEndpint() as
caching versions.

Once this is accepted, Phase2 will replace all config parameters that appear
frequenctly in single-peer runs with NOOPS with the function calls defined here. Later phases will fix up any remaining issues. I've already seen that when we're done it will make
significant improvements in performance.

Note, the Go tests all run, but some Behave tests fail intermittently. I Don't think this changeset is the cause.

Also note that a few of the changes here come from running 'gofmt' on files I changed.
