### PR TITLE
Increase timeouts on some behave tests

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -465,7 +465,7 @@ Feature: lanching 3 peers
                     |arg1|arg2|arg3|
                     | b  | a  | 1  |
 	        Then I should have received a transactionID
-	        Then I wait up to "30" seconds for transaction to be committed to peers:
+	        Then I wait up to "60" seconds for transaction to be committed to peers:
                     | vp0  | vp1 | vp2 | vp3 |
 
             When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -482,7 +482,7 @@ Feature: lanching 3 peers
 			|arg1|arg2|arg3|
 			| a  | b  | 10 |
 	    Then I should have received a transactionID
-	    Then I wait up to "10" seconds for transaction to be committed to peers:
+	    Then I wait up to "120" seconds for transaction to be committed to peers:
             | vp0  | vp1 | vp2 |
 
         When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -609,7 +609,7 @@ Feature: lanching 3 peers
            |arg1|arg2|arg3|
            | a  | b  | 1  |
        Then I should have received a transactionID
-       Then I wait up to "10" seconds for transaction to be committed to peers:
+       Then I wait up to "60" seconds for transaction to be committed to peers:
            | vp0  | vp1 | vp2 | vp3 |
 
       When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -672,7 +672,7 @@ Feature: lanching 3 peers
          |arg1|arg2|arg3|
          | a  | b  | 1  |
      Then I should have received a transactionID
-     Then I wait up to "5" seconds for transaction to be committed to peers:
+     Then I wait up to "60" seconds for transaction to be committed to peers:
          | vp0  | vp1 | vp2 | vp3 |
 
     When I query chaincode "example2" function name "query" with value "a" on peers:


### PR DESCRIPTION
Simply increases the timeouts on some behave tests that intermittently fail because the timeout is too low. 
