### PR TITLE
Fix #1301 by changing port events_test port from 50303 to 60303

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -148,7 +148,7 @@ func TestMain(m *testing.M) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress = "0.0.0.0:50303"
+	peerAddress = "0.0.0.0:60303"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {


### PR DESCRIPTION
I've scanned the codebase - there are no other occurrences of 60303. I also looked for port conflicts in general. I did not see any more in the directories included in the tests, although there does appear that there might be one in the examples/chaincode/go/asset_management\* tests (which are currently excluded).

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
