### PR TITLE
Add behave test for crash fault tolerance

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -777,3 +777,70 @@ Feature: lanching 3 peers
     Examples: Consensus Options
         |          ComposeFile                                                       |   WaitTime   |
         |   docker-compose-4-consensus-batch.yml docker-compose-4-consensus-nvp0.yml |      60      |
+
+  #@doNotDecompose
+  @issue_1000
+	Scenario Outline: chaincode example02 with 4 peers and 1 membersrvc, test crash fault
+
+	    Given we compose "<ComposeFile>"
+	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
+                     | vp0  |
+            And I use the following credentials for querying peers:
+		     | peer |   username  |    secret    |
+		     | vp0  |  test_user0 | MS9qrN8hFjlE |
+		     | vp1  |  test_user1 | jGlNl6ImkuDo |
+		     | vp2  |  test_user2 | zMflqOKezFiA |
+		     | vp3  |  test_user3 | vWdLCE00vJy0 |
+
+	    When requesting "/chain" from "vp0"
+	        Then I should get a JSON response with "height" = "1"
+
+            # Deploy
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+                    | arg1 |  arg2 | arg3 | arg4 |
+                    |  a   |  100  |  b   |  200 |
+	        Then I should have received a chaincode name
+	        Then I wait up to "<WaitTime>" seconds for transaction to be committed to peers:
+                     | vp0  | vp1 | vp2 | vp3 |
+
+            # Build up a sizable blockchain, to advance the sequence number
+            When I invoke chaincode "example2" function name "invoke" on "vp0" "30" times
+                    |arg1|arg2|arg3|
+                    | b  | a  | 1  |
+	        Then I should have received a transactionID
+	        Then I wait up to "60" seconds for transaction to be committed to peers:
+                    | vp0  | vp1 | vp2 | vp3 |
+
+            When I query chaincode "example2" function name "query" with value "a" on peers:
+                    | vp0  | vp1 | vp2 | vp3 |
+	        Then I should get a JSON response from peers with "OK" = "130"
+                    | vp0  | vp1 | vp2 | vp3 |
+
+        # Stop vp1, vp2, vp3
+        Given I stop peers:
+            | vp1 | vp2 | vp3 |
+
+        # Now start vp1, vp2 again, hopefully retaining pbft state
+        Given I start peers:
+            | vp1 | vp2 |
+        And I wait "15" seconds
+
+        # Invoke 1 more tx, if the crash recovery worked, it will commit, otherwise, it will not
+        When I invoke chaincode "example2" function name "invoke" on "vp0"
+			|arg1|arg2|arg3|
+			| a  | b  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "60" seconds for transaction to be committed to peers:
+            | vp0  | vp1 | vp2 |
+        When I query chaincode "example2" function name "query" with value "a" on peers:
+            | vp0  | vp1 | vp2 |
+	    Then I should get a JSON response from peers with "OK" = "120"
+            | vp0  | vp1 | vp2 |
+
+
+    Examples: Consensus Options
+        |          ComposeFile                       |   WaitTime   |
+        |   docker-compose-4-consensus-classic.yml   |      60      |
+        |   docker-compose-4-consensus-batch.yml     |      60      |
+        |   docker-compose-4-consensus-sieve.yml     |      60      |
+

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -842,5 +842,5 @@ Feature: lanching 3 peers
         |          ComposeFile                       |   WaitTime   |
         |   docker-compose-4-consensus-classic.yml   |      60      |
         |   docker-compose-4-consensus-batch.yml     |      60      |
-        |   docker-compose-4-consensus-sieve.yml     |      60      |
+        #|   docker-compose-4-consensus-sieve.yml     |      60      | // TODO, this is known to be broken, pending a fix
 

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -328,7 +328,7 @@ func (op *obcSieve) processExecute() {
 	_ = results // XXX what to do?
 	_ = err     // XXX what to do?
 
-	logger.Debug("Sieve replica %d results=%x err=%v", op.id, results, err)
+	logger.Debug("Sieve replica %d results=%x err=%v using lastPbftExec of %d", op.id, results, err, op.lastExecPbftSeqNo)
 
 	meta, _ := proto.Marshal(&Metadata{op.lastExecPbftSeqNo})
 	op.currentResult, err = op.stack.PreviewCommitTxBatch(op.currentReq, meta)

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -807,29 +807,6 @@ func (instance *pbftCore) executeOutstanding() {
 	return
 }
 
-func (instance *pbftCore) executionCheckpont(seqNo uint64, id []byte) {
-	if seqNo%instance.K != 0 {
-		logger.Error("Attempted to checkpoint a sequence number (%d) which is not a multiple of the checkpoint interval (%d)", seqNo, instance.K)
-		return
-	}
-
-	idAsString := base64.StdEncoding.EncodeToString(id)
-
-	logger.Debug("Replica %d preparing checkpoint for view=%d/seqNo=%d and b64 id of %s",
-		instance.id, instance.view, seqNo, idAsString)
-
-	chkpt := &Checkpoint{
-		SequenceNumber: seqNo,
-		ReplicaId:      instance.id,
-		Id:             idAsString,
-	}
-	instance.chkpts[seqNo] = idAsString
-
-	instance.persistCheckpoint(seqNo, id)
-	instance.recvCheckpoint(chkpt)
-	instance.innerBroadcast(&Message{&Message_Checkpoint{chkpt}})
-}
-
 func (instance *pbftCore) executeOne(idx msgID) bool {
 	cert := instance.certStore[idx]
 
@@ -890,6 +867,7 @@ func (instance *pbftCore) Checkpoint(seqNo uint64, id []byte) {
 	}
 	instance.chkpts[seqNo] = idAsString
 
+	instance.persistCheckpoint(seqNo, id)
 	instance.recvCheckpoint(chkpt)
 	instance.innerBroadcast(&Message{&Message_Checkpoint{chkpt}})
 }

--- a/consensus/obcpbft/pbft-persist.go
+++ b/consensus/obcpbft/pbft-persist.go
@@ -149,6 +149,7 @@ func (instance *pbftCore) restoreState() {
 			if _, err = fmt.Sscanf(key, "chkpt.%d", &seqNo); err != nil {
 				logger.Warning("Replica %d could not restore checkpoint key %s", instance.id, key)
 			} else {
+				logger.Debug("Replica %d found checkpoint %s for seqNo %d", instance.id, string(id), seqNo)
 				instance.chkpts[seqNo] = string(id)
 				if seqNo > highSeq {
 					highSeq = seqNo

--- a/consensus/obcpbft/pbft-persist.go
+++ b/consensus/obcpbft/pbft-persist.go
@@ -20,6 +20,7 @@ under the License.
 package obcpbft
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
@@ -149,8 +150,9 @@ func (instance *pbftCore) restoreState() {
 			if _, err = fmt.Sscanf(key, "chkpt.%d", &seqNo); err != nil {
 				logger.Warning("Replica %d could not restore checkpoint key %s", instance.id, key)
 			} else {
-				logger.Debug("Replica %d found checkpoint %s for seqNo %d", instance.id, string(id), seqNo)
-				instance.chkpts[seqNo] = string(id)
+				idAsString := base64.StdEncoding.EncodeToString(id)
+				logger.Debug("Replica %d found checkpoint %s for seqNo %d", instance.id, idAsString, seqNo)
+				instance.chkpts[seqNo] = idAsString
 				if seqNo > highSeq {
 					highSeq = seqNo
 				}


### PR DESCRIPTION
Added a behave test to explicitly test crash fault tolerance.

In this behave test the following occurs:

```
vp{0,1,2,3} up
execute some transactions
vp{1,2,3} down
vp{1,2} up
execute some transactions
verify result
```

If vp1 and vp2 do not recover their state, there are not 2f+1 functioning nodes who can come to a consensus of the next sequence number, and the final execute will not occur.

Discovered a bug had been introduced in the persistence, likely during one of its many rebases, where the checkpointing code had bifurcated, and one method became dead code.  This dead code contained the call to persist the checkpoint, while the active code did not.  This changeset also fixes this problem

This is likely of particular interest to @corecode but it's correctness should be easily verifiable by anyone familiar with the consensus code (looking at @tuand27613 and or @kchristidis)

Signed-off-by: Jason Yellick jyellick@us.ibm.com
