### PR TITLE
Updated /docs/README.md with linked TOC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 
 ## Getting started
 
-Welcome to the documentation README. This page contains: 1) Getting started doc links; 2) Setup doc links; and 3) Table of Contents doc links for the complete library.
+Welcome to the fabric documentation README. This page contains: 1) Getting started doc links; 2) Setup doc links; and 3) Table of Contents doc links for the complete library.
 
 If you are new, and want to learn about our position and the scope of the project, please start by reading the [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
 
 When you are ready to start building applications or to otherwise contribute to the project, we strongly recommend that you read our [protocol specification](protocol-spec.md) for the technical details. Procedurally, we use the agile methodology with a weekly sprint, organized by [issues](https://github.com/hyperledger/fabric/issues), so take a look to familiarize yourself with the current work.
 
-## Documentation
-In addition to the <b>Getting started</b> documentation, the following topics are also available:
+## Quickstart documentation
+In addition to the <b>Getting started</b> documentation, the following quickstart topics are available:
 - [Fabric FAQs](https://github.com/hyperledger/fabric/tree/master/docs/FAQ)
 - [Canonical use cases](https://github.com/hyperledger/fabric/blob/master/docs/biz/usecases.md)
 - [Development environment set-up](https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/devenv.md)
@@ -19,14 +19,59 @@ In addition to the <b>Getting started</b> documentation, the following topics ar
 
 ## Table of Contents
 
-This table of contents provides links to the complete documentation library:
+This table of contents provides links to the complete documentation library: Overview docs; Reference docs; Developer docs; API docs; External links.
 
 ### Overview docs:
 
-- [Hyperledger project](../../hyperledger/hyperledger/)
+- [Hyperledger project](https://github.com/hyperledger/hyperledger)
+- [Fabric README](../README.md)
 - [Protocol specification](protocol-spec.md)
 - [Figures & Diagrams](/docs/images/)
 - [Glossary](glossary.md)
+
+### Reference docs:
+
+- [Maintainers](MAINTAINERS.md)
+- [Contributing](CONTRIBUTING.md)
+- [Communicating](../README.md#communication-)
+- [Project Lifecycle](https://github.com/hyperledger/hyperledger/wiki/Project-Lifecycle)
+- [License](LICENSE)
+
+### Chaincode developer docs:
+
+- [Setting up the development environment]dev-setup/devenv.md):
+     Overview (Vagrant/Docker) 
+     Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS) 
+     Steps (GOPATH, Windows, Clone Peer, VM Vagrant 
+- [Building the fabric core](../README.md#building-the-fabric-core-)
+- [Building outside of Vagrant](../README.md#building-outside-of-vagrant-)
+- [Code contributions](../README.md#code-contributions-)
+- [Coding Golang](../README.md#coding-golang-)
+- [Headers](dev-setup/headers.txt)
+- [Writing Chaincode](../README.md#writing-chaincode-)
+- [Writing, Building, and Running Chaincode in a Development Environment](API/SandboxSetup.md)
+- [Setting Up a Network](../README.md#setting-up-a-network-)
+- [Setting Up a Network For Development](dev-setup/devnet-setup.md):
+     Docker
+     Validating Peers
+     Run chaincode
+     Consensus Plugin
+- [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
+- [APIs - CLI, REST, and Node.js](../API/CoreAPI.md)
+- [Configuration](../README.md#configuration-)
+- [Logging](../README.md#logging-)
+- [Logging control](../README.md#dev-setup/logging-control.md):
+     Overview
+     Peer
+     Go
+- [Generating grpc code](../README.md#generating-grpc-code-)
+- [Adding or updating Go packages](../README.md#adding-or-updating-go-packages-)
+
+
+
+
+
+
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@ This table of contents provides links to the complete documentation library:
 
 ### Overview docs:
 
-- [Whitepaper](../../hyperledger/hyperledger/wiki/Whitepaper-WG)
-- [Protocol Specification](protocol-spec.md)
+- [Hyperledger project](../../hyperledger/hyperledger/)
+- [Protocol specification](protocol-spec.md)
 - [Figures & Diagrams](/docs/images/)
 - [Glossary](glossary.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
 
 ## Getting started
 
+Welcome to the documentation README. This page contains: 1) Getting started doc links; 2) Setup doc links; and 3) Table of Contents doc links for the complete library.
+
 If you are new, and want to learn about our position and the scope of the project, please start by reading the [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
 
 When you are ready to start building applications or to otherwise contribute to the project, we strongly recommend that you read our [protocol specification](protocol-spec.md) for the technical details. Procedurally, we use the agile methodology with a weekly sprint, organized by [issues](https://github.com/hyperledger/fabric/issues), so take a look to familiarize yourself with the current work.
@@ -14,3 +16,17 @@ In addition to the <b>Getting started</b> documentation, the following topics ar
 - [APIs](https://github.com/hyperledger/fabric/blob/master/docs/API/CoreAPI.md)
 - [Network setup](https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/devnet-setup.md)
 - [Technical implementation details](https://github.com/hyperledger/fabric/tree/master/docs/tech)
+
+## Table of Contents
+
+This table of contents provides links to the complete documentation library:
+
+### Overview docs:
+
+- [Whitepaper](../../hyperledger/wiki/Whitepaper-WG)
+- [Protocol Specification](protocol-spec.md)
+- [Figures & Diagrams](/docs/images/)
+- [Glossary](docs/glossary.md)
+
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 
 ## Getting started
 
-Welcome to the fabric documentation README. This page contains: 1) Getting started doc links; 2) Setup doc links; and 3) Table of Contents doc links for the complete library.
+Welcome to the fabric documentation README. This page contains: 
+1) Getting started doc links; 2) Quickstart doc links; and 3) Table of Contents links to the complete library.
 
 If you are new, and want to learn about our position and the scope of the project, please start by reading the [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
 
@@ -19,7 +20,8 @@ In addition to the <b>Getting started</b> documentation, the following quickstar
 
 ## Table of Contents
 
-This table of contents provides links to the complete documentation library: Overview docs; Reference docs; Developer docs; API docs; External links.
+This table of contents provides links to the complete documentation library: 
+Overview docs; Reference docs; Developer docs; API docs; External links.
 
 ### Overview docs:
 
@@ -37,9 +39,9 @@ This table of contents provides links to the complete documentation library: Ove
 - [Project Lifecycle](https://github.com/hyperledger/hyperledger/wiki/Project-Lifecycle)
 - [License](LICENSE)
 
-### Chaincode developer docs:
+### API and Chaincode developer docs:
 
-- [Setting up the development environment]dev-setup/devenv.md):
+- [Setting up the development environment](dev-setup/devenv.md): 
      Overview (Vagrant/Docker) 
      Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS) 
      Steps (GOPATH, Windows, Clone Peer, VM Vagrant 
@@ -50,23 +52,28 @@ This table of contents provides links to the complete documentation library: Ove
 - [Headers](dev-setup/headers.txt)
 - [Writing Chaincode](../README.md#writing-chaincode-)
 - [Writing, Building, and Running Chaincode in a Development Environment](API/SandboxSetup.md)
+- [Chaincode FAQ](FAQ/chaincode_FAQ.md)
 - [Setting Up a Network](../README.md#setting-up-a-network-)
-- [Setting Up a Network For Development](dev-setup/devnet-setup.md):
-     Docker
-     Validating Peers
-     Run chaincode
-     Consensus Plugin
+- [Setting Up a Network For Development](dev-setup/devnet-setup.md): 
+     Docker 
+     Validating Peers 
+     Run chaincode 
+     Consensus Plugin 
 - [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
-- [APIs - CLI, REST, and Node.js](../API/CoreAPI.md)
+- [APIs - CLI, REST, and Node.js](../API/CoreAPI.md): 
+     - [CLI](API/CoreAPI.md#cli)
+	- [REST](API/CoreAPI.md#rest-api)
+	- [Node.js Application](API/CoreAPI.md#nodejs-application)
 - [Configuration](../README.md#configuration-)
 - [Logging](../README.md#logging-)
-- [Logging control](../README.md#dev-setup/logging-control.md):
-     Overview
-     Peer
-     Go
+- [Logging control](../README.md#dev-setup/logging-control.md): 
+     Overview 
+     Peer 
+     Go 
 - [Generating grpc code](../README.md#generating-grpc-code-)
 - [Adding or updating Go packages](../README.md#adding-or-updating-go-packages-)
 
+### Network Operations docs:
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,10 +23,10 @@ This table of contents provides links to the complete documentation library:
 
 ### Overview docs:
 
-- [Whitepaper](../../hyperledger/wiki/Whitepaper-WG)
+- [Whitepaper](../../hyperledger/hyperledger/wiki/Whitepaper-WG)
 - [Protocol Specification](protocol-spec.md)
 - [Figures & Diagrams](/docs/images/)
-- [Glossary](docs/glossary.md)
+- [Glossary](glossary.md)
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,10 @@
 
 ## Getting started
 
-Welcome to the fabric documentation README. This page contains: <br>
-1) Getting started doc links; 2) Quickstart doc links; and 3) Table of Contents links to the complete library.
+Welcome to the fabric documentation README. This page contains: 
+- Getting started doc links 
+- Quickstart doc links
+- Table of Contents links to the complete library
 
 If you are new to the Linux Foundation Hyperledger Project, please start by reading the  [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
 
@@ -21,7 +23,7 @@ In addition to the <b>Getting started</b> documentation, the following quickstar
 ## Table of Contents
 
 This table of contents provides links to the complete documentation library: <br>
-Overview docs; Reference docs; API and chaincode developer docs; Network operations docs; Security administration docs; Use cases and demos; 
+Overview docs; Reference docs; API and chaincode developer docs; Network operations docs; Security administration docs; Use cases and demos; Protocol specification.
 
 ### Overview docs:
 
@@ -42,10 +44,10 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 
 ### API and chaincode developer docs:
 
-- [Setting up the development environment](dev-setup/devenv.md): <br>
-     Overview (Vagrant/Docker) <br>
-     Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS) <br>
-     Steps (GOPATH, Windows, Clone Peer, VM Vagrant <br>
+- [Setting up the development environment](dev-setup/devenv.md): 
+     - Overview (Vagrant/Docker) 
+     - Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS)
+     - Steps (GOPATH, Windows, Clone Peer, VM Vagrant
 - [Building the fabric core](../README.md#building-the-fabric-core-)
 - [Building outside of Vagrant](../README.md#building-outside-of-vagrant-)
 - [Code contributions](../README.md#code-contributions-)
@@ -55,11 +57,11 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 - [Writing, Building, and Running Chaincode in a Development Environment](API/SandboxSetup.md)
 - [Chaincode FAQ](FAQ/chaincode_FAQ.md)
 - [Setting Up a Network](../README.md#setting-up-a-network-)
-- [Setting Up a Network For Development](dev-setup/devnet-setup.md): <br>
-     - Docker <br>
-          Validating Peers <br>
-          Run chaincode <br>
-          Consensus Plugin <br>
+- [Setting Up a Network For Development](dev-setup/devnet-setup.md):
+     - Docker
+     - Validating Peers
+     - Run chaincode
+     - Consensus Plugin
 - [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
 - [APIs - CLI, REST, and Node.js](../API/CoreAPI.md): 
      - [CLI](API/CoreAPI.md#cli)
@@ -82,38 +84,38 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 
 ### Security administration docs:
 
-- [Certificate Authority (CA) Setup](dev-setup/obcca-setup.md): <br>
-     Enrollment CA <br>
-     Transaction CA <br>
-     TLS CA <br>
-     Configuration <br>
-     Build and Run <br> 
+- [Certificate Authority (CA) Setup](dev-setup/obcca-setup.md):
+     - Enrollment CA
+     - Transaction CA
+     - TLS CA
+     - Configuration
+     - Build and Run <br> 
 - [Application ACL](tech/application-ACL.md):
-     Fabric Support <br>
-     Certificate Handler <br>
-     Transaction Handler <br>
-     Client <br>
-     Transaction Format <br>
-     Validators <br>
-     Deploy Transaction <br>
-     Execute Transaction <br>
-     Chaincode Execution <br>
+     - Fabric Support
+     - Certificate Handler
+     - Transaction Handler
+     - Client
+     - Transaction Format
+     - Validators
+     - Deploy Transaction
+     - Execute Transaction
+     - Chaincode Execution
 
 ### Use cases and demos:
-- [Canonical Use Cases](/biz/usecases.md) <br>
-     B2B Contract <br>
-     Manufacturing Supply Chain <br> 
-     Asset Depository <br>
-- [Extended Use Cases](/biz/usecases.md) <br>
-     One Trade, One Contract <br>
-     Direct Communication <br>
-     Separation of Asset Ownership and Custodian's Duties <br>
-     Interoperability of Assets <br>
+- [Canonical Use Cases](/biz/usecases.md):
+     - B2B Contract
+     - Manufacturing Supply Chain
+     - Asset Depository
+- [Extended Use Cases](/biz/usecases.md):
+     - One Trade, One Contract
+     - Direct Communication
+     - Separation of Asset Ownership and Custodian's Duties
+     - Interoperability of Assets
 - [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
 - [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
 
 ### Protocol specification: 
-[Protocol Specification](protocol-spec.md) 
+[Protocol Specification](protocol-spec.md):
 - Introduction (fabric, terminology)
 - Fabric: 
      - Architecture (Membership Services, Blockchain Services, Chaincode Services, Events, API, CLI)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,50 +1,51 @@
 
 ## Getting started
 
-Welcome to the fabric documentation README. This page contains: 
+Welcome to the fabric documentation README. This page contains: <br>
 1) Getting started doc links; 2) Quickstart doc links; and 3) Table of Contents links to the complete library.
 
-If you are new, and want to learn about our position and the scope of the project, please start by reading the [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
+If you are new to the Linux Foundation Hyperledger Project, please start by reading the  [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
 
 When you are ready to start building applications or to otherwise contribute to the project, we strongly recommend that you read our [protocol specification](protocol-spec.md) for the technical details. Procedurally, we use the agile methodology with a weekly sprint, organized by [issues](https://github.com/hyperledger/fabric/issues), so take a look to familiarize yourself with the current work.
 
 ## Quickstart documentation
 In addition to the <b>Getting started</b> documentation, the following quickstart topics are available:
-- [Fabric FAQs](https://github.com/hyperledger/fabric/tree/master/docs/FAQ)
-- [Canonical use cases](https://github.com/hyperledger/fabric/blob/master/docs/biz/usecases.md)
-- [Development environment set-up](https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/devenv.md)
-- [Chain code development environment](https://github.com/hyperledger/fabric/blob/master/docs/API/SandboxSetup.md)
-- [APIs](https://github.com/hyperledger/fabric/blob/master/docs/API/CoreAPI.md)
-- [Network setup](https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/devnet-setup.md)
+- [Fabric FAQs](FAQ)
+- [Canonical use cases](biz/usecases.md)
+- [Development environment set-up](dev-setup/devenv.md)
+- [Chain code development environment](API/SandboxSetup.md)
+- [APIs](API/CoreAPI.md)
+- [Network setup](dev-setup/devnet-setup.md)
 - [Technical implementation details](https://github.com/hyperledger/fabric/tree/master/docs/tech)
 
 ## Table of Contents
 
 This table of contents provides links to the complete documentation library: 
-Overview docs; Reference docs; Developer docs; API docs; External links.
+Overview docs; Reference docs; Developer docs; API docs; External links. 
 
 ### Overview docs:
 
 - [Hyperledger project](https://github.com/hyperledger/hyperledger)
+- [Whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG)
 - [Fabric README](../README.md)
 - [Protocol specification](protocol-spec.md)
-- [Figures & Diagrams](/docs/images/)
-- [Glossary](glossary.md)
+- [Glossary](glossary.md) 
+- [Figures & Diagrams](/docs/images/) 
 
 ### Reference docs:
 
-- [Maintainers](MAINTAINERS.md)
 - [Contributing](CONTRIBUTING.md)
 - [Communicating](../README.md#communication-)
 - [Project Lifecycle](https://github.com/hyperledger/hyperledger/wiki/Project-Lifecycle)
 - [License](LICENSE)
+- [Maintainers](MAINTAINERS.md)
 
-### API and Chaincode developer docs:
+### API and chaincode developer docs:
 
-- [Setting up the development environment](dev-setup/devenv.md): 
-     Overview (Vagrant/Docker) 
-     Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS) 
-     Steps (GOPATH, Windows, Clone Peer, VM Vagrant 
+- [Setting up the development environment](dev-setup/devenv.md): <br>
+     Overview (Vagrant/Docker) <br>
+     Prerequisites (Git, Go, Vagrant, VirtualBox, BIOS) <br>
+     Steps (GOPATH, Windows, Clone Peer, VM Vagrant <br>
 - [Building the fabric core](../README.md#building-the-fabric-core-)
 - [Building outside of Vagrant](../README.md#building-outside-of-vagrant-)
 - [Code contributions](../README.md#code-contributions-)
@@ -54,11 +55,11 @@ Overview docs; Reference docs; Developer docs; API docs; External links.
 - [Writing, Building, and Running Chaincode in a Development Environment](API/SandboxSetup.md)
 - [Chaincode FAQ](FAQ/chaincode_FAQ.md)
 - [Setting Up a Network](../README.md#setting-up-a-network-)
-- [Setting Up a Network For Development](dev-setup/devnet-setup.md): 
-     Docker 
-     Validating Peers 
-     Run chaincode 
-     Consensus Plugin 
+- [Setting Up a Network For Development](dev-setup/devnet-setup.md): <br>
+     Docker <br>
+     Validating Peers <br>
+     Run chaincode <br>
+     Consensus Plugin <br>
 - [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
 - [APIs - CLI, REST, and Node.js](../API/CoreAPI.md): 
      - [CLI](API/CoreAPI.md#cli)
@@ -72,13 +73,44 @@ Overview docs; Reference docs; Developer docs; API docs; External links.
      Go 
 - [Generating grpc code](../README.md#generating-grpc-code-)
 - [Adding or updating Go packages](../README.md#adding-or-updating-go-packages-)
+- [SDK](wiki-images)
 
-### Network Operations docs:
+### Network operations docs:
 
+- [Setting Up a Network](../README.md#setting-up-a-network-)
+- [Consensus Algorithms](FAQ/consensus_FAQ.md)
 
+### Security administration docs:
 
+- [Certificate Authority (CA) Setup](dev-setup/obcca-setup.md): <br>
+     Enrollment CA <br>
+     Transaction CA <br>
+     TLS CA <br>
+     Configuration <br>
+     Build and Run <br> 
+- [Application ACL](tech/application-ACL.md):
+     Fabric Support <br>
+     Certificate Handler <br>
+     Transaction Handler <br>
+     Client <br>
+     Transaction Format <br>
+     Validators <br>
+     Deploy Transaction <br>
+     Execute Transaction <br>
+     Chaincode Execution <br>
 
-
+### Use cases and demos:
+- [Canonical Use Cases](/biz/usecases.md) <br>
+     B2B Contract <br>
+     Manufacturing Supply Chain <br> 
+     Asset Depository <br>
+- [Extended Use Cases](/biz/usecases.md) <br>
+     One Trade, One Contract <br>
+     Direct Communication <br>
+     Separation of Asset Ownership and Custodian's Duties <br>
+     Interoperability of Assets <br>
+- [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
+- [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
 
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,15 @@
 
 ## Getting started
 
-Welcome to the fabric documentation README. This page contains: 
+Welcome to the Linux Foundation Hyperledger Project documentation README. This page contains: 
 - Getting started doc links 
 - Quickstart doc links
 - Table of Contents links to the complete library
 
-If you are new to the Linux Foundation Hyperledger Project, please start by reading the  [whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG). In addition, we encourage you to review our [glossary](glossary.md) to understand the terminology that we use throughout the website and project.
+If you are new to the project, you can begin by reviewing the following documents:
+- [Whitepaper WG](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG)
+- [Requirements WG](https://github.com/hyperledger/hyperledger/wiki/Requirements-WG)
+- [Glossary](glossary.md): to understand the terminology that we use throughout the website and project.
 
 When you are ready to start building applications or to otherwise contribute to the project, we strongly recommend that you read our [protocol specification](protocol-spec.md) for the technical details. Procedurally, we use the agile methodology with a weekly sprint, organized by [issues](https://github.com/hyperledger/fabric/issues), so take a look to familiarize yourself with the current work.
 
@@ -109,18 +112,3 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - Deploy Transaction
      - Execute Transaction
      - Chaincode Execution
-
-### Use cases and demos:
-- [Canonical Use Cases](biz/usecases.md):
-     - B2B Contract
-     - Manufacturing Supply Chain
-     - Asset Depository
-- [Extended Use Cases](biz/usecases.md):
-     - One Trade, One Contract
-     - Direct Communication
-     - Separation of Asset Ownership and Custodian's Duties
-     - Interoperability of Assets
-- [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
-- [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
-
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - [Node.js Application](API/CoreAPI.md#nodejs-application)
 - [Configuration](../README.md#configuration-)
 - [Logging](../README.md#logging-)
-- [Logging control](../README.md#dev-setup/logging-control.md): 
+- [Logging control](dev-setup/logging-control.md): 
      - Overview 
      - Peer
      - Go 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,24 +15,33 @@ In addition to the <b>Getting started</b> documentation, the following quickstar
 - [Fabric FAQs](FAQ)
 - [Canonical use cases](biz/usecases.md)
 - [Development environment set-up](dev-setup/devenv.md)
-- [Chain code development environment](API/SandboxSetup.md)
+- [Chaincode development environment](API/SandboxSetup.md)
 - [APIs](API/CoreAPI.md)
 - [Network setup](dev-setup/devnet-setup.md)
-- [Technical implementation details](https://github.com/hyperledger/fabric/tree/master/docs/tech)
 
 ## Table of Contents
 
 This table of contents provides links to the complete documentation library: <br>
-Overview docs; Reference docs; API and chaincode developer docs; Network operations docs; Security administration docs; Use cases and demos; Protocol specification.
+Overview docs; Reference docs; API and chaincode developer docs; Network operations docs; Security administration docs; Use cases and demos
 
 ### Overview docs:
 
 - [Hyperledger project](https://github.com/hyperledger/hyperledger)
 - [Whitepaper](https://github.com/hyperledger/hyperledger/wiki/Whitepaper-WG)
 - [Fabric README](../README.md)
-- [Protocol specification](protocol-spec.md)
 - [Glossary](glossary.md) 
 - [Figures & Diagrams](/docs/images/) 
+- [Protocol specification](protocol-spec.md):
+     - Introduction (fabric, terminology)
+     - Fabric: 
+          - Architecture (Membership Services, Blockchain Services, Chaincode Services, Events, API, CLI)
+          - Topology (SVP, MVP, Multichain)
+          - Protocol (Messages, Ledger, Chaincode, Consensus, Events)
+          - Security (Business Security, User Security, Transaction Security, App. ACL, Wallet, Network Security (TLS))
+          - PBFT (Core PBFT, PI, Sieve)
+          - API (REST service, REST API, CLI)
+          - Application Model (Composition, Sample)
+          - Future (Systems Integration, Performance & Scalability, Consensus Plugins, Additional Languages)
 
 ### Reference docs:
 
@@ -40,7 +49,7 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 - [Communicating](../README.md#communication-)
 - [Project Lifecycle](https://github.com/hyperledger/hyperledger/wiki/Project-Lifecycle)
 - [License](../LICENSE)
-- [Maintainers](../MAINTAINERS.md)
+- [Maintainers](../MAINTAINERS.txt)
 
 ### API and chaincode developer docs:
 
@@ -114,16 +123,4 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 - [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
 - [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
 
-### Protocol specification:
-[Protocol Specification](protocol-spec.md):
-- Introduction (fabric, terminology)
-- Fabric: 
-     - Architecture (Membership Services, Blockchain Services, Chaincode Services, Events, API, CLI)
-     - Topology (SVP, MVP, Multichain)
-     - Protocol (Messages, Ledger, Chaincode, Consensus, Events)
-     - Security (Business Security, User Security, Transaction Security, App. ACL, Wallet, Network Security (TLS))
-     - PBFT (Core PBFT, PI, Sieve,)
-     - API (REST service, REST API, CLI)
-     - Application Model (Composition, Sample)
-     - Future (Systems Integration, Performance & Scalability, Consensus Plugins, Additional Languages)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ In addition to the <b>Getting started</b> documentation, the following quickstar
 
 ## Table of Contents
 
-This table of contents provides links to the complete documentation library: 
-Overview docs; Reference docs; Developer docs; API docs; External links. 
+This table of contents provides links to the complete documentation library: <br>
+Overview docs; Reference docs; API and chaincode developer docs; Network operations docs; Security administration docs; Use cases and demos; 
 
 ### Overview docs:
 
@@ -56,21 +56,21 @@ Overview docs; Reference docs; Developer docs; API docs; External links.
 - [Chaincode FAQ](FAQ/chaincode_FAQ.md)
 - [Setting Up a Network](../README.md#setting-up-a-network-)
 - [Setting Up a Network For Development](dev-setup/devnet-setup.md): <br>
-     Docker <br>
-     Validating Peers <br>
-     Run chaincode <br>
-     Consensus Plugin <br>
+     - Docker <br>
+          Validating Peers <br>
+          Run chaincode <br>
+          Consensus Plugin <br>
 - [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
 - [APIs - CLI, REST, and Node.js](../API/CoreAPI.md): 
      - [CLI](API/CoreAPI.md#cli)
-	- [REST](API/CoreAPI.md#rest-api)
-	- [Node.js Application](API/CoreAPI.md#nodejs-application)
+     - [REST](API/CoreAPI.md#rest-api)
+     - [Node.js Application](API/CoreAPI.md#nodejs-application)
 - [Configuration](../README.md#configuration-)
 - [Logging](../README.md#logging-)
 - [Logging control](../README.md#dev-setup/logging-control.md): 
-     Overview 
-     Peer 
-     Go 
+     - Overview 
+     - Peer
+     - Go 
 - [Generating grpc code](../README.md#generating-grpc-code-)
 - [Adding or updating Go packages](../README.md#adding-or-updating-go-packages-)
 - [SDK](wiki-images)
@@ -112,5 +112,16 @@ Overview docs; Reference docs; Developer docs; API docs; External links.
 - [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
 - [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
 
-
+### Protocol specification: 
+[Protocol Specification](protocol-spec.md) 
+- Introduction (fabric, terminology)
+- Fabric: 
+     - Architecture (Membership Services, Blockchain Services, Chaincode Services, Events, API, CLI)
+     - Topology (SVP, MVP, Multichain)
+     - Protocol (Messages, Ledger, Chaincode, Consensus, Events)
+     - Security (Business Security, User Security, Transaction Security, App. ACL, Wallet, Network Security (TLS))
+     - PBFT (Core PBFT, PI, Sieve,)
+     - API (REST service, REST API, CLI)
+     - Application Model (Composition, Sample)
+     - Future (Systems Integration, Performance & Scalability, Consensus Plugins, Additional Languages)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,11 +36,11 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 
 ### Reference docs:
 
-- [Contributing](CONTRIBUTING.md)
+- [Contributing](../CONTRIBUTING.md)
 - [Communicating](../README.md#communication-)
 - [Project Lifecycle](https://github.com/hyperledger/hyperledger/wiki/Project-Lifecycle)
-- [License](LICENSE)
-- [Maintainers](MAINTAINERS.md)
+- [License](../LICENSE)
+- [Maintainers](../MAINTAINERS.md)
 
 ### API and chaincode developer docs:
 
@@ -63,7 +63,7 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - Run chaincode
      - Consensus Plugin
 - [Working with CLI, REST, and Node.js](../README.md#working-with-cli-rest-and-nodejs-)
-- [APIs - CLI, REST, and Node.js](../API/CoreAPI.md): 
+- [APIs - CLI, REST, and Node.js](API/CoreAPI.md): 
      - [CLI](API/CoreAPI.md#cli)
      - [REST](API/CoreAPI.md#rest-api)
      - [Node.js Application](API/CoreAPI.md#nodejs-application)
@@ -102,11 +102,11 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - Chaincode Execution
 
 ### Use cases and demos:
-- [Canonical Use Cases](/biz/usecases.md):
+- [Canonical Use Cases](biz/usecases.md):
      - B2B Contract
      - Manufacturing Supply Chain
      - Asset Depository
-- [Extended Use Cases](/biz/usecases.md):
+- [Extended Use Cases](biz/usecases.md):
      - One Trade, One Contract
      - Direct Communication
      - Separation of Asset Ownership and Custodian's Duties
@@ -114,7 +114,7 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
 - [Marbles Demo Application](https://github.com/IBM-Blockchain/marbles )
 - [Commercial Paper Demo Application](https://github.com/IBM-Blockchain/cp-web )
 
-### Protocol specification: 
+### Protocol specification:
 [Protocol Specification](protocol-spec.md):
 - Introduction (fabric, terminology)
 - Fabric: 


### PR DESCRIPTION
TOC done for organization by function and links to GitHub docs.
Where entries are plain text, it's because the target file doesn't have the anchors in them. Will do that Tuesday. 
