### PR TITLE
Fixed a bug in bucket-tree caching

### DIFF
--- a/core/ledger/statemgmt/buckettree/bucket_cache.go
+++ b/core/ledger/statemgmt/buckettree/bucket_cache.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/perfstat"
+	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 )
 
 var defaultBucketCacheMaxSize = 100 // MBs
@@ -71,8 +72,8 @@ func (cache *bucketCache) loadAllBucketNodesFromDB() {
 			itr.Value().Free()
 			break
 		}
-		bKey := decodeBucketKey(itr.Key().Data())
-		nodeBytes := itr.Value().Data()
+		bKey := decodeBucketKey(statemgmt.Copy(itr.Key().Data()))
+		nodeBytes := statemgmt.Copy(itr.Value().Data())
 		bucketNode := unmarshalBucketNode(&bKey, nodeBytes)
 		size := bKey.size() + bucketNode.size()
 		cache.size += size


### PR DESCRIPTION
Making a copy of bytes received from rocks db before freeing the memory.
To me it appears that this is what causes the behavior described in the following PR.
https://github.com/hyperledger/fabric/pull/1289
Signed-off-by:manishsethi@in.ibm.com
