### PR TITLE
Issue 1278

### DIFF
--- a/consensus/helper/handler.go
+++ b/consensus/helper/handler.go
@@ -81,9 +81,8 @@ func (handler *ConsensusHandler) HandleMessage(msg *pb.Message) error {
 		if err == nil {
 			if tx.Type == pb.Transaction_CHAINCODE_QUERY {
 				return handler.doChainQuery(tx)
-			} else {
-				return handler.doChainTransaction(msg, tx)
 			}
+		  return handler.doChainTransaction(msg, tx)
 		}
 	}
 


### PR DESCRIPTION
fix lint warning in handler.go

Fixes #1278

handler.go:84:11: if block ends with a return statement, so drop this
else and outdent its block

Signed-off-by: Christopher Ferris chrisfer@us.ibm.com
