### PR TITLE
Add a common "host.sh" for sharing provisioning logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,11 @@ install:
 
 before_script:
 
- - echo " CREATING BASE IMAGE "
- - echo " Calling docker.sh to build Openblockchain/baseimage "
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x host.sh && sudo ./host.sh
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x common.sh && sudo ./common.sh
+ - echo " Provisioning environment "
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x host.sh && ./host.sh
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x common.sh && ./common.sh
  - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - go build && echo " STARTING PEER PROCESS "

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_script:
  - echo " CREATING BASE IMAGE "
  - echo " Calling docker.sh to build Openblockchain/baseimage "
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x host.sh && ./host.sh
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x common.sh && ./common.sh
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_script:
  - echo " CREATING BASE IMAGE "
  - echo " Calling docker.sh to build Openblockchain/baseimage "
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x host.sh && ./host.sh
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x common.sh && ./common.sh
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x host.sh && sudo ./host.sh
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x common.sh && sudo ./common.sh
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -82,9 +82,6 @@ docker run --rm busybox echo All good
 
 /hyperledger/scripts/provision/docker.sh $BASEIMAGE_RELEASE
 
-# Run our common setup
-/hyperledger/scripts/provision/common.sh
-
 # Install Python, pip, behave, nose
 #
 # install python-dev and libyaml-dev to get compiled speedups
@@ -115,11 +112,9 @@ PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 cd $GOPATH/src/github.com/hyperledger/fabric/peer
 CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
 
-# Copy protobuf dir so we can build the protoc-gen-go binary. Then delete the directory.
-mkdir -p $GOPATH/src/github.com/golang/protobuf/
-cp -r $GOPATH/src/github.com/hyperledger/fabric/vendor/github.com/golang/protobuf/ $GOPATH/src/github.com/golang/
-go install -a github.com/golang/protobuf/protoc-gen-go
-rm -rf $GOPATH/src/github.com/golang/protobuf
+# Run our common scripts
+/hyperledger/scripts/provision/host.sh
+/hyperledger/scripts/provision/common.sh
 
 # Compile proto files
 # /hyperledger/devenv/compile_protos.sh

--- a/scripts/provision/common.sh
+++ b/scripts/provision/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Add any logic that is common to both the peer and docker environments here
+# Add any logic that is common to all (vagrant, travis, docker, etc) environments here
 
 apt-get update -qq
 

--- a/scripts/provision/common.sh
+++ b/scripts/provision/common.sh
@@ -2,7 +2,7 @@
 
 # Add any logic that is common to all (vagrant, travis, docker, etc) environments here
 
-apt-get update -qq
+sudo apt-get update -qq
 
 # Used by CHAINTOOL
-apt-get install -y default-jre
+sudo apt-get install -y default-jre

--- a/scripts/provision/host.sh
+++ b/scripts/provision/host.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Add any logic that is common to any host (vagrant, travis, etc) environments here
+
+# Copy protobuf dir so we can build the protoc-gen-go binary. Then delete the directory.
+mkdir -p $GOPATH/src/github.com/golang/protobuf/
+cp -r $GOPATH/src/github.com/hyperledger/fabric/vendor/github.com/golang/protobuf/ $GOPATH/src/github.com/golang/
+go install -a github.com/golang/protobuf/protoc-gen-go
+rm -rf $GOPATH/src/github.com/golang/protobuf
+


### PR DESCRIPTION
Travis is missing the protoc compiler, so this starts to incorporate a shared facility to keep travis
updated along with vagrant.  It can be exploited by other hosting environments too.

(possible) Fix for #1326.  We won't know until travis run completes.  Still running local test/behave in parallel and will update with final result. 

Signed-off-by: Gregory Haskins gregory.haskins@gmail.com
