### PR TITLE
Fix Issue 1223

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ before_script:
 script:
 
  - echo "Executing Behave test scripts"
- - ps -ef | grep peer | grep -v grep | kill -9 `awk '{print $2}'`
  - cd $HOME/gopath/src/github.com/hyperledger/fabric/bddtests
  - sed -i -e 's/172.17.0.1:4243\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
  - sleep 5

--- a/bddtests/environment.py
+++ b/bddtests/environment.py
@@ -44,4 +44,4 @@ def after_scenario(context, scenario):
 
 # stop any running peer that could get in the way before starting the tests 
 def before_all(context):
-        cli_call(context, ["peer", "stop"], expect_success=False)
+        cli_call(context, ["../peer/peer", "stop"], expect_success=False)

--- a/bddtests/environment.py
+++ b/bddtests/environment.py
@@ -41,3 +41,7 @@ def after_scenario(context, scenario):
                     #print("docker rm {0}".format(containerId))
                     context.compose_output, context.compose_error, context.compose_returncode = \
                         cli_call(context, ["docker",  "rm", "-f", containerId], expect_success=True)
+
+# stop any running peer that could get in the way before starting the tests 
+def before_all(context):
+        cli_call(context, ["peer", "stop"], expect_success=False)


### PR DESCRIPTION
This simple fix to issue #1223 stops the local running peer if any before starting the behave tests so that it doesn't get in the way.
This depends on the fix to issue-1224 so that "peer stop" can be invoked successfully from the bddtests directory.

Signed-off-by: Arnaud Le Hors lehors@us.ibm.com
