### PR TITLE
Added support for multiple NVP rootnodes random selection

### DIFF
--- a/core/discovery_test.go
+++ b/core/discovery_test.go
@@ -19,14 +19,91 @@ under the License.
 
 package core
 
-import "testing"
+import (
 
-func TestDiscovery_GetRootNode(t *testing.T) {
-	rootNode, err := GetRootNode()
+	"github.com/hyperledger/fabric/discovery"
+
+	"testing"
+	"github.com/spf13/viper"
+)
+
+func TestDiscovery_GetEmptyRootNode(t *testing.T) {
+	discovery.SetDiscoveryService(NewStaticDiscovery(true))
+	assertRootNode(t,"")
+
+}
+
+func TestDiscovery_GetSingleValidatingPeer(t *testing.T) {
+	viper.Set("peer.discovery.rootnode","someHost")
+	discovery.SetDiscoveryService(NewStaticDiscovery(true))
+	assertRootNode(t,"someHost")
+}
+
+// Check that function always returns first one
+func TestDiscovery_GetMultiValidatingPeer(t *testing.T) {
+	viper.Set("peer.discovery.rootnode","a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z")
+	discovery.SetDiscoveryService(NewStaticDiscovery(true))
+
+	for i := 0; i < 100; i++ {
+		assertRootNode(t,"a")
+	}
+}
+
+// Check that function always returns first one
+func TestDiscovery_GetMultiNonValidatingPeer(t *testing.T) {
+	viper.Set("peer.discovery.rootnode","a,b,c,d,e")
+	discovery.SetDiscoveryService(NewStaticDiscovery(false))
+	assertRootNodeRandomValues(t,[]string{"a","b","c","d","e"})
+}
+
+func assertRootNode(t *testing.T,expected string) {
+	rootNode, err := discovery.GetRootNode()
 	if err != nil {
 		t.Fail()
 		t.Logf("Error getting rootnode:  %s", err)
 	}
-	t.Logf("RootNode value: %s", rootNode)
+	if rootNode != expected {
+		t.Fail()
+		t.Logf("RootNode's value should be '%s'",expected)
+	}
+}
+
+
+func assertRootNodeRandomValues(t *testing.T,expected []string) {
+
+	rootNode, err := discovery.GetRootNode()
+	if err != nil {
+		t.Fail()
+		t.Logf("Error getting rootnode:  %s", err)
+	}
+
+	if ! inArray(rootNode,expected) {
+		t.Fail()
+		t.Logf("RootNode's value should be one of '%v'",expected)
+
+	}
+
+	// Now test that a random value is sometimes returned
+	for i := 0; i < 100; i++ {
+		if val, err := discovery.GetRootNode(); err == nil && rootNode != val {
+			return
+		} else if err != nil {
+			t.Fail()
+			t.Logf("Error getting rootnode:  %s", err)
+		}
+	}
+	t.Fail()
+	t.Logf("returned value was always %s", rootNode)
 
 }
+
+
+func inArray(element string,array []string) bool {
+	for _, val := range array {
+		if val == element {
+			return true;
+		}
+	}
+	return false
+}
+

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/viper"
 
 	pb "github.com/hyperledger/fabric/protos"
+	"github.com/hyperledger/fabric/discovery"
 )
 
 // Is the configuration cached?
@@ -88,13 +89,15 @@ func CacheConfiguration() (err error) {
 
 	// getValidatorStreamAddress returns the address to stream requests to
 	getValidatorStreamAddress := func() string {
-		localaddr, _ := getLocalAddress()
+		localAddr, _ := getLocalAddress()
 		if viper.GetBool("peer.validator.enabled") { // in validator mode, send your own address
-			return localaddr
-		} else if valaddr := viper.GetString("peer.discovery.rootnode"); valaddr != "" {
-			return valaddr
+			return localAddr
+		} else if valAddr, err := discovery.GetRootNode(); err == nil{
+			if valAddr != "" {
+				return valAddr
+			}
 		}
-		return localaddr
+		return localAddr
 	}
 
 	// getPeerEndpoint returns the PeerEndpoint for this Peer instance.  Affected by env:peer.addressAutoDetect

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -43,6 +43,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/statemgmt/state"
 	"github.com/hyperledger/fabric/core/util"
 	pb "github.com/hyperledger/fabric/protos"
+	"github.com/hyperledger/fabric/discovery"
 )
 
 const defaultTimeout = time.Second * 3
@@ -233,8 +234,14 @@ func NewPeerWithHandler(secHelperFunc func() crypto.Peer, handlerFact HandlerFac
 		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
 	}
 	peer.ledgerWrapper = &ledgerWrapper{ledger: ledgerPtr}
-	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
-	return peer, nil
+
+	if rootNode, err := discovery.GetRootNode(); err == nil {
+		go peer.chatWithPeer(rootNode)
+		return peer, nil
+	} else {
+		return nil, err
+	}
+
 }
 
 // NewPeerWithHandler returns a Peer which uses the supplied handler factory function for creating new handlers on new Chat service invocations.
@@ -265,9 +272,16 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
 	}
+
 	peer.ledgerWrapper = &ledgerWrapper{ledger: ledgerPtr}
-	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
-	return peer, nil
+
+
+	if rootNode, err := discovery.GetRootNode(); err == nil {
+		go peer.chatWithPeer(rootNode)
+		return peer, nil
+	} else {
+		return nil, err
+	}
 }
 
 // Chat implementation of the the Chat bidi streaming RPC function

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -17,38 +17,25 @@ specific language governing permissions and limitations
 under the License.
 */
 
-package core
+package discovery
 
 
-import (
-	"strings"
-	"math/rand"
-	"time"
+type Discovery interface {
 
-	"github.com/spf13/viper"
+	// GetRootNode function for providing a bootstrap address for a peer
+	GetRootNode() (string, error)
 
-)
-
-
-
-type StaticDiscovery struct {
-	rootNodes []string
-	random *rand.Rand
-	isValidator bool
 }
 
-func NewStaticDiscovery(isValidator bool) *StaticDiscovery {
-	staticDisc := StaticDiscovery{}
-	staticDisc.rootNodes   = strings.Split(viper.GetString("peer.discovery.rootnode"),",")
-	staticDisc.random      = rand.New(rand.NewSource(time.Now().Unix()))
-	staticDisc.isValidator = isValidator
-	return &staticDisc
+var discInstance Discovery
+
+func SetDiscoveryService(instance Discovery) {
+	discInstance = instance
 }
 
-func (sd *StaticDiscovery) GetRootNode() (string, error) {
-	if sd.isValidator {
-		return sd.rootNodes[0], nil
-	}
-	return sd.rootNodes[sd.random.Int() % (len(sd.rootNodes))], nil
+func GetRootNode() (string, error) {
+	return discInstance.GetRootNode();
 }
+
+
 

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/genesis"
 	"github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/core/rest"
+	"github.com/hyperledger/fabric/discovery"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -376,7 +377,8 @@ func startOpenchain(t *testing.T) error {
 	// Create and register the REST service
 	go rest.StartOpenchainRESTServer(serverOpenchain, serverDevops)
 
-	rootNode, err := core.GetRootNode()
+	discovery.SetDiscoveryService(core.NewStaticDiscovery(viper.GetBool("peer.validator.enabled")))
+	rootNode, err := discovery.GetRootNode()
 	if err != nil {
 		grpclog.Fatalf("Failed to get peer.discovery.rootnode valey: %s", err)
 	}

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -197,6 +197,7 @@ peer:
 
         # The root nodes are used for bootstrapping purposes, and generally
         # supplied through ENV variables
+        # If it's a non-validating peer it can be either a single host or a comma separated list of hosts.
         rootnode:
 
         # The duration of time between attempts to asks peers for their connected peers


### PR DESCRIPTION
The root node is selected by looking at peer.discovery.rootnode with viper.
Non validating peers can only have 1 root node, so they can't do load balancing between
different validating peers.
Now the peer.discovery.rootnode can be a comma separated list and if the peer is non validating,
it will randomly select one of them.
If the peer is a validating peer and it's still given a comma separated list, it selectes the first peer (this is on purpose, because random selection with validating peers may reach a state of 2 mutually exclusive membership views (e.g {vp0, vp1}, {vp2, vp3})).

I tested it by running some validating peers and also spawning a non validating peer with CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303,172.17.0.3:30303,172.17.0.4:30303,172.17.0.5:30303 and ran deployment + invocations through the non validating peer. 
