### PR TITLE
Fix for #1291 'panic: concurrent map writes in crypto.(*peerImpl).getEnrollmentCert'

### DIFF
--- a/core/crypto/peer.go
+++ b/core/crypto/peer.go
@@ -131,7 +131,7 @@ func CloseAllPeers() (bool, []error) {
 // Private Methods
 
 func newPeer() *peerImpl {
-	return &peerImpl{&nodeImpl{}, nil, false}
+	return &peerImpl{&nodeImpl{}, sync.RWMutex{}, nil, false}
 }
 
 func closePeerInternal(peer Peer, force bool) error {

--- a/core/crypto/peer_eca.go
+++ b/core/crypto/peer_eca.go
@@ -37,7 +37,7 @@ func (peer *peerImpl) getEnrollmentCert(id []byte) (*x509.Certificate, error) {
 
 	peer.debug("Getting enrollment certificate for [%s]", sid)
 
-	if cert := peer.enrollCerts[sid]; cert != nil {
+	if cert := peer.getNodeEnrollmentCertificate(sid); cert != nil {
 		peer.debug("Enrollment certificate for [%s] already in memory.", sid)
 		return cert, nil
 	}
@@ -58,7 +58,7 @@ func (peer *peerImpl) getEnrollmentCert(id []byte) (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	peer.enrollCerts[sid] = cert
+	peer.putNodeEnrollmentCertificate(sid, cert)
 
 	return cert, nil
 }
@@ -107,4 +107,16 @@ func (peer *peerImpl) getEnrollmentCertByHashFromECA(id []byte) ([]byte, []byte,
 	}
 
 	return responce.Sign, responce.Enc, nil
+}
+
+func (peer *peerImpl) getNodeEnrollmentCertificate(sid string) *x509.Certificate {
+	peer.nodeEnrollmentCertificatesMutex.RLock()
+	defer peer.nodeEnrollmentCertificatesMutex.RUnlock()
+	return peer.nodeEnrollmentCertificates[sid]
+}
+
+func (peer *peerImpl) putNodeEnrollmentCertificate(sid string, cert *x509.Certificate) {
+	peer.nodeEnrollmentCertificatesMutex.Lock()
+	defer peer.nodeEnrollmentCertificatesMutex.Unlock()
+	peer.nodeEnrollmentCertificates[sid] = cert
 }

--- a/core/crypto/peer_impl.go
+++ b/core/crypto/peer_impl.go
@@ -26,12 +26,14 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	obc "github.com/hyperledger/fabric/protos"
+	"sync"
 )
 
 type peerImpl struct {
 	*nodeImpl
 
-	enrollCerts map[string]*x509.Certificate
+	nodeEnrollmentCertificatesMutex sync.RWMutex
+	nodeEnrollmentCertificates      map[string]*x509.Certificate
 
 	isInitialized bool
 }
@@ -210,7 +212,7 @@ func (peer *peerImpl) init(eType NodeType, id string, pwd []byte) error {
 	peer.isInitialized = true
 
 	// EnrollCerts
-	peer.enrollCerts = make(map[string]*x509.Certificate)
+	peer.nodeEnrollmentCertificates = make(map[string]*x509.Certificate)
 
 	return nil
 }

--- a/core/crypto/validator.go
+++ b/core/crypto/validator.go
@@ -131,7 +131,7 @@ func CloseAllValidators() (bool, []error) {
 // Private Methods
 
 func newValidator() *validatorImpl {
-	return &validatorImpl{&peerImpl{&nodeImpl{}, nil, false}, false, nil}
+	return &validatorImpl{&peerImpl{&nodeImpl{}, sync.RWMutex{}, nil, false}, false, nil}
 }
 
 func closeValidatorInternal(peer Peer, force bool) error {


### PR DESCRIPTION
Addressing issue #1291 addeding a RWMutex to control access to the internal data structure used to store the enrollment certificates of the nvp and vp.

@corecode, may you give a look at this? :)

Signed-off-by: Angelo De Caro  adc@zurich.ibm.com
