### PR TITLE
Fixing permission issue when running CA server and the peer

### DIFF
--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -84,7 +84,7 @@ From your command line terminal, move to the `devenv` subdirectory of your works
 Register the user though the CLI, substituting for `<username>` appropriately:
 
     cd $GOPATH/src/github.com/hyperledger/fabric/peer
-    ./peer login <username>
+    sudo ./peer login <username>
 
 The command will prompt for a password, which must match the <b>enrollmentPW</b> listed for the target user in the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file. If the password entered does not match the <b>enrollmentPW</b>, an error will result.
 

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -25,9 +25,7 @@ To set up the local development environment with security enabled, you must firs
 
     cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
     go build
-    sudo -s
-    export GOPATH=/opt/gopath
-    ./membersrvc
+    sudo ./membersrvc
 
 Running the above commands builds and runs the CA server with the default setup, which is defined in the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) configuration file. The default configuration includes multiple users who are already registered with the CA; these users are listed in the 'users' section of the configuration file. To register additional users with the CA for testing, modify the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file to include additional enrollmentID and enrollmentPW pairs. Note the integer that precedes the enrollmentPW. That integer indicates the role of the user, where 1 = client, 2 = non-validating peer, 4 = validating peer, and 8 = auditor.
 
@@ -42,9 +40,7 @@ Build and run the peer process to enable security and privacy after setting <b>s
 
     cd $GOPATH/src/github.com/hyperledger/fabric/peer
     go build
-    sudo -s
-    export GOPATH=/opt/gopath
-    ./peer peer --peer-chaincodedev   
+    sudo ./peer peer --peer-chaincodedev   
 
 Alternatively, enable security and privacy on the peer with environment variables:
 

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -25,6 +25,8 @@ To set up the local development environment with security enabled, you must firs
 
     cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
     go build
+    sudo -s
+    export GOPATH=/opt/gopath
     ./membersrvc
 
 Running the above commands builds and runs the CA server with the default setup, which is defined in the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) configuration file. The default configuration includes multiple users who are already registered with the CA; these users are listed in the 'users' section of the configuration file. To register additional users with the CA for testing, modify the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file to include additional enrollmentID and enrollmentPW pairs. Note the integer that precedes the enrollmentPW. That integer indicates the role of the user, where 1 = client, 2 = non-validating peer, 4 = validating peer, and 8 = auditor.
@@ -40,6 +42,8 @@ Build and run the peer process to enable security and privacy after setting <b>s
 
     cd $GOPATH/src/github.com/hyperledger/fabric/peer
     go build
+    sudo -s
+    export GOPATH=/opt/gopath
     ./peer peer --peer-chaincodedev   
 
 Alternatively, enable security and privacy on the peer with environment variables:


### PR DESCRIPTION
Without 'sudo -s' if someone follows the doc as it is, they will get following errors,

```
vagrant@ubuntu-1404:/opt/gopath/src/github.com/hyperledger/fabric/membersrvc$ ./membersrvc
2016/05/01 09:46:08 Log level not recognized '', defaulting to DEBUG: logger: invalid log level
2016/05/01 09:46:08 Working at security level [256]
INFO: 2016/05/01 09:46:08 CA Server (0.1)
INFO: 2016/05/01 09:46:08 Fresh start; creating databases, key pairs, and certificates.
PANIC: 2016/05/01 09:46:08 ca.go:173: mkdir /var/hyperledger: permission denied
panic: mkdir /var/hyperledger: permission denied


goroutine 1 [running]:
panic(0x991a20, 0xc8201baea0)
    /opt/go/src/runtime/panic.go:464 +0x3e6
log.(*Logger).Panicln(0xc820131f90, 0xc82012d8f0, 0x1, 0x1)
    /opt/go/src/log/log.go:220 +0xbf
github.com/hyperledger/fabric/membersrvc/ca.NewCA(0xb681c8, 0x3, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/membersrvc/ca/ca.go:173 +0x387
github.com/hyperledger/fabric/membersrvc/ca.NewECA(0xc820131ea0)
    /opt/gopath/src/github.com/hyperledger/fabric/membersrvc/ca/eca.go:80 +0x63
main.main()
    /opt/gopath/src/github.com/hyperledger/fabric/membersrvc/server.go:82 +0xafb
```

and 

```
vagrant@ubuntu-1404:/opt/gopath/src/github.com/hyperledger/fabric/peer$ ./peer peer --peer-chaincodedev   
09:47:54.647 [crypto] main -> INFO 001 Log level recognized 'info', set to INFO
09:47:54.650 [logging] LoggingInit -> DEBU 002 Setting default logging level to DEBUG for command 'peer'
09:47:54.650 [main] serve -> INFO 003 Running in chaincode development mode
09:47:54.650 [main] serve -> INFO 004 Set consensus to NOOPS and user starts chaincode
09:47:54.651 [main] serve -> INFO 005 Disable loading validity system chaincode
09:47:54.653 [sysccapi] RegisterSysCC -> DEBU 006 system chaincode github.com/hyperledger/fabric/core/system_chaincode/sample_syscc registered
09:47:54.657 [eventhub_producer] AddEventType -> DEBU 007 registering block
09:47:54.657 [eventhub_producer] AddEventType -> DEBU 008 registering register
09:47:54.658 [main] serve -> INFO 00a Security enabled status: false
09:47:54.657 [eventhub_producer] start -> INFO 009 event processor started
09:47:54.658 [main] serve -> INFO 00b Privacy enabled status: false
09:47:54.660 [chaincode] NewChaincodeSupport -> INFO 00c Chaincode support using peerAddress: 0.0.0.0:30303
09:47:54.660 [main] serve -> DEBU 00d Running as validating peer - making genesis block if needed
09:47:54.661 [db] createDBIfDBPathEmpty -> DEBU 00e Is db path [/var/hyperledger/production/db] empty [true]
09:47:54.662 [db] CreateDB -> DEBU 00f Creating DB at [/var/hyperledger/production/db]
09:47:54.663 [db] CreateDB -> ERRO 010 Error calling  os.MkdirAll for directory path [/var/hyperledger/production/db]: mkdir /var/hyperledger: permission denied
Error opening DB IO error: /var/hyperledger/production/db: No such file or directory
panic: Could not open openchain db error = [IO error: /var/hyperledger/production/db: No such file or directory]

goroutine 1 [running]:
panic(0xb94ec0, 0xc820254d90)
    /opt/go/src/runtime/panic.go:464 +0x3e6
github.com/hyperledger/fabric/core/db.GetDBHandle(0x49dc01)
    /opt/gopath/src/github.com/hyperledger/fabric/core/db/db.go:107 +0x2cf
github.com/hyperledger/fabric/core/ledger.fetchBlockchainSizeFromDB(0xc820000300, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/blockchain.go:308 +0x28
github.com/hyperledger/fabric/core/ledger.newBlockchain(0x8, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/blockchain.go:52 +0x2e
github.com/hyperledger/fabric/core/ledger.newLedger(0xc8201ef388, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/ledger.go:71 +0x28
github.com/hyperledger/fabric/core/ledger.GetLedger.func1()
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/ledger.go:65 +0x1c
sync.(*Once).Do(0x14e3650, 0xfac858)
    /opt/go/src/sync/once.go:44 +0xe4
github.com/hyperledger/fabric/core/ledger.GetLedger(0xc8201ef418, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/ledger.go:66 +0x3b
github.com/hyperledger/fabric/core/ledger/genesis.MakeGenesis.func1()
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/genesis/genesis.go:43 +0x37
sync.(*Once).Do(0x14e3670, 0xfac868)
    /opt/go/src/sync/once.go:44 +0xe4
github.com/hyperledger/fabric/core/ledger/genesis.MakeGenesis(0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/core/ledger/genesis/genesis.go:171 +0x3b
main.serve(0xc8201f47e0, 0x0, 0x1, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:456 +0xd90
main.glob.func3(0x14a5f80, 0xc8201f47e0, 0x0, 0x1, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:89 +0x41
github.com/hyperledger/fabric/vendor/github.com/spf13/cobra.(*Command).execute(0x14a5f80, 0xc8201f4790, 0x1, 0x1, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/vendor/github.com/spf13/cobra/command.go:497 +0x62c
github.com/hyperledger/fabric/vendor/github.com/spf13/cobra.(*Command).Execute(0x14a5dc0, 0x0, 0x0)
    /opt/gopath/src/github.com/hyperledger/fabric/vendor/github.com/spf13/cobra/command.go:584 +0x46a
main.main()
    /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:307 +0x17d5
```
