### PR TITLE
Protect against decrypting empty state when creating table

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -571,6 +571,10 @@ func (handler *Handler) handleGetState(msg *pb.ChaincodeMessage) {
 			payload := []byte(err.Error())
 			chaincodeLogger.Error(fmt.Sprintf("[%s]Failed to get chaincode state(%s). Sending %s", shortuuid(msg.Uuid), err, pb.ChaincodeMessage_ERROR))
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
+		} else if res == nil {
+			//The state object being requested does not exist, so don't attempt to decrypt it
+			chaincodeLogger.Debug("[%s]No state associated with key: %s. Sending %s with an empty payload", shortuuid(msg.Uuid), key, pb.ChaincodeMessage_RESPONSE)
+			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_RESPONSE, Payload: res, Uuid: msg.Uuid}
 		} else {
 			// Decrypt the data if the confidential is enabled
 			if res, err = handler.decrypt(msg.Uuid, res); err == nil {


### PR DESCRIPTION
When a table does not exist the state value returned is nil. The code then attempts to decrypt this nil value and throws an error. Noticed this behavior when attempting to create a table when privacy was enabled.
