### PR TITLE
Issue1128 phase2

### DIFF
--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -22,7 +22,6 @@ package helper
 import (
 	"fmt"
 
-	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 
 	"github.com/hyperledger/fabric/core/chaincode"
@@ -45,7 +44,7 @@ type Helper struct {
 // NewHelper constructs the consensus helper object
 func NewHelper(mhc peer.MessageHandlerCoordinator) consensus.Stack {
 	return &Helper{coordinator: mhc,
-		secOn:     viper.GetBool("security.enabled"),
+		secOn:     peer.SecurityEnabled(),
 		secHelper: mhc.GetSecHelper()}
 }
 

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/hyperledger/fabric/core"
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/consensus"
 	crypto "github.com/hyperledger/fabric/core/crypto"
@@ -44,7 +45,7 @@ type Helper struct {
 // NewHelper constructs the consensus helper object
 func NewHelper(mhc peer.MessageHandlerCoordinator) consensus.Stack {
 	return &Helper{coordinator: mhc,
-		secOn:     peer.SecurityEnabled(),
+		secOn:     core.SecurityEnabled(),
 		secHelper: mhc.GetSecHelper()}
 }
 

--- a/core/devops.go
+++ b/core/devops.go
@@ -125,7 +125,7 @@ func (d *Devops) Deploy(ctx context.Context, spec *pb.ChaincodeSpec) (*pb.Chainc
 	var tx *pb.Transaction
 	var sec crypto.Client
 
-	if viper.GetBool("security.enabled") {
+	if peer.SecurityEnabled() {
 		if devopsLogger.IsEnabledFor(logging.DEBUG) {
 			devopsLogger.Debug("Initializing secure devops using context %s", spec.SecureContext)
 		}
@@ -178,7 +178,7 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 	var transaction *pb.Transaction
 	var err error
 	var sec crypto.Client
-	if viper.GetBool("security.enabled") {
+	if peer.SecurityEnabled() {
 		if devopsLogger.IsEnabledFor(logging.DEBUG) {
 			devopsLogger.Debug("Initializing secure devops using context %s", chaincodeInvocationSpec.ChaincodeSpec.SecureContext)
 		}

--- a/core/peer/handler.go
+++ b/core/peer/handler.go
@@ -158,7 +158,7 @@ func (d *Handler) beforeHello(e *fsm.Event) {
 	peerLogger.Debug("Received %s from endpoint=%s", e.Event, helloMessage)
 
 	// If security enabled, need to verify the signature on the hello message
-	if viper.GetBool("security.enabled") {
+	if SecurityEnabled() {
 		if err := d.Coordinator.GetSecHelper().Verify(helloMessage.PeerEndpoint.PkiID, msg.Signature, msg.Payload); err != nil {
 			e.Cancel(fmt.Errorf("Error Verifying signature for received HelloMessage: %s", err))
 			return

--- a/core/peer/handler_sync_state.go
+++ b/core/peer/handler_sync_state.go
@@ -22,8 +22,6 @@ package peer
 import (
 	"sync"
 
-	"github.com/spf13/viper"
-
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -54,7 +52,7 @@ func (srh *syncStateSnapshotRequestHandler) createRequest() *pb.SyncStateSnapsho
 }
 
 func makeStateSnapshotChannel() chan *pb.SyncStateSnapshot {
-	return make(chan *pb.SyncStateSnapshot, viper.GetInt("peer.sync.state.snapshot.channelSize"))
+	return make(chan *pb.SyncStateSnapshot, SyncStateSnapshotChannelSize())
 }
 
 func newSyncStateSnapshotRequestHandler() *syncStateSnapshotRequestHandler {
@@ -82,7 +80,7 @@ func (ssdh *syncStateDeltasHandler) createRequest(syncBlockRange *pb.SyncBlockRa
 }
 
 func makeSyncStateDeltasChannel() chan *pb.SyncStateDeltas {
-	return make(chan *pb.SyncStateDeltas, viper.GetInt("peer.sync.state.deltas.channelSize"))
+	return make(chan *pb.SyncStateDeltas, SyncStateDeltasChannelSize())
 }
 
 func newSyncStateDeltasHandler() *syncStateDeltasHandler {

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -144,7 +144,7 @@ func GetLocalIP() string {
 // NewPeerClientConnectionWithAddress Returns a new grpc.ClientConn to the configured local PEER.
 func NewPeerClientConnectionWithAddress(peerAddress string) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
-	if viper.GetBool("peer.tls.enabled") {
+	if TlsEnabled() {
 		var sn string
 		if viper.GetString("peer.tls.serverhostoverride") != "" {
 			sn = viper.GetString("peer.tls.serverhostoverride")
@@ -222,7 +222,7 @@ func NewPeerWithHandler(secHelperFunc func() crypto.Peer, handlerFact HandlerFac
 	peer.secHelper = secHelperFunc()
 
 	// Install security object for peer
-	if viper.GetBool("security.enabled") {
+	if SecurityEnabled() {
 		if peer.secHelper == nil {
 			return nil, fmt.Errorf("Security helper not provided")
 		}
@@ -242,11 +242,11 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 	peer = new(PeerImpl)
 	peer.handlerMap = &handlerMap{m: make(map[pb.PeerID]MessageHandler)}
 
-	peer.isValidator = viper.GetBool("peer.validator.enabled")
+	peer.isValidator = ValidatorEnabled()
 	peer.secHelper = secHelperFunc()
 
 	// Install security object for peer
-	if viper.GetBool("security.enabled") {
+	if SecurityEnabled() {
 		if peer.secHelper == nil {
 			return nil, fmt.Errorf("Security helper not provided")
 		}
@@ -545,7 +545,7 @@ func (p *PeerImpl) ExecuteTransaction(transaction *pb.Transaction) (response *pb
 // GetPeerEndpoint returns the endpoint for this peer
 func (p *PeerImpl) GetPeerEndpoint() (*pb.PeerEndpoint, error) {
 	ep, err := GetPeerEndpoint()
-	if err == nil && viper.GetBool("security.enabled") {
+	if err == nil && SecurityEnabled() {
 		// Set the PkiID on the PeerEndpoint if security is enabled
 		ep.PkiID = p.GetSecHelper().GetID()
 	}
@@ -614,7 +614,7 @@ func (p *PeerImpl) GetSecHelper() crypto.Peer {
 
 // signMessage modifies the passed in Message by setting the Signature based upon the Payload.
 func (p *PeerImpl) signMessageMutating(msg *pb.Message) (error) {
-	if viper.GetBool("security.enabled") {
+	if SecurityEnabled() {
 		sig, err := p.secHelper.Sign(msg.Payload)
 		if err != nil {
 			return fmt.Errorf("Error signing Openchain Message: %s", err)

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -43,6 +43,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/crypto/utils"
+	"github.com/hyperledger/fabric/core/peer"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -375,7 +376,7 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 	}
 
 	// If security is enabled, initialize the crypto client
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		if restLogger.IsEnabledFor(logging.DEBUG) {
 			restLogger.Debug("Initializing secure client using context '%s'", enrollmentID)
 		}
@@ -497,7 +498,7 @@ func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web
 	}
 
 	// If security is enabled, initialize the crypto client
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		if restLogger.IsEnabledFor(logging.DEBUG) {
 			restLogger.Debug("Initializing secure client using context '%s'", enrollmentID)
 		}
@@ -749,7 +750,7 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 	}
 
 	// If security is enabled, add client login token
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		chaincodeUsr := spec.SecureContext
 		if chaincodeUsr == "" {
 			rw.WriteHeader(http.StatusBadRequest)
@@ -885,7 +886,7 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	}
 
 	// If security is enabled, add client login token
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		chaincodeUsr := spec.ChaincodeSpec.SecureContext
 		if chaincodeUsr == "" {
 			rw.WriteHeader(http.StatusBadRequest)
@@ -1021,7 +1022,7 @@ func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 	}
 
 	// If security is enabled, add client login token
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		chaincodeUsr := spec.ChaincodeSpec.SecureContext
 		if chaincodeUsr == "" {
 			rw.WriteHeader(http.StatusBadRequest)
@@ -1384,7 +1385,7 @@ func (s *ServerOpenchainREST) processChaincodeDeploy(spec *pb.ChaincodeSpec) rpc
 	// Check if security is enabled
 	//
 
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		// User registrationID must be present inside request payload with security enabled
 		chaincodeUsr := spec.SecureContext
 		if chaincodeUsr == "" {
@@ -1512,7 +1513,7 @@ func (s *ServerOpenchainREST) processChaincodeInvokeOrQuery(method string, spec 
 	// Check if security is enabled
 	//
 
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		// User registrationID must be present inside request payload with security enabled
 		chaincodeUsr := spec.ChaincodeSpec.SecureContext
 		if chaincodeUsr == "" {
@@ -1738,7 +1739,7 @@ func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
 	router.NotFound((*ServerOpenchainREST).NotFound)
 
 	// Start server
-	if viper.GetBool("peer.tls.enabled") {
+	if peer.TlsEnabled() {
 		err := http.ListenAndServeTLS(viper.GetString("rest.address"), viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"), router)
 		if err != nil {
 			restLogger.Error(fmt.Sprintf("ListenAndServeTLS: %s", err))

--- a/events/consumer/consumer.go
+++ b/events/consumer/consumer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/hyperledger/fabric/core/peer"
 	ehpb "github.com/hyperledger/fabric/protos"
 )
 
@@ -51,7 +52,7 @@ func NewEventsClient(peerAddress string, adapter EventAdapter) *EventsClient {
 //newEventsClientConnectionWithAddress Returns a new grpc.ClientConn to the configured local PEER.
 func newEventsClientConnectionWithAddress(peerAddress string) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
-	if viper.GetBool("peer.tls.enabled") {
+	if peer.TlsEnabled() {
 		var sn string
 		if viper.GetString("peer.tls.serverhostoverride") != "" {
 			sn = viper.GetString("peer.tls.serverhostoverride")

--- a/peer/main.go
+++ b/peer/main.go
@@ -306,7 +306,7 @@ func createEventHubServer() (net.Listener, *grpc.Server, error) {
 	var lis net.Listener
 	var grpcServer *grpc.Server
 	var err error
-	if viper.GetBool("peer.validator.enabled") {
+	if peer.ValidatorEnabled() {
 		lis, err = net.Listen("tcp", viper.GetString("peer.validator.events.address"))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to listen: %v", err)
@@ -314,7 +314,7 @@ func createEventHubServer() (net.Listener, *grpc.Server, error) {
 
 		//TODO - do we need different SSL material for events ?
 		var opts []grpc.ServerOption
-		if viper.GetBool("peer.tls.enabled") {
+		if peer.TlsEnabled() {
 			creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
 			if err != nil {
 				return nil, nil, fmt.Errorf("Failed to generate credentials %v", err)
@@ -338,10 +338,10 @@ func getSecHelper() (crypto.Peer, error) {
 	var secHelper crypto.Peer
 	var err error
 	once.Do(func() {
-		if viper.GetBool("security.enabled") {
+		if core.SecurityEnabled() {
 			enrollID := viper.GetString("security.enrollID")
 			enrollSecret := viper.GetString("security.enrollSecret")
-			if viper.GetBool("peer.validator.enabled") {
+			if peer.ValidatorEnabled() {
 				logger.Debug("Registering validator with enroll ID: %s", enrollID)
 				if err = crypto.RegisterValidator(enrollID, nil, enrollID, enrollSecret); nil != err {
 					return
@@ -415,11 +415,11 @@ func serve(args []string) error {
 		grpclog.Fatalf("Failed to create ehub server: %v", err)
 	}
 
-	logger.Info("Security enabled status: %t", viper.GetBool("security.enabled"))
+	logger.Info("Security enabled status: %t", core.SecurityEnabled())
 	logger.Info("Privacy enabled status: %t", viper.GetBool("security.privacy"))
 
 	var opts []grpc.ServerOption
-	if viper.GetBool("peer.tls.enabled") {
+	if peer.TlsEnabled() {
 		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
 		if err != nil {
 			grpclog.Fatalf("Failed to generate credentials %v", err)
@@ -443,15 +443,12 @@ func serve(args []string) error {
 	var peerServer *peer.PeerImpl
 
 	//create the peerServer....
-	if viper.GetBool("peer.validator.enabled") {
-		if viper.GetBool("peer.validator.enabled") {
-			logger.Debug("Running as validating peer - making genesis block if needed")
-			makeGenesisError := genesis.MakeGenesis()
-			if makeGenesisError != nil {
-				return makeGenesisError
-			}
+	if peer.ValidatorEnabled() {
+		logger.Debug("Running as validating peer - making genesis block if needed")
+		makeGenesisError := genesis.MakeGenesis()
+		if makeGenesisError != nil {
+			return makeGenesisError
 		}
-
 		logger.Debug("Running as validating peer - installing consensus %s", viper.GetString("peer.validator.consensus"))
 		peerServer, err = peer.NewPeerWithEngine(secHelperFunc, helper.GetEngine)
 	} else {
@@ -497,7 +494,7 @@ func serve(args []string) error {
 
 	logger.Info("Starting peer with id=%s, network id=%s, address=%s, discovery.rootnode=%s, validator=%v",
 		peerEndpoint.ID, viper.GetString("peer.networkId"),
-		peerEndpoint.Address, rootNode, viper.GetBool("peer.validator.enabled"))
+		peerEndpoint.Address, rootNode, peer.ValidatorEnabled())
 
 	// Start the grpc server. Done in a goroutine so we can deploy the
 	// genesis block if needed.
@@ -782,7 +779,7 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 		ChaincodeID: &pb.ChaincodeID{Path: chaincodePath, Name: chaincodeName}, CtorMsg: input}
 
 	// If security is enabled, add client login token
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		logger.Debug("Security is enabled. Include security context in deploy spec")
 		if chaincodeUsr == undefinedParamValue {
 			err = errors.New("Must supply username for chaincode when security is enabled")
@@ -873,7 +870,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 		ChaincodeID: &pb.ChaincodeID{Name: chaincodeName}, CtorMsg: input}
 
 	// If security is enabled, add client login token
-	if viper.GetBool("security.enabled") {
+	if core.SecurityEnabled() {
 		if chaincodeUsr == undefinedParamValue {
 			err = errors.New("Must supply username for chaincode when security is enabled")
 			return


### PR DESCRIPTION
In the second phase of solving #1128, occurrences of the variables "security.enabled",
"peer.validator.enabled" and "peer.tls.enabled" in mainline code are replaced
with the cached versions.

Note: Based on one benchmark, the cumlative performance improvement over the baseline
is 26% for the first phase (already committed), and is now 29% after the second phase (this PR).

Once this PR is processed I'll finish by looking to see if there are commonly used variables that appear in other benchmarks, and by modifying the Go language tests for consistency.
