### PR TITLE
Use make to build the fabric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ before_script:
 
  - echo " CREATING BASE IMAGE "
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
- - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
+ - cd /$HOME/gopath/src/github.com/hyperledger/fabric
  - make peer && echo " STARTING PEER PROCESS "
- - ./peer peer &
+ - (cd ./peer; ./peer peer) &
  - make unit-test
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,12 @@ install:
 before_script:
 
  - echo " CREATING BASE IMAGE "
- - echo " Calling docker.sh to build Openblockchain/baseimage "
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
- - go build && echo " STARTING PEER PROCESS "
+ - make peer && echo " STARTING PEER PROCESS "
  - ./peer peer &
- - go test -timeout=20m $(go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/)
+ - make unit-test
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ install:
    echo " Installing Rocks DB, g++ compilers & Dependencies "
    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -qq update && sudo apt-get -qq install g++-4.8 && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
    sudo pip install --upgrade pip && sudo pip install behave && sudo apt-get install build-essential -y
-   cd /opt  && sudo git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && sudo make shared_lib
-   sudo cp /opt/rocksdb/*.so* /usr/lib/ && export LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH && sudo apt-get update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-   export CGO_CFLAGS="-I/opt/rocksdb/include" && export CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
+   sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+   cd /tmp
+   git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git
+   cd rocksdb
+   make shared_lib
+   sudo (INSTALL_PATH=/usr/local make install-shared && ldconfig)
 
 before_script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ install:
    git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git
    cd rocksdb
    make shared_lib
-   sudo (INSTALL_PATH=/usr/local make install-shared && ldconfig)
+   sudo INSTALL_PATH=/usr/local make install-shared
+   sudo ldconfig
 
 before_script:
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+PKGNAME = github.com/hyperledger/fabric
+CGO_LDFLAGS = -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
+
+EXECUTABLES = go docker
+K := $(foreach exec,$(EXECUTABLES),\
+	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH: Check dependencies")))
+
+all: peer
+
+peer: baseimage ./peer/peer
+
+membersrvc: ./membersrvc/membersrvc
+
+./peer/peer:
+	cd peer; CGO_CFLAGS=" "	CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
+
+./membersrvc/membersrvc:
+	cd membersrvc; CGO_CFLAGS=" " CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
+
+unit-test: baseimage
+	@echo "Running unit-tests"
+	@go test -timeout=20m $(shell go list $(PKGNAME)/... | grep -v /vendor/ | grep -v /examples/)
+	@touch .peerimage-dummy
+
+behave-deps: .peerimage-dummy
+
+behave: behave-deps
+	@echo "Running behave tests"
+	@cd bddtests; behave
+
+.peerimage-dummy: .baseimage-dummy
+	go test $(PKGNAME)/core/container -run=BuildImage_Peer
+	go test $(PKGNAME)/core/container -run=BuildImage_Obcca
+	@touch $@
+
+baseimage: .baseimage-dummy
+
+.baseimage-dummy:
+	@echo "Building docker base-image"
+	@./scripts/provision/docker.sh 0.0.9
+	@touch $@
+
+protos:
+	./devenv/compile_protos.sh
+
+.PHONY: clean
+clean:
+	-@rm .baseimage-dummy ||:
+	-@rm .peerimage-dummy ||:
+	-@rm -f ./peer/peer ||:
+	-@rm -f ./membersrvc/membersrvc ||:
+
+.PHONY: dist-clean
+dist-clean: clean
+	-@rm -rf /var/hyperledger/* ||:

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -80,8 +80,6 @@ usermod -a -G docker vagrant # Add vagrant user to the docker group
 # Test docker
 docker run --rm busybox echo All good
 
-/hyperledger/scripts/provision/docker.sh $BASEIMAGE_RELEASE
-
 # Run our common setup
 /hyperledger/scripts/provision/common.sh
 
@@ -111,10 +109,6 @@ PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 #install golang deps
 ./installGolang.sh
 
-# Run go install - CGO flags for RocksDB
-cd $GOPATH/src/github.com/hyperledger/fabric/peer
-CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
-
 # Copy protobuf dir so we can build the protoc-gen-go binary. Then delete the directory.
 mkdir -p $GOPATH/src/github.com/golang/protobuf/
 cp -r $GOPATH/src/github.com/hyperledger/fabric/vendor/github.com/golang/protobuf/ $GOPATH/src/github.com/golang/
@@ -143,3 +137,7 @@ cat <<EOF >/etc/profile.d/vagrant-devenv.sh
 export PATH=\$PATH:/hyperledger/devenv/tools
 export VAGRANT=1
 EOF
+
+# Build the actual hyperledger peer
+cd $GOPATH/src/github.com/hyperledger/fabric
+make clean peer

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -680,13 +680,13 @@ You can interface with the peer process from a Node.js application. One way to a
 1. Build and install the [fabric core](https://github.com/hyperledger/fabric/blob/master/README.md#building-the-fabric-core-).
 
     ```
-    cd /opt/gopath/src/github.com/hyperledger/fabric/peer
-    go build
+    cd /opt/gopath/src/github.com/hyperledger/fabric
+    make peer
     ```
 
 2. Run a local peer node only (not a complete network) with:
 
-    `./peer`
+    `cd peer; ./peer`
 
 3. Set up a test blockchain data structure (with 5 blocks only) by running a test from within Vagrant as follows. Subsequently restart the peer process.
 

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -25,7 +25,7 @@ To set up the local development environment with security enabled, you must firs
 
     cd $GOPATH/src/github.com/hyperledger/fabric
     make membersrvc
-    (cd menbersrvc; ./membersrvc)
+    (cd membersrvc; ./membersrvc)
 
 Running the above commands builds and runs the CA server with the default setup, which is defined in the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) configuration file. The default configuration includes multiple users who are already registered with the CA; these users are listed in the 'users' section of the configuration file. To register additional users with the CA for testing, modify the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file to include additional enrollmentID and enrollmentPW pairs. Note the integer that precedes the enrollmentPW. That integer indicates the role of the user, where 1 = client, 2 = non-validating peer, 4 = validating peer, and 8 = auditor.
 

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -23,9 +23,9 @@ From your command line terminal, move to the `devenv` subdirectory of your works
 
 To set up the local development environment with security enabled, you must first build and run the <b>Certificate Authority (CA)</b> server:
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
-    go build
-    ./membersrvc
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make membersrvc
+    (cd menbersrvc; ./membersrvc)
 
 Running the above commands builds and runs the CA server with the default setup, which is defined in the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) configuration file. The default configuration includes multiple users who are already registered with the CA; these users are listed in the 'users' section of the configuration file. To register additional users with the CA for testing, modify the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file to include additional enrollmentID and enrollmentPW pairs. Note the integer that precedes the enrollmentPW. That integer indicates the role of the user, where 1 = client, 2 = non-validating peer, 4 = validating peer, and 8 = auditor.
 
@@ -38,9 +38,10 @@ From your command line terminal, move to the `devenv` subdirectory of your works
 
 Build and run the peer process to enable security and privacy after setting <b>security.enabled</b> and <b>security.privacy</b> settings to 'true'.
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/peer
-    go build
-    ./peer peer --peer-chaincodedev   
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make peer
+    cd ./peer
+    ./peer peer --peer-chaincodedev
 
 Alternatively, enable security and privacy on the peer with environment variables:
 

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -27,14 +27,14 @@ From within the VM, you can build, run, and test your environment.
 #### 1. Go build
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric
-go build -o peer
+make peer
 ```
 
 #### 2. Run
 
 To see what commands are available, simply execute the following command:
 
-    cd $GOPATH/src/github.com/hyperledger/fabric
+    cd $GOPATH/src/github.com/hyperledger/fabric/peer
     ./peer
 
 You should see some output similar to below (**NOTE**: The root command below is hardcoded in the [main.go](./main.go). Current build will actually create a *peer* executable file).
@@ -82,15 +82,15 @@ To run a specific test use the `-run RE` flag where RE is a regular expression t
 [Behave](http://pythonhosted.org/behave/) tests will setup networks of peers with different security and consensus configurations and verify that transactions run properly. To run these tests
 
 ```
-cd $GOPATH/src/github.com/hyperledger/fabric/bddtests
-behave
+cd $GOPATH/src/github.com/hyperledger/fabric
+make behave
 ```
 Some of the Behave tests run inside Docker containers. If a test fails and you want to have the logs from the Docker containers, run the tests with this option
 ```
 behave -D logs=Y
 ```
 
-Note, you must run the unit tests first to build the necessary Peer and Member Services docker images. These images can also be individually built using the commands
+Note, in order to run behave directly, you must run 'make behave-deps' first to build the necessary Peer and Member Services docker images. These images can also be individually built using the commands
 ```
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Obcca
@@ -115,7 +115,7 @@ INSTALL_PATH=/usr/local make install-shared
 - Run the following commands:
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric
-CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+make
 ```
 - Make sure that the Docker daemon initialization includes the options
 ```

--- a/docs/dev-setup/obcca-setup.md
+++ b/docs/dev-setup/obcca-setup.md
@@ -62,12 +62,12 @@ When the CA is started for the first time, it will generate all of its required 
 
 The CA can be built with the following command executed in the `membersrvc` directory:
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
-    go build
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make membersrvc
 
-The CA can be started with the following command executed in the directory where the CA binary is located:
+The CA can be started with the following command executed in the directory where the CA binary is located (cd ./membersrvc):
 
     ./membersrvc
 
-	
+
 The CA looks for an `membersrvc.yaml` configuration file in the same location as the server binary.  If the CA is started for the first time, it creates all its required state (e.g., internal databases, CA certificates, blockchain keys, etc.) and write each state to the directory given in the CA configuration.


### PR DESCRIPTION
RFC @bcbrock @corecode @srderson 

Specifically withholding DCO for now until testing and discussion are complete.

---

This patch adds a top-level makefile with various build targets:

*) peer (default) - builds the fabric ./peer/peer binary
*) membersrvc - builds the ./membersrvc/membersrvc binary
*) unit-test - runs the go-test based unit tests
*) behave - runs the behave test
*) behave-deps - ensures pre-requisites are availble for running behave manually
*) clean - cleans the build area
*) dist-clean - superset of 'clean' that also removes persistent state

Why?

Our current environment relies heavily on vagrant performing a good deal of the
preparation such that we can perform operations like "cd peer; go build".  One
minor problem is that a common vagrant-based workflow is to subsequently update
the code and rebuild without necessarily rebuilding the vagrant environment
(e.g. git pull && go build).  Any dependency changes in the underlying code
may not be properly satisfied with such a workflow.

To make matters more complicated, many other environments outside vagrant
exist (e.g. TravisCI, non vagrant based development environments, production
deployments, etc).  These environments are even more adversely affected with
extrinsic dependencies.  Work has been done (see the ./scripts/provisioning
area for an example) to try to help unify the different environments to
a single source of truth.  Despite this, we still struggle to provide a smooth
experience because these mechanisms need to be understood by all and
incorporated into the relevant workflows.  Often times, developers/users
don't even know these problems/mechanisms exist until they find things broken
in typically non-obvious ways.

Whats needed is an easy way to operate with a more self-contained approach
such that we can support the "git pull && do-it" type workflow.  However,
we also need to observe that the "go" tooling is probably ill equiped for
anything except the most basic of pure go development:  It intentionally
doesn't support external hooks, etc, as you would find in a general build
framework like Make or Maven.  Once you have a polyglot and/or dependencies
on external facilities (e.g. docker, protobuf, etc) starts to feel more
closer to "gcc" than to "make".

This isn't necessarily a bad thing, but trying to centralize our tooling
on a "go" tool based workflow I suspect is a large part of the current pain
being felt.  Instead, lets embrace it for what I believe it was intended
to do really well (compile go code), and augment it with a tool that
is better suited to managing a polyglot/external-dep universe, of which
golang is just one part.

There are many build frameworks to choose from, but Make is ubiquitous,
well understood, and well suited to the task.  I therefore think
it makes a perfectly reasonable approach to serve as the centerpoint
of our build system.

The intention is that developers/packagers/etc migrate to using make
in conjunction with the targets listed above rather than the raw commands
that have been historically employed.  While the old methods should
continue to work, the new workflow can incorporate more automation that
will help keep the build process running smoothly and adapting to future
requirements without users needing to be aware.  In this new model, the
typical workflow would become:

```
 git pull && make clean peer
```

This should generally allow most things to either be:

```
 a) automatically managed

  OR

 b) cleanly reported when automation cannot solve the problem (e.g.
    external dependencies that need to be manually installed).
```

I believe this should lay the groundwork for a vast improvement over the
current process.
