### PR TITLE
Issue 1266

### DIFF
--- a/bddtests/out.txt
+++ b/bddtests/out.txt
@@ -1,0 +1,1057 @@
+Feature: lanching 3 peers # peer_basic.feature:11
+  As a HyperLedger developer
+  I want to be able to launch a 3 peers
+  Scenario: Peers list test, single peer issue #827                            # peer_basic.feature:16
+    Given we compose "docker-compose-1.yml"                                    # steps/peer_basic_impl.py:95
+    And I wait "1" seconds                                                     # steps/peer_basic_impl.py:132
+    When requesting "/network/peers" from "vp0"                                # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with array "peers" contains "1" elements # steps/peer_basic_impl.py:125
+
+  Scenario: Peers list test,3 peers issue #827                                 # peer_basic.feature:23
+    Given we compose "docker-compose-3.yml"                                    # steps/peer_basic_impl.py:95
+    And I wait "1" seconds                                                     # steps/peer_basic_impl.py:132
+    When requesting "/network/peers" from "vp0"                                # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with array "peers" contains "3" elements # steps/peer_basic_impl.py:125
+
+  @wip @issue_767
+  Scenario: Range query test, single peer, issue #767                                                           # peer_basic.feature:32
+    Given we compose "docker-compose-1.yml"                                                                     # None
+    And I wait "1" seconds                                                                                      # None
+    When requesting "/chain" from "vp0"                                                                         # None
+    Then I should get a JSON response with "height" = "1"                                                       # None
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/map" with ctor "init" to "vp0" # None
+      |  |
+      |  |
+    Then I should have received a chaincode name                                                                # None
+    Then I wait up to "60" seconds for transaction to be committed to all peers                                 # None
+    When requesting "/chain" from "vp0"                                                                         # None
+    Then I should get a JSON response with "height" = "2"                                                       # None
+    When I invoke chaincode "map" function name "put" on "vp0"                                                  # None
+      | arg1 | arg2   |
+      | key1 | value1 |
+    Then I should have received a transactionID                                                                 # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                 # None
+    When requesting "/chain" from "vp0"                                                                         # None
+    Then I should get a JSON response with "height" = "3"                                                       # None
+    When I query chaincode "map" function name "get" on "vp0"                                                   # None
+      | arg1 |
+      | key1 |
+    Then I should get a JSON response with "OK" = "value1"                                                      # None
+    When I invoke chaincode "map" function name "put" on "vp0"                                                  # None
+      | arg1 | arg2   |
+      | key2 | value2 |
+    Then I should have received a transactionID                                                                 # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                 # None
+    When requesting "/chain" from "vp0"                                                                         # None
+    Then I should get a JSON response with "height" = "4"                                                       # None
+    When I query chaincode "map" function name "keys" on "vp0"                                                  # None
+      |  |
+      |  |
+    Then I should get a JSON response with "OK" = "["key1","key2"]"                                             # None
+    When I invoke chaincode "map" function name "remove" on "vp0"                                               # None
+      | arg1 |  |
+      | key1 |  |
+    Then I should have received a transactionID                                                                 # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                 # None
+    When requesting "/chain" from "vp0"                                                                         # None
+    Then I should get a JSON response with "height" = "5"                                                       # None
+    When I query chaincode "map" function name "keys" on "vp0"                                                  # None
+      |  |
+      |  |
+    Then I should get a JSON response with "OK" = "["key2"]"                                                    # None
+
+  @wip @issue_477
+  Scenario: chaincode shim table API, issue 477                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # peer_basic.feature:92
+    Given we compose "docker-compose-1.yml"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    And I wait "1" seconds                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "1"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I deploy chaincode "github.com/hyperledger/fabric/bddtests/chaincode/go/table" with ctor "init" to "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       # None
+      |  |
+      |  |
+    Then I should have received a chaincode name                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # None
+    Then I wait up to "60" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "2"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "insertRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  | arg2 | arg3 |
+      | test1 | 10   | 20   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "3"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "insertRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  | arg2 | arg3 |
+      | test2 | 10   | 20   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "4"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test1 |
+    Then I should get a JSON response with "OK" = "{[string:"test1"  int32:10  int32:20 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1 | arg2 | arg3 | arg3 |
+      | foo2 | 34   | 65   | bar8 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "5"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I query chaincode "table_test" function name "getRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1 | arg2 | arg3 |
+      | foo2 | 65   | bar8 |
+    Then I should get a JSON response with "OK" = "{[string:"foo2"  int32:34  int32:65  string:"bar8" ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "replaceRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    # None
+      | arg1  | arg2 | arg3 |
+      | test1 | 30   | 40   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "6"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test1 |
+    Then I should get a JSON response with "OK" = "{[string:"test1"  int32:30  int32:40 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I invoke chaincode "table_test" function name "deleteRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  |
+      | test1 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "7"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test1 |
+    Then I should get a JSON response with "OK" = "{[]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test2 |
+    Then I should get a JSON response with "OK" = "{[string:"test2"  int32:10  int32:20 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I invoke chaincode "table_test" function name "insertRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  | arg2 | arg3 |
+      | test3 | 10   | 20   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "8"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "insertRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  | arg2 | arg3 |
+      | test4 | 10   | 20   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "9"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "insertRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1  | arg2 | arg3 |
+      | test5 | 10   | 20   |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "10"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test3 |
+    Then I should get a JSON response with "OK" = "{[string:"test3"  int32:10  int32:20 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test4 |
+    Then I should get a JSON response with "OK" = "{[string:"test4"  int32:10  int32:20 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test5 |
+    Then I should get a JSON response with "OK" = "{[string:"test5"  int32:10  int32:20 ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+    When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1 | arg2 | arg3 | arg3  |
+      | foo2 | 35   | 65   | bar10 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "11"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1 | arg2 | arg3 | arg3  |
+      | foo2 | 36   | 65   | bar11 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "12"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1 | arg2 | arg3 | arg3  |
+      | foo2 | 37   | 65   | bar12 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "13"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I invoke chaincode "table_test" function name "insertRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     # None
+      | arg1 | arg2 | arg3 | arg3  |
+      | foo2 | 38   | 66   | bar10 |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "14"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # None
+      | arg1 | arg2 |
+      | foo2 | 65   |
+    Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]}]"                                                                                                                        # None
+    When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # None
+      | arg1 | arg2 |
+      | foo2 | 66   |
+    Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]}]"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            # None
+    When I query chaincode "table_test" function name "getRowsTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # None
+      | arg1 |
+      | foo2 |
+    Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":37}},{"Value":{"Int32":65}},{"Value":{"String_":"bar12"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":34}},{"Value":{"Int32":65}},{"Value":{"String_":"bar8"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":36}},{"Value":{"Int32":65}},{"Value":{"String_":"bar11"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":38}},{"Value":{"Int32":66}},{"Value":{"String_":"bar10"}}]},{"columns":[{"Value":{"String_":"foo2"}},{"Value":{"Int32":35}},{"Value":{"Int32":65}},{"Value":{"String_":"bar10"}}]}]" # None
+    When I invoke chaincode "table_test" function name "deleteAndRecreateTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # None
+      |  |
+      |  |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "15"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test3 |
+    Then I should get a JSON response with "OK" = "{[]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test4 |
+    Then I should get a JSON response with "OK" = "{[]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test5 |
+    Then I should get a JSON response with "OK" = "{[]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowTableOne" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1  |
+      | test2 |
+    Then I should get a JSON response with "OK" = "{[]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowTableTwo" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+      | arg1 | arg2 | arg3 |
+      | foo2 | 65   | bar8 |
+    Then I should get a JSON response with "OK" = "{[string:"foo2"  int32:34  int32:65  string:"bar8" ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               # None
+    When I invoke chaincode "table_test" function name "insertRowTableThree" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   # None
+      | arg1 | arg2 | arg3 | arg4 | arg5 | arg6  | arg7 |
+      | foo2 | -38  | -66  | 77   | 88   | hello | true |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "16"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I query chaincode "table_test" function name "getRowTableThree" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       # None
+      | arg1 |
+      | foo2 |
+    Then I should get a JSON response with "OK" = "{[string:"foo2"  int32:-38  int64:-66  uint32:77  uint64:88  bytes:"hello"  bool:true ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            # None
+    When I invoke chaincode "table_test" function name "insertRowTableFour" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    # None
+      | arg1   |
+      | foobar |
+    Then I should have received a transactionID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         # None
+    When requesting "/chain" from "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 # None
+    Then I should get a JSON response with "height" = "17"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              # None
+    When I query chaincode "table_test" function name "getRowTableFour" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # None
+      | arg1   |
+      | foobar |
+    Then I should get a JSON response with "OK" = "{[string:"foobar" ]}"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                # None
+    When I query chaincode "table_test" function name "getRowsTableFour" on "vp0"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       # None
+      | arg1   |
+      | foobar |
+    Then I should get a JSON response with "OK" = "[{"columns":[{"Value":{"String_":"foobar"}}]}]"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      # None
+
+  Scenario: chaincode example 02 single peer                                                                                    # peer_basic.feature:322
+    Given we compose "docker-compose-1.yml"                                                                                     # steps/peer_basic_impl.py:95
+    And I wait "1" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to all peers                                                 # steps/peer_basic_impl.py:276
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "2"                                                                       # steps/peer_basic_impl.py:119
+    When I query chaincode "example2" function name "query" on "vp0"                                                            # steps/peer_basic_impl.py:207
+      | arg1 |
+      | a    |
+    Then I should get a JSON response with "OK" = "100"                                                                         # steps/peer_basic_impl.py:119
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                                 # steps/peer_basic_impl.py:276
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "3"                                                                       # steps/peer_basic_impl.py:119
+    When I query chaincode "example2" function name "query" on "vp0"                                                            # steps/peer_basic_impl.py:207
+      | arg1 |
+      | a    |
+    Then I should get a JSON response with "OK" = "90"                                                                          # steps/peer_basic_impl.py:119
+    When I query chaincode "example2" function name "query" on "vp0"                                                            # steps/peer_basic_impl.py:207
+      | arg1 |
+      | b    |
+    Then I should get a JSON response with "OK" = "210"                                                                         # steps/peer_basic_impl.py:119
+
+  Scenario: chaincode example02 with 5 peers, issue #520                                                                        # peer_basic.feature:363
+    Given we compose "docker-compose-5.yml"                                                                                     # steps/peer_basic_impl.py:95
+    And I wait "1" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to all peers                                                 # steps/peer_basic_impl.py:276
+    When I query chaincode "example2" function name "query" on all peers                                                        # steps/peer_basic_impl.py:363
+      | arg1 |
+      | a    |
+    Then I should get a JSON response from all peers with "OK" = "100"                                                          # steps/peer_basic_impl.py:423
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 20   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "20" seconds for transaction to be committed to all peers                                                 # steps/peer_basic_impl.py:276
+    When I query chaincode "example2" function name "query" on all peers                                                        # steps/peer_basic_impl.py:363
+      | arg1 |
+      | a    |
+    Then I should get a JSON response from all peers with "OK" = "80"                                                           # steps/peer_basic_impl.py:423
+
+  @issue_567
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #567 -- @1.1 Consensus Options                     # peer_basic.feature:437
+    Given we compose "docker-compose-4-consensus-noops.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    And I wait "2" seconds                                                                                                      # steps/peer_basic_impl.py:140
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 20   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "80"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_567
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #567 -- @1.2 Consensus Options                     # peer_basic.feature:438
+    Given we compose "docker-compose-4-consensus-classic.yml"                                                                   # steps/peer_basic_impl.py:95
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    And I wait "2" seconds                                                                                                      # steps/peer_basic_impl.py:140
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 20   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "80"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_567
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #567 -- @1.3 Consensus Options                     # peer_basic.feature:439
+    Given we compose "docker-compose-4-consensus-batch.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    And I wait "2" seconds                                                                                                      # steps/peer_basic_impl.py:140
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 20   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "80"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_567
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #567 -- @1.4 Consensus Options                     # peer_basic.feature:440
+    Given we compose "docker-compose-4-consensus-sieve.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    And I wait "2" seconds                                                                                                      # steps/peer_basic_impl.py:140
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 20   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "80"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_680
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #680 (State transfer) -- @1.1 Consensus Options    # peer_basic.feature:521
+    Given we compose "docker-compose-4-consensus-classic.yml"                                                                   # steps/peer_basic_impl.py:95
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "30" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | b    | a    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "30" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "130"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "120"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+    Given I start peers                                                                                                         # steps/peer_basic_impl.py:515
+      | vp3 |
+    And I wait "15" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "6" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "60"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_680
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #680 (State transfer) -- @1.2 Consensus Options    # peer_basic.feature:522
+    Given we compose "docker-compose-4-consensus-batch.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "30" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | b    | a    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "30" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "130"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "120"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+    Given I start peers                                                                                                         # steps/peer_basic_impl.py:515
+      | vp3 |
+    And I wait "15" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "6" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "60"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_680
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #680 (State transfer) -- @1.3 Consensus Options    # peer_basic.feature:523
+    Given we compose "docker-compose-4-consensus-sieve.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # steps/peer_basic_impl.py:442
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "30" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | b    | a    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "30" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "130"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0"                                                          # steps/peer_basic_impl.py:196
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "120"                                                              # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+    Given I start peers                                                                                                         # steps/peer_basic_impl.py:515
+      | vp3 |
+    And I wait "15" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "6" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 10   |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "60"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+
+  @issue_724
+  Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, issue #724 -- @1.1 Consensus Options                     # peer_basic.feature:572
+    Given we compose "docker-compose-4-consensus-noops.yml"                                                                     # None
+    And I wait "3" seconds                                                                                                      # None
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                        # None
+      | vp0 |
+    And I use the following credentials for querying peers                                                                      # None
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When requesting "/chain" from "vp0"                                                                                         # None
+    Then I should get a JSON response with "height" = "1"                                                                       # None
+    And I wait "2" seconds                                                                                                      # None
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # None
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # None
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # None
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # None
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # None
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # None
+      | vp0 | vp1 | vp2 | vp3 |
+    And I wait "1" seconds                                                                                                      # None
+    Given I start peers                                                                                                         # None
+      | vp0 | vp1 | vp2 | vp3 |
+    And I wait "5" seconds                                                                                                      # None
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # None
+      | vp3 |
+    Then I should get a JSON response from peers with "OK" = "100"                                                              # None
+      | vp3 |
+
+  Scenario: basic startup of 3 validating peers           # peer_basic.feature:577
+    Given we compose "docker-compose-3.yml"               # steps/peer_basic_impl.py:95
+    When requesting "/chain" from "vp0"                   # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1" # steps/peer_basic_impl.py:119
+
+  @TLS
+  Scenario: basic startup of 2 validating peers using TLS  # peer_basic.feature:584
+    Given we compose "docker-compose-2-tls-basic.yml"      # steps/peer_basic_impl.py:95
+    When requesting "/chain" from "vp0"                    # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"  # steps/peer_basic_impl.py:119
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if one backup replica fails -- @1.1 Consensus Options       # peer_basic.feature:650
+    Given we compose "docker-compose-4-consensus-classic.yml"                                                                   # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "90"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if one backup replica fails -- @1.2 Consensus Options       # peer_basic.feature:651
+    Given we compose "docker-compose-4-consensus-batch.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "90"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if one backup replica fails -- @1.3 Consensus Options       # peer_basic.feature:652
+    Given we compose "docker-compose-4-consensus-sieve.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "10" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "90"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus fails if 2 backup replicas fail -- @1.1 Consensus Options               # peer_basic.feature:712
+    Given we compose "docker-compose-4-consensus-classic.yml"                                                                   # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "5" seconds for transaction to be committed to peers                                                      # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp1 | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:136
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus fails if 2 backup replicas fail -- @1.2 Consensus Options               # peer_basic.feature:713
+    Given we compose "docker-compose-4-consensus-batch.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "5" seconds for transaction to be committed to peers                                                      # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp1 | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:136
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus fails if 2 backup replicas fail -- @1.3 Consensus Options               # peer_basic.feature:714
+    Given we compose "docker-compose-4-consensus-sieve.yml"                                                                     # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "5" seconds for transaction to be committed to peers                                                      # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 | vp3 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 | vp3 |
+    Given I stop peers                                                                                                          # steps/peer_basic_impl.py:499
+      | vp1 | vp2 |
+    And I wait "3" seconds                                                                                                      # steps/peer_basic_impl.py:132
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "5" times                                                # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    And I wait "5" seconds                                                                                                      # steps/peer_basic_impl.py:136
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "95"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp3 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if 1 peer (vp3) is byzantine -- @1.1 Consensus Options      # peer_basic.feature:757
+    Given we compose "docker-compose-4-consensus-classic-1-byzantine.yml"                                                       # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "50" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "15" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "50"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if 1 peer (vp3) is byzantine -- @1.2 Consensus Options      # peer_basic.feature:758
+    Given we compose "docker-compose-4-consensus-batch-1-byzantine.yml"                                                         # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "50" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "15" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "50"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+
+  Scenario Outline: 4 peers and 1 membersrvc, consensus still works if 1 peer (vp3) is byzantine -- @1.3 Consensus Options      # peer_basic.feature:759
+    Given we compose "docker-compose-4-consensus-sieve-1-byzantine.yml"                                                         # steps/peer_basic_impl.py:95
+    And I wait "10" seconds                                                                                                     # steps/peer_basic_impl.py:132
+    And I use the following credentials for querying peers                                                                      # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers                                   # steps/peer_basic_impl.py:442
+      | vp0 |
+    When requesting "/chain" from "vp0"                                                                                         # steps/peer_basic_impl.py:109
+    Then I should get a JSON response with "height" = "1"                                                                       # steps/peer_basic_impl.py:119
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I invoke chaincode "example2" function name "invoke" on "vp0" "50" times                                               # steps/peer_basic_impl.py:190
+      | arg1 | arg2 | arg3 |
+      | a    | b    | 1    |
+    Then I should have received a transactionID                                                                                 # steps/peer_basic_impl.py:201
+    Then I wait up to "15" seconds for transaction to be committed to peers                                                     # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+    When I query chaincode "example2" function name "query" with value "a" on peers                                             # steps/peer_basic_impl.py:388
+      | vp0 | vp1 | vp2 |
+    Then I should get a JSON response from peers with "OK" = "50"                                                               # steps/peer_basic_impl.py:431
+      | vp0 | vp1 | vp2 |
+
+  @issue_1182
+  Scenario Outline: chaincode example02 with 4 peers,1 membersrvc, and 1 non-validating peer. -- @1.1 Consensus Options          # peer_basic.feature:792
+    Given we compose "docker-compose-4-consensus-batch.yml docker-compose-4-consensus-nvp0.yml"                                  # steps/peer_basic_impl.py:95
+    And I wait "5" seconds                                                                                                       # steps/peer_basic_impl.py:132
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers                                         # steps/peer_basic_impl.py:442
+      | nvp0 |
+    And I use the following credentials for querying peers                                                                       # steps/peer_basic_impl.py:472
+      | peer | username   | secret       |
+      | vp0  | test_user0 | MS9qrN8hFjlE |
+      | vp1  | test_user1 | jGlNl6ImkuDo |
+      | vp2  | test_user2 | zMflqOKezFiA |
+      | vp3  | test_user3 | vWdLCE00vJy0 |
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "nvp0" # steps/peer_basic_impl.py:145
+      | arg1 | arg2 | arg3 | arg4 |
+      | a    | 100  | b    | 200  |
+    Then I should have received a chaincode name                                                                                 # steps/peer_basic_impl.py:181
+    Then I wait up to "60" seconds for transaction to be committed to peers                                                      # steps/peer_basic_impl.py:323
+      | vp0 | vp1 | vp2 |
+
+Feature: utxo # utxo.feature:11
+  As an openchain developer
+  I want to be able to launch a 3 peers
+  @wip @issueUtxo
+  Scenario: UTXO chaincode test                                                                                       # utxo.feature:18
+    Given we compose "docker-compose-1.yml"                                                                           # None
+    And I wait "1" seconds                                                                                            # None
+    When requesting "/chain" from "vp0"                                                                               # None
+    Then I should get a JSON response with "height" = "1"                                                             # None
+    When I deploy chaincode "github.com/openblockchain/obc-peer/examples/chaincode/go/utxo" with ctor "init" to "vp0" # None
+      |  |
+      |  |
+    Then I should have received a chaincode name                                                                      # None
+    Then I wait up to "60" seconds for transaction to be committed to all peers                                       # None
+    When requesting "/chain" from "vp0"                                                                               # None
+    Then I should get a JSON response with "height" = "2"                                                             # None
+    When I invoke chaincode "map" function name "execute" on "vp0"                                                    # None
+      | arg1                                                                                                                                                                                                                                                                             |
+      | AQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP////9NBP//AB0BBEVUaGUgVGltZXMgMDMvSmFuLzIwMDkgQ2hhbmNlbGxvciBvbiBicmluayBvZiBzZWNvbmQgYmFpbG91dCBmb3IgYmFua3P/////AQDyBSoBAAAAQ0EEZ4r9sP5VSCcZZ/GmcTC3EFzWqCjgOQmmeWLg6h9h3rZJ9rw/TO84xPNVBOUewRLeXDhN97oLjVeKTHAra/EdX6wAAAAA |
+    Then I should have received a transactionID                                                                       # None
+    Then I wait up to "25" seconds for transaction to be committed to all peers                                       # None
+    When requesting "/chain" from "vp0"                                                                               # None
+    Then I should get a JSON response with "height" = "3"                                                             # None
+

--- a/peer/main.go
+++ b/peer/main.go
@@ -389,7 +389,7 @@ func serve(args []string) error {
 		return err
 	}
 
-	//register all system chaincodes. This just registers chaincodes, they must be 
+	//register all system chaincodes. This just registers chaincodes, they must be
 	//still be deployed and launched
 	system_chaincode.RegisterSysCCs()
 	peerEndpoint, err := peer.GetPeerEndpoint()
@@ -575,20 +575,18 @@ func stop() (err error) {
 			return
 		}
 		return nil
-	} else {
-		logger.Info("Stopping peer using grpc")
-		serverClient := pb.NewAdminClient(clientConn)
-
-		status, err := serverClient.StopServer(context.Background(), &google_protobuf.Empty{})
-		if err != nil {
-			fmt.Println(&pb.ServerStatus{Status: pb.ServerStatus_STOPPED})
-			return nil
-		} else {
-			err = fmt.Errorf("Connection remain opened, peer process doesn't exit")
-			fmt.Println(status)
-			return err
-		}
 	}
+	logger.Info("Stopping peer using grpc")
+	serverClient := pb.NewAdminClient(clientConn)
+
+	status, err := serverClient.StopServer(context.Background(), &google_protobuf.Empty{})
+	if err != nil {
+		fmt.Println(&pb.ServerStatus{Status: pb.ServerStatus_STOPPED})
+		return nil
+	}
+	err = fmt.Errorf("Connection remain opened, peer process doesn't exit")
+	fmt.Println(status)
+	return err
 }
 
 // login confirms the enrollmentID and secret password of the client with the
@@ -627,9 +625,8 @@ func login(args []string) (err error) {
 		if pw, err = gopass.GetPasswdMasked(); err != nil {
 			err = fmt.Errorf("Error trying to read password from console: %s", err)
 			return
-		} else {
-			loginPW = string(pw)
 		}
+		loginPW = string(pw)
 	}
 
 	// Log in the user
@@ -733,7 +730,7 @@ func checkChaincodeCmdParams(cmd *cobra.Command) (err error) {
 			err = fmt.Errorf("Non-empty JSON chaincode parameters must contain exactly 2 keys - 'Function' and 'Args'")
 			return
 		}
-		for k, _ := range m {
+		for k := range m {
 			switch strings.ToLower(k) {
 			case "function":
 			case "args":


### PR DESCRIPTION
fix golint errors

Fixes #1266

main.go:578:9: if block ends with a return statement, so drop this else
and outdent its block
main.go:586:10: if block ends with a return statement, so drop this
else and outdent its block
main.go:630:10: if block ends with a return statement, so drop this
else and outdent its block
main.go:736:10: should omit 2nd value from range; this loop is
equivalent to `for k := range 
…`

Signed-off-by: Christopher Ferris chrisfer@us.ibm.com
