### PR TITLE
Incubation in Italic + Lifecycle URL change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/hyperledger/fabric.svg?branch=master)](https://travis-ci.org/hyperledger/fabric)
 
 ## Incubation Notice
-This is a Hyperledger project in Incubation. It was proposed to the community and documented [here](https://goo.gl/RYQZ5N). Information on what Incubation entails can be found in the Hyperledger Project Lifecycle [document](https://goo.gl/4edNRc).
+This is a Hyperledger project in _Incubation_. It was proposed to the community and documented [here](https://goo.gl/RYQZ5N). Information on what _Incubation_ entails can be found in the [Hyperledger Project Lifecycle document](https://goo.gl/4edNRc).
 
 ## Overview
 This project contains the core blockchain fabric code, development environment scripts, and documents for developers to contribute fabric code or work on their own applications.


### PR DESCRIPTION
Minor/cosmetic:
- Highlighting that Incubation is a term (using an Italic font as per the Hyperledger Project Lifecycle document)
- Extending the url/link to span the "Hyperledger Project Lifecycle document"

[ci skip]

Please note that changes were approved @[1282](https://github.com/hyperledger/fabric/pull/1282).

@srderson: resubmitted as requested.
