### PR TITLE
Close clients

### DIFF
--- a/core/crypto/client.go
+++ b/core/crypto/client.go
@@ -227,7 +227,7 @@ func initClientLayer() {
 		done = make(chan struct{})
 
 		// Start client instances cleaner
-		go clientInstancesCleaner()
+		//go clientInstancesCleaner()
 
 		initialized = true
 		log.Debug("Initilize client layer...done!")

--- a/core/crypto/client.go
+++ b/core/crypto/client.go
@@ -22,16 +22,22 @@ package crypto
 import (
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	"sync"
+	"time"
 )
 
 // Private Variables
 
 type clientEntry struct {
-	client  Client
-	counter int64
+	client    Client
+	counter   int64
+	timestamp time.Time
 }
 
 var (
+	// Is client module initialized
+	initialized bool
+	done        chan struct{}
+
 	// Map of initialized clients
 	clients = make(map[string]clientEntry)
 
@@ -45,6 +51,9 @@ var (
 func RegisterClient(name string, pwd []byte, enrollID, enrollPWD string) error {
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
+
+	// Init the client layer if necessary
+	initClientLayer()
 
 	log.Info("Registering client [%s] with name [%s]...", enrollID, name)
 
@@ -78,11 +87,15 @@ func InitClient(name string, pwd []byte) (Client, error) {
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
 
+	// Init the client layer if necessary
+	initClientLayer()
+
 	log.Info("Initializing client [%s]...", name)
 
 	if entry, ok := clients[name]; ok {
 		log.Info("Client already initiliazied [%s]. Increasing counter from [%d]", name, clients[name].counter)
 		entry.counter++
+		entry.timestamp = time.Now()
 		clients[name] = entry
 
 		return clients[name].client, nil
@@ -95,7 +108,7 @@ func InitClient(name string, pwd []byte) (Client, error) {
 		return nil, err
 	}
 
-	clients[name] = clientEntry{client, 1}
+	clients[name] = clientEntry{client, 1, time.Now()}
 	log.Info("Initializing client [%s]...done!", name)
 
 	return client, nil
@@ -114,6 +127,10 @@ func CloseAllClients() (bool, []error) {
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
 
+	// Send the 'done' signal
+	done <- struct{}{}
+
+	// Close all the clients
 	log.Info("Closing all clients...")
 
 	errs := make([]error, len(clients))
@@ -124,6 +141,9 @@ func CloseAllClients() (bool, []error) {
 	}
 
 	log.Info("Closing all clients...done!")
+
+	// Reset
+	initialized = false
 
 	return len(errs) != 0, errs
 }
@@ -159,4 +179,60 @@ func closeClientInternal(client Client, force bool) error {
 	log.Debug("Closing client [%s]...decreased counter at [%d].", name, clients[name].counter)
 
 	return nil
+}
+
+func initClientLayer() {
+	if !initialized {
+		log.Debug("Initilize client layer...")
+		done = make(chan struct{})
+
+		// Start client instances cleaner
+		go clientInstancesCleaner()
+
+		initialized = true
+		log.Debug("Initilize client layer...")
+	} else {
+		log.Debug("Client layer already initialized.")
+	}
+
+}
+
+func clientInstancesCleaner() {
+	log.Debug("Client Instanes cleaner starting...")
+	var terminate bool = false
+	for {
+		select {
+		case <-done:
+			terminate = true
+
+		case <-time.After(1 * time.Second):
+			log.Debug("Time elpased, clean old client instances...")
+
+			cleanOldClientInstances()
+		}
+
+		if terminate {
+			break
+		}
+	}
+}
+
+func cleanOldClientInstances() {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+
+	now := time.Now()
+	log.Debug("Cleaning old client instances [%s]...", now)
+
+	for name, clientEntry := range clients {
+		elapsed := now.Sub(clientEntry.timestamp)
+
+		log.Debug("Client Entry [%s], elapsed [%s]", name, elapsed)
+		if elapsed.Hours() >= 1 {
+			// This entry must be removed
+
+			err := closeClientInternal(clientEntry.client, true)
+			log.Error("Failed closing client (clientInstancesCleaner) [%s]", err)
+		}
+	}
 }

--- a/core/crypto/client.go
+++ b/core/crypto/client.go
@@ -230,7 +230,7 @@ func initClientLayer() {
 		go clientInstancesCleaner()
 
 		initialized = true
-		log.Debug("Initilize client layer...")
+		log.Debug("Initilize client layer...done!")
 	} else {
 		log.Debug("Client layer already initialized.")
 	}
@@ -238,7 +238,7 @@ func initClientLayer() {
 }
 
 func clientInstancesCleaner() {
-	log.Debug("Client Instanes cleaner starting...")
+	log.Debug("Client Instances cleaner starting...")
 
 	var terminate bool = false
 	for {
@@ -250,12 +250,16 @@ func clientInstancesCleaner() {
 			log.Debug("Time elpased, clean old client instances...")
 
 			cleanOldClientInstances()
+
+			log.Debug("Time elpased, clean old client instances...done!")
 		}
 
 		if terminate {
 			break
 		}
 	}
+
+	log.Debug("Client Instances cleaner starting...done!")
 }
 
 func cleanOldClientInstances() {

--- a/core/crypto/crypto_settings.go
+++ b/core/crypto/crypto_settings.go
@@ -1,13 +1,16 @@
 package crypto
 
 import (
-	"github.com/op/go-logging"
 	"github.com/hyperledger/fabric/core/crypto/conf"
+	"github.com/op/go-logging"
 	"github.com/spf13/viper"
+	"time"
 )
 
 var (
 	log = logging.MustGetLogger("crypto")
+
+	refreshTimePeriod time.Duration
 )
 
 // Init initializes the crypto layer. It load from viper the security level
@@ -27,6 +30,15 @@ func Init() (err error) {
 			logging.GetLevel("crypto"), err)
 	}
 
+	// Init refresh time period
+	refreshTimePeriod = 720 // minutes
+	if viper.IsSet("security.client.refreshTimePeriod") {
+		ovveride := viper.GetInt("security.client.refreshTimePeriod")
+		if ovveride != 0 {
+			refreshTimePeriod = time.Duration(ovveride)
+		}
+	}
+
 	// Init security level
 
 	securityLevel := 256
@@ -36,7 +48,7 @@ func Init() (err error) {
 			securityLevel = ovveride
 		}
 	}
-	
+
 	hashAlgorithm := "SHA3"
 	if viper.IsSet("security.hashAlgorithm") {
 		ovveride := viper.GetString("security.hashAlgorithm")
@@ -44,7 +56,7 @@ func Init() (err error) {
 			hashAlgorithm = ovveride
 		}
 	}
-	
+
 	log.Debug("Working at security level [%d]", securityLevel)
 	if err = conf.InitSecurityLevel(hashAlgorithm, securityLevel); err != nil {
 		log.Debug("Failed setting security level: [%s]", err)

--- a/core/crypto/crypto_test.yaml
+++ b/core/crypto/crypto_test.yaml
@@ -21,7 +21,7 @@ security:
     tcert:
       batch:
         # The size of the batch of TCerts
-        size:  200
+        size:  50
 
 
 eca:

--- a/core/crypto/crypto_test.yaml
+++ b/core/crypto/crypto_test.yaml
@@ -21,7 +21,7 @@ security:
     tcert:
       batch:
         # The size of the batch of TCerts
-        size:  50
+        size:  2
 
 
 eca:

--- a/core/devops.go
+++ b/core/devops.go
@@ -129,8 +129,9 @@ func (d *Devops) Deploy(ctx context.Context, spec *pb.ChaincodeSpec) (*pb.Chainc
 		if devopsLogger.IsEnabledFor(logging.DEBUG) {
 			devopsLogger.Debug("Initializing secure devops using context %s", spec.SecureContext)
 		}
-		sec, err = crypto.InitClient(spec.SecureContext, nil)
-		defer crypto.CloseClient(sec)
+		sec, err = crypto.InitShortLivingClient(spec.SecureContext, nil)
+		// No need to explicitly close short-living client instances
+		// defer crypto.CloseClient(sec)
 
 		// remove the security context since we are no longer need it down stream
 		spec.SecureContext = ""
@@ -182,8 +183,9 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 		if devopsLogger.IsEnabledFor(logging.DEBUG) {
 			devopsLogger.Debug("Initializing secure devops using context %s", chaincodeInvocationSpec.ChaincodeSpec.SecureContext)
 		}
-		sec, err = crypto.InitClient(chaincodeInvocationSpec.ChaincodeSpec.SecureContext, nil)
-		defer crypto.CloseClient(sec)
+		sec, err = crypto.InitShortLivingClient(chaincodeInvocationSpec.ChaincodeSpec.SecureContext, nil)
+		// No need to explicitly close short-living client instances
+		// defer crypto.CloseClient(sec)
 		// remove the security context since we are no longer need it down stream
 		chaincodeInvocationSpec.ChaincodeSpec.SecureContext = ""
 		if nil != err {

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -381,7 +381,7 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 		}
 
 		// Initialize the security client
-		sec, err := crypto.InitClient(enrollmentID, nil)
+		sec, err := crypto.InitShortLivingClient(enrollmentID, nil)
 		if err != nil {
 			rw.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
@@ -437,7 +437,8 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 		urlEncodedCert := url.QueryEscape(string(certPEM))
 
 		// Close the security client
-		crypto.CloseClient(sec)
+		// No need to explicitly close short-living client instances
+		//crypto.CloseClient(sec)
 
 		rw.WriteHeader(http.StatusOK)
 		fmt.Fprintf(rw, "{\"OK\": \"%s\"}", urlEncodedCert)
@@ -503,7 +504,7 @@ func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web
 		}
 
 		// Initialize the security client
-		sec, err := crypto.InitClient(enrollmentID, nil)
+		sec, err := crypto.InitShortLivingClient(enrollmentID, nil)
 		if err != nil {
 			rw.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
@@ -567,7 +568,8 @@ func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web
 		}
 
 		// Close the security client
-		crypto.CloseClient(sec)
+		// No need to explicitly close short-living client instances
+		//crypto.CloseClient(sec)
 
 		// Construct a JSON formatted response
 		jsonResponse, err := json.Marshal(tcertArray)


### PR DESCRIPTION
We now distinguish between long-living and short-living client instances. 

A short-living client instance is one that is initialized (InitShortLivingClient), used (for a limited amount of time) and discarded. For this kind of instances there is no need to invoke CloseClient. An internal garbage collector will reclaim them if the time elapsed from the last initialization is more than a certain lower-bound (that can be specified using the property 'security.client.refreshTimePeriod' – an integer that represents the number of minutes).

On the other hand, a long-living client instance (InitClient) is one that can be used indefinitely and therefore CloseClient needs to be invoked explicitly when the instance is not required anymore and the 
resources can be released.

This PR introduces the differentiation described above and addresses issues #811, #996
