### PR TITLE
make sure dbBucketNode is not nil before printing it

### DIFF
--- a/core/ledger/statemgmt/buckettree/state_impl.go
+++ b/core/ledger/statemgmt/buckettree/state_impl.go
@@ -151,11 +151,11 @@ func (stateImpl *StateImpl) processBucketTreeDelta() error {
 		for _, bucketNode := range bucketNodes {
 			logger.Debug("bucketNode in tree-delta [%s]", bucketNode)
 			dbBucketNode, err := stateImpl.bucketCache.get(*bucketNode.bucketKey)
-			logger.Debug("bucket node from db [%s]", dbBucketNode)
 			if err != nil {
 				return err
 			}
 			if dbBucketNode != nil {
+				logger.Debug("bucket node from db [%s]", dbBucketNode)
 				bucketNode.mergeBucketNode(dbBucketNode)
 				logger.Debug("After merge... bucketNode in tree-delta [%s]", bucketNode)
 			}


### PR DESCRIPTION
It is possible to get nil, nil from stateImpl.bucketCache.get(_bucketNode.bucketKey), if it calls fetchBucketNodeFromDB(bucketKey *bucketKey) (_bucketNode, error) and gets nil, nil returned.
It gets crash if we want to print nil string via logger.Debug().
