### PR TITLE
Add unit test for crash fault including view change

### DIFF
--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -567,6 +567,7 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 	}
 
 	if instance.primary(instance.view) == instance.id && instance.activeView { // if we're primary of current view
+		logger.Debug("Replica %d is primary, issuing pre-prepare for request %s", instance.id, digest)
 		n := instance.seqNo + 1
 		haveOther := false
 
@@ -599,7 +600,11 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 
 			instance.innerBroadcast(&Message{&Message_PrePrepare{preprep}})
 			return instance.maybeSendCommit(digest, instance.view, n)
+		} else {
+			logger.Debug("Replica %d is primary, not sending pre-prepare for request %s because it is out of sequence numbers", instance.id, digest)
 		}
+	} else {
+		logger.Debug("Replica %d is backup, not sending pre-prepare for request %s", digest)
 	}
 
 	return nil
@@ -614,9 +619,11 @@ outer:
 	for d, req := range instance.outstandingReqs {
 		for _, cert := range instance.certStore {
 			if cert.digest == d {
+				logger.Debug("Replica %d already has certificate for request %s not going to resubmit", instance.id, d)
 				continue outer
 			}
 		}
+		logger.Debug("Replica %d has detected request %s must be resubmitted", instance.id, d)
 
 		// This is a request that has not been pre-prepared yet
 		// Trigger request processing again.
@@ -673,6 +680,7 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 		}
 
 		instance.reqStore[digest] = preprep.Request
+		logger.Debug("Replica %d storing request %s in oustanding request store", instance.id, digest)
 		instance.outstandingReqs[digest] = preprep.Request
 		instance.persistRequest(digest)
 	}

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -604,7 +604,7 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 			logger.Debug("Replica %d is primary, not sending pre-prepare for request %s because it is out of sequence numbers", instance.id, digest)
 		}
 	} else {
-		logger.Debug("Replica %d is backup, not sending pre-prepare for request %s", digest)
+		logger.Debug("Replica %d is backup, not sending pre-prepare for request %s", instance.id, digest)
 	}
 
 	return nil

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1144,3 +1144,89 @@ func TestReplicaCrash2(t *testing.T) {
 		}
 	}
 }
+
+// TestReplicaCrash3 simulates the restart requiring a view change
+// to a checkpoint which was restored from the persistance state
+// Replicas 0,1,2 participate up to a checkpoint, then all crash
+// Then replicas 0,1,3 start back up, and a view change must be
+// triggered to get vp3 up to speed
+func TestReplicaCrash3(t *testing.T) {
+	validatorCount := 4
+	net := makePBFTNetwork(validatorCount, func(pep *pbftEndpoint) {
+		pep.pbft.K = 2
+		pep.pbft.L = 2 * pep.pbft.K
+	})
+	defer net.stop()
+
+	twoOffline := false
+	threeOffline := true
+	net.filterFn = func(src int, dst int, msg []byte) []byte {
+		if twoOffline && dst == 2 { // 3 is 'offline'
+			return nil
+		}
+		if threeOffline && dst == 3 { // 3 is 'offline'
+			return nil
+		}
+		return msg
+	}
+
+	mkreq := func(n int64) *Request {
+		txTime := &gp.Timestamp{Seconds: n, Nanos: 0}
+		tx := &pb.Transaction{Type: pb.Transaction_CHAINCODE_DEPLOY, Timestamp: txTime}
+		txPacked, _ := proto.Marshal(tx)
+
+		return &Request{
+			Timestamp: &gp.Timestamp{Seconds: n, Nanos: 0},
+			Payload:   txPacked,
+			ReplicaId: uint64(generateBroadcaster(validatorCount)),
+		}
+	}
+
+	for i := int64(1); i <= 8; i++ {
+		net.pbftEndpoints[0].pbft.recvRequest(mkreq(i))
+	}
+	net.process() // vp0,1,2 should have a stable checkpoint for seqNo 8
+
+	// Create new pbft instances to restore from persistence
+	for id := 0; id < 2; id++ {
+		pe := net.pbftEndpoints[id]
+		os.Setenv("CORE_PBFT_GENERAL_K", "2") // TODO, this is a hacky way to inject config before initialization rather than after, address this in a future changeset
+		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc)
+		pe.pbft.N = 4
+		pe.pbft.f = (4 - 1) / 3
+		pe.pbft.requestTimeout = 200 * time.Millisecond
+	}
+
+	threeOffline = false
+	twoOffline = true
+
+	// Because vp2 is 'offline', and vp3 is still at the genesis block, the network needs to make a view change
+
+	net.pbftEndpoints[0].pbft.recvRequest(mkreq(9))
+	net.process()
+
+	// Now vp0,1,3 should be in sync with 3 executions in view 1, and vp2 should be at 2 executions in view 0
+	for i, pep := range net.pbftEndpoints {
+
+		if i == 2 {
+			// 2 is 'offline'
+			if pep.pbft.view != 0 {
+				t.Errorf("Expected replica %d to be in view 0, got %d", pep.id, pep.pbft.view)
+			}
+			expectedExecutions := uint64(8)
+			if pep.sc.executions != expectedExecutions {
+				t.Errorf("Expected %d executions on replica %d, got %d", expectedExecutions, pep.id, pep.sc.executions)
+			}
+			continue
+		}
+
+		if pep.pbft.view != 1 {
+			t.Errorf("Expected replica %d to be in view 1, got %d", pep.id, pep.pbft.view)
+		}
+
+		expectedExecutions := uint64(9)
+		if pep.sc.executions != expectedExecutions {
+			t.Errorf("Expected %d executions on replica %d, got %d", expectedExecutions, pep.id, pep.sc.executions)
+		}
+	}
+}

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1161,7 +1161,7 @@ func TestReplicaCrash3(t *testing.T) {
 	twoOffline := false
 	threeOffline := true
 	net.filterFn = func(src int, dst int, msg []byte) []byte {
-		if twoOffline && dst == 2 { // 3 is 'offline'
+		if twoOffline && dst == 2 { // 2 is 'offline'
 			return nil
 		}
 		if threeOffline && dst == 3 { // 3 is 'offline'
@@ -1205,7 +1205,7 @@ func TestReplicaCrash3(t *testing.T) {
 	net.pbftEndpoints[0].pbft.recvRequest(mkreq(9))
 	net.process()
 
-	// Now vp0,1,3 should be in sync with 3 executions in view 1, and vp2 should be at 2 executions in view 0
+	// Now vp0,1,3 should be in sync with 9 executions in view 1, and vp2 should be at 8 executions in view 0
 	for i, pep := range net.pbftEndpoints {
 
 		if i == 2 {

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -428,6 +428,7 @@ func (instance *pbftCore) processNewView2(nv *NewView) error {
 			instance.innerBroadcast(&Message{&Message_Prepare{prep}})
 		}
 	} else {
+		logger.Debug("Replica %d is now primary, attempting to resubmit requests", instance.id)
 		instance.resubmitRequests()
 	}
 


### PR DESCRIPTION
This is intended to help address #1364 

This test simulates a more complex crash fault than the existing units tests. It relies on the existence of recovered checkpoints to trigger a view change, so that the network can process a new request.

This test did not uncover any additional bugs, but should be useful to help prevent regression in the future, and because it is a unit test, adds negligible time to the test process.

Included outside of the test file are a few logging enhancements to make debugging easier.

Review from @corecode, @tuand27613, or @kchristidis would be helpful, though as this does not change any PBFT logic, PBFT expertise is less required.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
