### PR TITLE
Disable the platforms/car unit test when run under vagrant

### DIFF
--- a/core/chaincode/platforms/car/test/car_test.go
+++ b/core/chaincode/platforms/car/test/car_test.go
@@ -15,6 +15,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestCar_BuildImage(t *testing.T) {
+	if os.Getenv("TRAVIS") != "" {
+		t.Skip("skipping test; TravisCI not supported")
+	}
+
 	vm, err := container.NewVM()
 	if err != nil {
 		t.Fail()


### PR DESCRIPTION
This is an experiment to see if I can work-around some travis wonkiness related to Issue #1326 

Preference is to fix the travis environment.  However, if this works we can use it as a stop-gap until the travis issue is resolved and then revert this one.

Signed-off-by: Gregory Haskins gregory.haskins@gmail.com
