### PR TITLE
Issue #1247: An empty ciphertext decrypts to nil

### DIFF
--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -794,6 +794,14 @@ func TestValidatorQueryTransaction(t *testing.T) {
 			if !bytes.Equal(pt, aPt) {
 				t.Fatalf("Failed decrypting state [%s != %s]: %s", string(pt), string(aPt), err)
 			}
+			// Try to decrypt nil. It should return nil with no error
+			out, err := seOne.Decrypt(nil)
+			if err != nil {
+				t.Fatal("Decrypt should not fail on nil input")
+			}
+			if out != nil {
+				t.Fatal("Nil input should decrypto to nil")
+			}
 
 			// Second invokeTx
 			seTwo, err := validator.GetStateEncryptor(deployTx, invokeTxTwo)
@@ -806,6 +814,14 @@ func TestValidatorQueryTransaction(t *testing.T) {
 			}
 			if !bytes.Equal(pt, aPt2) {
 				t.Fatalf("Failed decrypting state [%s != %s]: %s", string(pt), string(aPt), err)
+			}
+			// Try to decrypt nil. It should return nil with no error
+			out, err = seTwo.Decrypt(nil)
+			if err != nil {
+				t.Fatal("Decrypt should not fail on nil input")
+			}
+			if out != nil {
+				t.Fatal("Nil input should decrypto to nil")
 			}
 
 			// queryTx
@@ -822,7 +838,6 @@ func TestValidatorQueryTransaction(t *testing.T) {
 			if !bytes.Equal(aPt2, aPt3) {
 				t.Fatalf("Failed decrypting query result [%s != %s]: %s", string(aPt2), string(aPt3), err)
 			}
-
 		}
 	}
 }
@@ -878,6 +893,15 @@ func TestValidatorStateEncryptor(t *testing.T) {
 		t.Fatalf("Failed decrypting state [%s != %s]: %s", string(pt), string(aPt), err)
 	}
 
+	// Try to decrypt nil. It should return nil with no error
+	out, err := seOne.Decrypt(nil)
+	if err != nil {
+		t.Fatal("Decrypt should not fail on nil input")
+	}
+	if out != nil {
+		t.Fatal("Nil input should decrypto to nil")
+	}
+
 	seTwo, err := validator.GetStateEncryptor(deployTx, invokeTxTwo)
 	if err != nil {
 		t.Fatalf("Failed creating state encryptor [%s].", err)
@@ -888,6 +912,15 @@ func TestValidatorStateEncryptor(t *testing.T) {
 	}
 	if !bytes.Equal(pt, aPt2) {
 		t.Fatalf("Failed decrypting state [%s != %s]: %s", string(pt), string(aPt), err)
+	}
+
+	// Try to decrypt nil. It should return nil with no error
+	out, err = seTwo.Decrypt(nil)
+	if err != nil {
+		t.Fatal("Decrypt should not fail on nil input")
+	}
+	if out != nil {
+		t.Fatal("Nil input should decrypto to nil")
 	}
 
 }

--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -800,7 +800,7 @@ func TestValidatorQueryTransaction(t *testing.T) {
 				t.Fatal("Decrypt should not fail on nil input")
 			}
 			if out != nil {
-				t.Fatal("Nil input should decrypto to nil")
+				t.Fatal("Nil input should decrypt to nil")
 			}
 
 			// Second invokeTx
@@ -821,7 +821,7 @@ func TestValidatorQueryTransaction(t *testing.T) {
 				t.Fatal("Decrypt should not fail on nil input")
 			}
 			if out != nil {
-				t.Fatal("Nil input should decrypto to nil")
+				t.Fatal("Nil input should decrypt to nil")
 			}
 
 			// queryTx
@@ -899,7 +899,7 @@ func TestValidatorStateEncryptor(t *testing.T) {
 		t.Fatal("Decrypt should not fail on nil input")
 	}
 	if out != nil {
-		t.Fatal("Nil input should decrypto to nil")
+		t.Fatal("Nil input should decrypt to nil")
 	}
 
 	seTwo, err := validator.GetStateEncryptor(deployTx, invokeTxTwo)
@@ -920,7 +920,7 @@ func TestValidatorStateEncryptor(t *testing.T) {
 		t.Fatal("Decrypt should not fail on nil input")
 	}
 	if out != nil {
-		t.Fatal("Nil input should decrypto to nil")
+		t.Fatal("Nil input should decrypt to nil")
 	}
 
 }

--- a/core/crypto/validator_state.go
+++ b/core/crypto/validator_state.go
@@ -273,7 +273,7 @@ func (se *stateEncryptorImpl) Decrypt(raw []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	if len(raw) <= utils.NonceSize {
+	if len(raw) <= primitives.NonceSize {
 		return nil, utils.ErrDecrypt
 	}
 
@@ -360,7 +360,7 @@ func (se *queryStateEncryptor) Decrypt(raw []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	if len(raw) <= utils.NonceSize {
+	if len(raw) <= primitives.NonceSize {
 		return nil, utils.ErrDecrypt
 	}
 

--- a/core/crypto/validator_state.go
+++ b/core/crypto/validator_state.go
@@ -268,7 +268,12 @@ func (se *stateEncryptorImpl) Encrypt(msg []byte) ([]byte, error) {
 }
 
 func (se *stateEncryptorImpl) Decrypt(raw []byte) ([]byte, error) {
-	if len(raw) <= primitives.NonceSize {
+	if len(raw) == 0 {
+		// A nil ciphertext decrypts to nil
+		return nil, nil
+	}
+
+	if len(raw) <= utils.NonceSize {
 		return nil, utils.ErrDecrypt
 	}
 
@@ -350,7 +355,12 @@ func (se *queryStateEncryptor) Encrypt(msg []byte) ([]byte, error) {
 }
 
 func (se *queryStateEncryptor) Decrypt(raw []byte) ([]byte, error) {
-	if len(raw) <= primitives.NonceSize {
+	if len(raw) == 0 {
+		// A nil ciphertext decrypts to nil
+		return nil, nil
+	}
+
+	if len(raw) <= utils.NonceSize {
 		return nil, utils.ErrDecrypt
 	}
 


### PR DESCRIPTION
When security and confidentiality is on and a chaincode tries to get a state that does not exists then the validator asks the crypto layer to decrypt an empty ciphertext This PR modify the behavior at the crypto layer side in the following way: An empty ciphertext is decrypted to nil!

This addresses Issue #1247 
