### PR TITLE
Invert our platforms/car unit-test exclusion logic

### DIFF
--- a/core/chaincode/platforms/car/test/car_test.go
+++ b/core/chaincode/platforms/car/test/car_test.go
@@ -15,8 +15,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestCar_BuildImage(t *testing.T) {
-	if os.Getenv("TRAVIS") != "" {
-		t.Skip("skipping test; TravisCI not supported")
+	if os.Getenv("VAGRANT") == "" {
+		t.Skip("skipping test; only supported within vagrant")
 	}
 
 	vm, err := container.NewVM()

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -137,7 +137,9 @@ sudo cp /hyperledger/devenv/limits.conf /etc/security/limits.conf
 # Set our shell prompt to something less ugly than the default from packer
 echo "PS1=\"\u@hyperledger-devenv:v$BASEIMAGE_RELEASE-$DEVENV_REVISION:\w$ \"" >> /home/vagrant/.bashrc
 
+# configure vagrant specific environment
+cat <<EOF >/etc/profile.d/vagrant-devenv.sh
 # Expose the devenv/tools in the $PATH
-cat <<EOF >/etc/profile.d/devenv-tools.sh
 export PATH=\$PATH:/hyperledger/devenv/tools
+export VAGRANT=1
 EOF


### PR DESCRIPTION
We previously made the test exclude TravisCI.  However, there are
other environments besides travis that do not have the prerequisites
installed and thus fail this test as well.  Therefore, we invert the
logic so that the test _only_ runs under vagrant and is disabled
everywhere else.  When the dependency issue is resolved, we can
remove this exclusion.

Signed-off-by: Gregory Haskins gregory.haskins@gmail.com
