### PR TITLE
Nominate Greg Haskins as a maintainer

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -4,3 +4,4 @@ Binh Nguyen binhn binhn@us.ibm.com
 Sheehan Anderson srderson sheehan@us.ibm.com
 Tamas Blummer tamasblummer tamas@digitalasset.com
 Robert Fajta rfajta robert@digitalasset.com 
+Greg Haskins ghaskins ghaskins@lseg.com


### PR DESCRIPTION
I would like to nominate Greg Haskins (@ghaskins) from the London Stock Exchange Group as a new maintainer on the Hyperledger Fabric project. Greg has been the leading contributor to the Fabric’s development environment for several months now, one of the most important components as it serves as an onboarding and development tool for all developers.

Greg can be found on Slack late at night assisting users with environment questions and is quick to fix issues when they arise, such as a recent [bug in the Travis build](https://github.com/hyperledger/fabric/pull/1329), demonstrating his dedication and commitment in addition to his technical skills. Greg has also undertaken major architectural changes such as the new [base image](https://github.com/hyperledger/fabric/blob/master/devenv/baseimage/README.md)

His knowledge extends well beyond the development environment, as described by senior developer Jeff Garratt (@jeffgarratt) who said “This is a testament your comprehension of the mechanisms of the system” in one of Greg’s [recent PRs](https://github.com/hyperledger/fabric/pull/1250#issuecomment-216281563).

It’s clear that Greg’s contributions are a major part of the Hyperledger Fabric project’s current success. For these reasons, I believe he would be an excellent addition to the current list of maintainers.

Based on the rules described under the “Becoming a maintainer” section in the [CONTRIBUTING document](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md), existing maintainers should add a comment indicating if they agree with Greg’s addition as a new maintainer on the project.

[ci skip]

Signed-off-by: sheehan@us.ibm.com
