### PR TITLE
add extra wait to test 680 to let state transfer finish

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -465,7 +465,7 @@ Feature: lanching 3 peers
                     |arg1|arg2|arg3|
                     | b  | a  | 1  |
 	        Then I should have received a transactionID
-	        Then I wait up to "60" seconds for transaction to be committed to peers:
+	        Then I wait up to "120" seconds for transaction to be committed to peers:
                     | vp0  | vp1 | vp2 | vp3 |
 
             When I query chaincode "example2" function name "query" with value "a" on peers:
@@ -490,7 +490,7 @@ Feature: lanching 3 peers
 	    Then I should get a JSON response from peers with "OK" = "120"
             | vp0  | vp1 | vp2 |
 
-        # Now start vp3 again and run 8 more transactions
+        # Now start vp3 again
         Given I start peers:
             | vp3  |
         And I wait "15" seconds
@@ -502,6 +502,8 @@ Feature: lanching 3 peers
 	    Then I should have received a transactionID
 	    Then I wait up to "60" seconds for transaction to be committed to peers:
             | vp0  | vp1 | vp2 | vp3 |
+       # wait a bit longer and let state transfer finish
+       Then I wait "60" seconds
         When I query chaincode "example2" function name "query" with value "a" on peers:
             | vp0  | vp1 | vp2 | vp3 |
 	    Then I should get a JSON response from peers with "OK" = "20"
@@ -843,4 +845,3 @@ Feature: lanching 3 peers
         |   docker-compose-4-consensus-classic.yml   |      60      |
         |   docker-compose-4-consensus-batch.yml     |      60      |
         #|   docker-compose-4-consensus-sieve.yml     |      60      | // TODO, this is known to be broken, pending a fix
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

add wait before last query call to let state transfer finish on vp3
## Motivation and Context

Fixes #1358
## How Has This Been Tested?

Unit tests run.
Behave tests run.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

Signed-off-by: Tuan Dang tdang@us.ibm.com
