### PR TITLE
Added the `shim.SetLoggingLevel` API

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 
@@ -37,8 +36,6 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	pb "github.com/hyperledger/fabric/protos"
 )
-
-var chaincodeLog = logging.MustGetLogger("chaincode")
 
 // ChainName is the name of the chain to which this chaincode support belongs to.
 type ChainName string
@@ -107,12 +104,12 @@ func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEn
 
 	peerEndpoint, err := getPeerEndpoint()
 	if err != nil {
-		chaincodeLog.Error(fmt.Sprintf("Error getting PeerEndpoint, using peer.address: %s", err))
+		chaincodeLogger.Error(fmt.Sprintf("Error getting PeerEndpoint, using peer.address: %s", err))
 		s.peerAddress = viper.GetString("peer.address")
 	} else {
 		s.peerAddress = peerEndpoint.Address
 	}
-	chaincodeLog.Info("Chaincode support using peerAddress: %s\n", s.peerAddress)
+	chaincodeLogger.Info("Chaincode support using peerAddress: %s\n", s.peerAddress)
 	//peerAddress = viper.GetString("peer.address")
 	if s.peerAddress == "" {
 		s.peerAddress = peerAddressDefault
@@ -226,7 +223,7 @@ func (chaincodeSupport *ChaincodeSupport) sendInitOrReady(context context.Contex
 	var ok bool
 	if chrte, ok = chaincodeSupport.chaincodeHasBeenLaunched(chaincode); !ok {
 		chaincodeSupport.runningChaincodes.Unlock()
-		chaincodeLog.Debug("handler not found for chaincode %s", chaincode)
+		chaincodeLogger.Debug("handler not found for chaincode %s", chaincode)
 		return fmt.Errorf("handler not found for chaincode %s", chaincode)
 	}
 	chaincodeSupport.runningChaincodes.Unlock()
@@ -260,7 +257,7 @@ func (chaincodeSupport *ChaincodeSupport) getArgsAndEnv(cID *pb.ChaincodeID) (ar
 	//chaincode executable will be same as the name of the chaincode
 	args = []string{chaincodeSupport.chaincodeInstallPath + cID.Name, fmt.Sprintf("-peer.address=%s", chaincodeSupport.peerAddress)}
 
-	chaincodeLog.Debug("Executable is %s", args[0])
+	chaincodeLogger.Debug("Executable is %s", args[0])
 
 	return args, envs, nil
 }
@@ -276,7 +273,7 @@ func (chaincodeSupport *ChaincodeSupport) launchAndWaitForRegister(ctxt context.
 	var ok bool
 	//if its in the map, there must be a connected stream...nothing to do
 	if _, ok = chaincodeSupport.chaincodeHasBeenLaunched(chaincode); ok {
-		chaincodeLog.Debug("chaincode is running and ready: %s", chaincode)
+		chaincodeLogger.Debug("chaincode is running and ready: %s", chaincode)
 		chaincodeSupport.runningChaincodes.Unlock()
 		return true, nil
 	}
@@ -291,7 +288,7 @@ func (chaincodeSupport *ChaincodeSupport) launchAndWaitForRegister(ctxt context.
 		return alreadyRunning, err
 	}
 
-	chaincodeLog.Debug("start container: %s(networkid:%s,peerid:%s)", chaincode, chaincodeSupport.peerNetworkID, chaincodeSupport.peerID)
+	chaincodeLogger.Debug("start container: %s(networkid:%s,peerid:%s)", chaincode, chaincodeSupport.peerNetworkID, chaincodeSupport.peerID)
 
 	vmtype, _ := chaincodeSupport.getVMType(cds)
 
@@ -321,10 +318,10 @@ func (chaincodeSupport *ChaincodeSupport) launchAndWaitForRegister(ctxt context.
 		err = fmt.Errorf("Timeout expired while starting chaincode %s(networkid:%s,peerid:%s,tx:%s)", chaincode, chaincodeSupport.peerNetworkID, chaincodeSupport.peerID, uuid)
 	}
 	if err != nil {
-		chaincodeLog.Debug("stopping due to error while launching %s", err)
+		chaincodeLogger.Debug("stopping due to error while launching %s", err)
 		errIgnore := chaincodeSupport.StopChaincode(ctxt, cds)
 		if errIgnore != nil {
-			chaincodeLog.Debug("error on stop %s(%s)", errIgnore, err)
+			chaincodeLogger.Debug("error on stop %s(%s)", errIgnore, err)
 		}
 	}
 	return alreadyRunning, err
@@ -401,16 +398,16 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 	if chrte, ok = chaincodeSupport.chaincodeHasBeenLaunched(chaincode); ok {
 		if !chrte.handler.registered {
 			chaincodeSupport.runningChaincodes.Unlock()
-			chaincodeLog.Debug("premature execution - chaincode (%s) is being launched", chaincode)
+			chaincodeLogger.Debug("premature execution - chaincode (%s) is being launched", chaincode)
 			err = fmt.Errorf("premature execution - chaincode (%s) is being launched", chaincode)
 			return cID, cMsg, err
 		}
 		if chrte.handler.isRunning() {
-			chaincodeLog.Debug("chaincode is running(no need to launch) : %s", chaincode)
+			chaincodeLogger.Debug("chaincode is running(no need to launch) : %s", chaincode)
 			chaincodeSupport.runningChaincodes.Unlock()
 			return cID, cMsg, nil
 		}
-		chaincodeLog.Debug("Container not in READY state(%s)...send init/ready", chrte.handler.FSM.Current())
+		chaincodeLogger.Debug("Container not in READY state(%s)...send init/ready", chrte.handler.FSM.Current())
 	}
 	chaincodeSupport.runningChaincodes.Unlock()
 
@@ -462,7 +459,7 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 	if (!chaincodeSupport.userRunsCC || cds.ExecEnv == pb.ChaincodeDeploymentSpec_SYSTEM) && (chrte == nil || chrte.handler == nil) {
 		_, err = chaincodeSupport.launchAndWaitForRegister(context, cds, cID, t.Uuid)
 		if err != nil {
-			chaincodeLog.Debug("launchAndWaitForRegister failed %s", err)
+			chaincodeLogger.Debug("launchAndWaitForRegister failed %s", err)
 			return cID, cMsg, err
 		}
 	}
@@ -471,17 +468,17 @@ func (chaincodeSupport *ChaincodeSupport) LaunchChaincode(context context.Contex
 		//send init (if (f,args)) and wait for ready state
 		err = chaincodeSupport.sendInitOrReady(context, t.Uuid, chaincode, f, initargs, chaincodeSupport.ccStartupTimeout, t, depTx)
 		if err != nil {
-			chaincodeLog.Debug("sending init failed(%s)", err)
+			chaincodeLogger.Debug("sending init failed(%s)", err)
 			err = fmt.Errorf("Failed to init chaincode(%s)", err)
 			errIgnore := chaincodeSupport.StopChaincode(context, cds)
 			if errIgnore != nil {
-				chaincodeLog.Debug("stop failed %s(%s)", errIgnore, err)
+				chaincodeLogger.Debug("stop failed %s(%s)", errIgnore, err)
 			}
 		}
-		chaincodeLog.Debug("sending init completed")
+		chaincodeLogger.Debug("sending init completed")
 	}
 
-	chaincodeLog.Debug("LaunchChaincode complete")
+	chaincodeLogger.Debug("LaunchChaincode complete")
 
 	return cID, cMsg, err
 }
@@ -515,14 +512,14 @@ func (chaincodeSupport *ChaincodeSupport) DeployChaincode(context context.Contex
 	}
 
 	if chaincodeSupport.userRunsCC {
-		chaincodeLog.Debug("user runs chaincode, not deploying chaincode")
+		chaincodeLogger.Debug("user runs chaincode, not deploying chaincode")
 		return nil, nil
 	}
 
 	chaincodeSupport.runningChaincodes.Lock()
 	//if its in the map, there must be a connected stream...and we are trying to build the code ?!
 	if _, ok := chaincodeSupport.chaincodeHasBeenLaunched(chaincode); ok {
-		chaincodeLog.Debug("deploy ?!! there's a chaincode with that name running: %s", chaincode)
+		chaincodeLogger.Debug("deploy ?!! there's a chaincode with that name running: %s", chaincode)
 		chaincodeSupport.runningChaincodes.Unlock()
 		return cds, fmt.Errorf("deploy attempted but a chaincode with same name running %s", chaincode)
 	}
@@ -538,7 +535,7 @@ func (chaincodeSupport *ChaincodeSupport) DeployChaincode(context context.Contex
 
 	vmtype, _ := chaincodeSupport.getVMType(cds)
 
-	chaincodeLog.Debug("deploying chaincode %s(networkid:%s,peerid:%s)", chaincode, chaincodeSupport.peerNetworkID, chaincodeSupport.peerID)
+	chaincodeLogger.Debug("deploying chaincode %s(networkid:%s,peerid:%s)", chaincode, chaincodeSupport.peerNetworkID, chaincodeSupport.peerID)
 
 	//create image and create container
 	_, err = container.VMCProcess(context, vmtype, cir)
@@ -585,7 +582,7 @@ func (chaincodeSupport *ChaincodeSupport) Execute(ctxt context.Context, chaincod
 	chrte, ok := chaincodeSupport.chaincodeHasBeenLaunched(chaincode)
 	if !ok {
 		chaincodeSupport.runningChaincodes.Unlock()
-		chaincodeLog.Debug("cannot execute-chaincode is not running: %s", chaincode)
+		chaincodeLogger.Debug("cannot execute-chaincode is not running: %s", chaincode)
 		return nil, fmt.Errorf("Cannot execute transaction or query for %s", chaincode)
 	}
 	chaincodeSupport.runningChaincodes.Unlock()

--- a/core/chaincode/config.go
+++ b/core/chaincode/config.go
@@ -46,7 +46,7 @@ func SetupTestLogging() {
 		logging.SetLevel(level, "server")
 		logging.SetLevel(level, "peer")
 	} else {
-		chaincodeLog.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("logging.peer"), logging.ERROR, err)
+		chaincodeLogger.Warning("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("logging.peer"), logging.ERROR, err)
 		logging.SetLevel(logging.ERROR, "main")
 		logging.SetLevel(logging.ERROR, "server")
 		logging.SetLevel(logging.ERROR, "peer")
@@ -74,6 +74,6 @@ func SetupTestConfig() {
 
 	// Set the number of maxprocs
 	var numProcsDesired = viper.GetInt("peer.gomaxprocs")
-	chaincodeLog.Debug("setting Number of procs to %d, was %d\n", numProcsDesired, runtime.GOMAXPROCS(2))
+	chaincodeLogger.Debug("setting Number of procs to %d, was %d\n", numProcsDesired, runtime.GOMAXPROCS(2))
 
 }

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -108,7 +108,7 @@ func (handler *Handler) serialSend(msg *pb.ChaincodeMessage) error {
 	handler.Lock()
 	defer handler.Unlock()
 	if err := handler.ChatStream.Send(msg); err != nil {
-		chaincodeLog.Error(fmt.Sprintf("Error sending %s: %s", msg.Type.String(), err))
+		chaincodeLogger.Error(fmt.Sprintf("Error sending %s: %s", msg.Type.String(), err))
 		return fmt.Errorf("Error sending %s: %s", msg.Type.String(), err)
 	}
 	return nil
@@ -268,7 +268,7 @@ func (handler *Handler) processStream() error {
 				chaincodeLogger.Debug("Received EOF, ending chaincode support stream, %s", err)
 				return err
 			} else if err != nil {
-				chaincodeLog.Error(fmt.Sprintf("Error handling chaincode support stream: %s", err))
+				chaincodeLogger.Error(fmt.Sprintf("Error handling chaincode support stream: %s", err))
 				return err
 			} else if in == nil {
 				err = fmt.Errorf("Received nil message, ending chaincode support stream")
@@ -293,7 +293,7 @@ func (handler *Handler) processStream() error {
 		}
 		err = handler.HandleMessage(in)
 		if err != nil {
-			chaincodeLog.Error(fmt.Sprintf("[%s]Error handling message, ending stream: %s", shortuuid(in.Uuid), err))
+			chaincodeLogger.Error(fmt.Sprintf("[%s]Error handling message, ending stream: %s", shortuuid(in.Uuid), err))
 			return fmt.Errorf("Error handling message, ending stream: %s", err)
 		}
 		if nsInfo != nil && nsInfo.sendToCC {

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -250,6 +250,23 @@ func (stub *ChaincodeStub) init(uuid string, secContext *pb.ChaincodeSecurityCon
 	stub.securityContext = secContext
 }
 
+// ------------- Logging Control ---------------
+
+// SetLoggingLevel allows a Go chaincode to set the logging level of its
+// shim. The logging level is a case-insensitive string chosen from CRITICAL,
+// ERROR, WARNING, NOTICE, INFO or DEBUG. In the event of errors assume that
+// the logging level has not changed. This API uses the string form of the
+// level so as not to require the caller to have imported go-logging.
+func SetLoggingLevel(levelString string) error {
+	level, err := logging.LogLevel(levelString)
+	if err != nil {
+		chaincodeLogger.Warning("Logging level '%s' not recognized; Logging level unchanged : %s", err)
+		return err
+	}
+	logging.SetLevel(level, "chaincode")
+	return nil
+}
+
 // --------- Security functions ----------
 //CHAINCODE SEC INTERFACE FUNCS TOBE IMPLEMENTED BY ANGELO
 

--- a/core/chaincode/shim/shim_test.go
+++ b/core/chaincode/shim/shim_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shim
+
+import (
+	"testing"
+)
+
+
+// Test Go shim functionality that can be tested outside of a real chaincode
+// context.
+
+
+// TestSetLoggingLevel simply tests that the API is working, and
+// case-insensitive strings are accepted. We don't actually test that the logs
+// are printed at the correct level.
+func TestSetLoggingLevel(t *testing.T) {
+	var err error
+	if err = SetLoggingLevel("debug"); err != nil {
+		t.Errorf("SetLoggingLevel(debug) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("INFO"); err != nil {
+		t.Errorf("SetLoggingLevel(INFO) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("Notice"); err != nil {
+		t.Errorf("SetLoggingLevel(Notice) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("WaRnInG"); err != nil {
+		t.Errorf("SetLoggingLevel(WaRnInG) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("ERRor"); err != nil {
+		t.Errorf("SetLoggingLevel(ERRor) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("critICAL"); err != nil {
+		t.Errorf("SetLoggingLevel(critiCAL) failed : %s", err.Error())
+	}
+	if err = SetLoggingLevel("foo"); err == nil {
+		t.Errorf("SetLoggingLevel(foo) should have failed but didn't!")
+	}
+}
+	
+		

--- a/docs/API/ChaincodeAPI.md
+++ b/docs/API/ChaincodeAPI.md
@@ -20,6 +20,17 @@ It's possible for one deployed chaincode to call another deployed chaincode usin
 
 `QueryChaincode(chaincodeName string, function string, args []string) ([]byte, error)` - Queries the specified chaincode from the current chaincode.
 
+## Logging
+
+`SetLoggingLevel` allows a Go chaincode to set the logging level of its
+shim. The logging level is a case-insensitive string chosen from CRITICAL,
+ERROR, WARNING, NOTICE, INFO or DEBUG. In the event of errors assume that the
+logging level has not changed. For information on how a chaincode can create
+its own logs, please see [here](../dev-setup/logging-control.md).
+
+`SetLoggingLevel(levelString string) error` - Set the logging level of the shim
+
+
 ## Future APIs
 
 The APIs available today are just a start. Future APIs will allow chaincode to query transactions, blocks, and possibly previous state. Open an issue in the [repository](https://github.com/hyperledger/fabric/issues) to add your support for APIs you would like to see.

--- a/docs/dev-setup/logging-control.md
+++ b/docs/dev-setup/logging-control.md
@@ -65,19 +65,32 @@ syntax. Examples of <level> specifications (valid for both --logging-level and
 
 
 
-### GO chaincodes
+### Go chaincodes
 
-There is currently no generic way to control logging in GO chaincodes. The
-chaincode _shim_ currently defaults to DEBUG level logging, creating large
-log files in the chaincode containers. The following is a suggested
-workaround: First, add
+As independently executed programs, user-provided chaincodes can use any
+appropriate technique to create their private logs - from simple print
+statements to annotated and level-controlled logs.  For example, one way to
+create basic levelled logs is to first add
 
     "github.com/op/go-logging"
 	
-to the _imports_ of the chaincode. Also add a line like
+to the _imports_ of the chaincode. Then define a logger for the chaincode
 
-    logging.SetLevel(logging.WARNING, "")
+    logger = logging.MustGetLogger("MyChaincode")
 	
-as the first line of the chaincode `main` routine to suppress all but WARNING
-and more severe errors.
+where "MyChaincode" is the logging _module_ name. Once the logger (or loggers)
+is defined, the chaincode can call `logging.Debug`, `logging.Info`, etc. to
+create logs at various severity levels. The logging level of a module can be
+set, for example by
 
+    logging.SetLevel(logging.WARNING, "MyChaincode")
+
+so that only WARNING and more severe messages are logged for the "MyChaincode"
+module. If you want to create fancier logs formatted with colors, timestamps,
+routine names etc., see how the peer sets up its logging
+[here](../../core/logging.go), or refer to the `go-logging` documentation
+[here](../../vendor/github.com/op/go-logging/README.md).
+
+Go language chaincodes can also control the logging level of the chaincode
+_shim_ interface through the `shim.SetLoggingLevel` API documented
+[here](../API/ChaincodeAPI.md).


### PR DESCRIPTION
This is a solution to #618. Go language chaincodes can now call
`shim.SetLoggingLevel` to control logging in the shim. There is no requirement
that the chaincode have included the op/go-logging package, or know anything
about how logging is implemented in the shim. The appropriate documentation
has also been updated.

Since I was mucking around with chaincode logging I went ahead and also fixed #1303 by deleting the redundant logger from the chaincode package.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
