### PR TITLE
Use make to build fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ membersrvc/membersrvc
 .#*
 # bddtest log files
 *.log
+# Makefile dummy artifacts
+.*-dummy

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - cd /$HOME/gopath/src/github.com/hyperledger/fabric
- - make unit-test
+ - make behave-deps unit-test
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ before_script:
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - cd /$HOME/gopath/src/github.com/hyperledger/fabric
- - make peer && echo " STARTING PEER PROCESS "
- - (cd ./peer; ./peer peer) &
  - make unit-test
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,23 @@ install:
    echo " Installing Rocks DB, g++ compilers & Dependencies "
    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get -qq update && sudo apt-get -qq install g++-4.8 && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
    sudo pip install --upgrade pip && sudo pip install behave && sudo apt-get install build-essential -y
-   cd /opt  && sudo git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb && sudo make shared_lib
-   sudo cp /opt/rocksdb/*.so* /usr/lib/ && export LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH && sudo apt-get update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-   export CGO_CFLAGS="-I/opt/rocksdb/include" && export CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
+   sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+   cd /tmp
+   git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git
+   cd rocksdb
+   make shared_lib
+   sudo INSTALL_PATH=/usr/local make install-shared
+   sudo ldconfig
 
 before_script:
 
  - echo " CREATING BASE IMAGE "
- - echo " Calling docker.sh to build Openblockchain/baseimage "
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts/provision/ && chmod +x docker.sh && ./docker.sh 0.0.9
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
- - cd /$HOME/gopath/src/github.com/hyperledger/$REPO_NAME/peer
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
- - go build && echo " STARTING PEER PROCESS "
- - ./peer peer &
- - go test -timeout=20m $(go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/)
+ - cd /$HOME/gopath/src/github.com/hyperledger/fabric
+ - make peer && echo " STARTING PEER PROCESS "
+ - (cd ./peer; ./peer peer) &
+ - make unit-test
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
  - cd $HOME/gopath/src/github.com/hyperledger/fabric
  - sed -i -e 's/172.17.0.1:4243\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
  - make behave BEHAVE_OPTS="-D logs=Y -o testsummary.log"
+ - make linter
 
 after_failure:
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,14 +39,14 @@ before_script:
  - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - cd /$HOME/gopath/src/github.com/hyperledger/fabric
- - make behave-deps unit-test
+ - make unit-test
 
 script:
 
  - echo "Executing Behave test scripts"
- - cd $HOME/gopath/src/github.com/hyperledger/fabric/bddtests
+ - cd $HOME/gopath/src/github.com/hyperledger/fabric
  - sed -i -e 's/172.17.0.1:4243\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
- - behave -D logs=Y -o testsummary.log
+ - make behave BEHAVE_OPTS="-D logs=Y -o testsummary.log"
 
 after_failure:
  

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# -------------------------------------------------------------
+# This makefile defines the following targets
+#
+#   - peer (default) - builds the fabric ./peer/peer binary
+#   - membersrvc - builds the ./membersrvc/membersrvc binary
+#   - unit-test - runs the go-test based unit tests
+#   - behave - runs the behave test
+#   - images - ensures pre-requisites are availble for running behave manually
+#   - peer-image - ensures the peer-image is available (for behave, etc)
+#   - ca-image - ensures the ca-image is available (for behave, etc)
+#   - protos - generate all protobuf artifacts based on .proto files
+#   - clean - cleans the build area
+#   - dist-clean - superset of 'clean' that also removes persistent state
+
+
+PKGNAME = github.com/hyperledger/fabric
+CGO_LDFLAGS = -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy
+
+EXECUTABLES = go docker
+K := $(foreach exec,$(EXECUTABLES),\
+	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH: Check dependencies")))
+
+all: peer
+
+.PHONY: peer
+peer: base-image
+	cd peer; CGO_CFLAGS=" "	CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
+
+.PHONY: membersrvc
+membersrvc:
+	cd membersrvc; CGO_CFLAGS=" " CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
+
+unit-test: base-image
+	@echo "Running unit-tests"
+	@go test -timeout=20m $(shell go list $(PKGNAME)/... | grep -v /vendor/ | grep -v /examples/)
+	@touch .peerimage-dummy
+	@touch .caimage-dummy
+
+base-image: .baseimage-dummy
+peer-image: .peerimage-dummy
+ca-image: .caimage-dummy
+images: peer-image ca-image
+
+behave: images
+	@echo "Running behave tests"
+	@cd bddtests; behave
+
+.peerimage-dummy: .baseimage-dummy
+	go test $(PKGNAME)/core/container -run=BuildImage_Peer
+	@touch $@
+
+.caimage-dummy: .baseimage-dummy
+	go test $(PKGNAME)/core/container -run=BuildImage_Obcca
+	@touch $@
+
+.baseimage-dummy:
+	@echo "Building docker base-image"
+	@./scripts/provision/docker.sh 0.0.9
+	@touch $@
+
+protos:
+	./devenv/compile_protos.sh
+
+.PHONY: clean
+clean:
+	-@rm .*image-dummy ||:
+	-@rm -f ./peer/peer ||:
+	-@rm -f ./membersrvc/membersrvc ||:
+
+.PHONY: dist-clean
+dist-clean: clean
+	-@rm -rf /var/hyperledger/* ||:

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ behave: behave-deps
 	@./scripts/provision/docker.sh 0.0.9
 	@touch $@
 
+.PHONY: protos
 protos:
 	./devenv/compile_protos.sh
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@
 #   - membersrvc - builds the ./membersrvc/membersrvc binary
 #   - unit-test - runs the go-test based unit tests
 #   - behave - runs the behave test
-#   - images - ensures pre-requisites are availble for running behave manually
+#   - behave-deps - ensures pre-requisites are availble for running behave manually
+#   - images - ensures all docker images are available
 #   - peer-image - ensures the peer-image is available (for behave, etc)
 #   - ca-image - ensures the ca-image is available (for behave, etc)
 #   - protos - generate all protobuf artifacts based on .proto files
@@ -60,7 +61,8 @@ peer-image: .peerimage-dummy
 ca-image: .caimage-dummy
 images: peer-image ca-image
 
-behave: images
+behave-deps: images peer
+behave: behave-deps
 	@echo "Running behave tests"
 	@cd bddtests; behave
 

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,11 @@ peer: base-image
 membersrvc:
 	cd membersrvc; CGO_CFLAGS=" " CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
 
-unit-test: base-image
+unit-test: peer-image
 	@echo "Running unit-tests"
+	$(eval CID := $(shell docker run -dit -p 30303:30303 hyperledger-peer peer peer))
 	@go test -timeout=20m $(shell go list $(PKGNAME)/... | grep -v /vendor/ | grep -v /examples/)
+	@docker kill $(CID)
 	@touch .peerimage-dummy
 	@touch .caimage-dummy
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ images: peer-image ca-image
 behave-deps: images peer
 behave: behave-deps
 	@echo "Running behave tests"
-	@cd bddtests; behave
+	@cd bddtests; behave $(BEHAVE_OPTS)
 
 .peerimage-dummy: .baseimage-dummy
 	go test $(PKGNAME)/core/container -run=BuildImage_Peer

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@
 # -------------------------------------------------------------
 # This makefile defines the following targets
 #
-#   - peer (default) - builds the fabric ./peer/peer binary
+#   - all (default) - builds all targets and runs all tests
+#   - peer - builds the fabric ./peer/peer binary
 #   - membersrvc - builds the ./membersrvc/membersrvc binary
 #   - unit-test - runs the go-test based unit tests
 #   - behave - runs the behave test
@@ -38,7 +39,7 @@ EXECUTABLES = go docker
 K := $(foreach exec,$(EXECUTABLES),\
 	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH: Check dependencies")))
 
-all: peer
+all: peer membersrvc unit-test behave
 
 .PHONY: peer
 peer: base-image

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,14 @@
 # -------------------------------------------------------------
 # This makefile defines the following targets
 #
-#   - all (default) - builds all targets and runs all tests
+#   - all (default) - builds all targets and runs all tests/checks
+#   - checks - runs all tests/checks
 #   - peer - builds the fabric ./peer/peer binary
 #   - membersrvc - builds the ./membersrvc/membersrvc binary
 #   - unit-test - runs the go-test based unit tests
 #   - behave - runs the behave test
 #   - behave-deps - ensures pre-requisites are availble for running behave manually
+#   - linter - runs all code checks
 #   - images - ensures all docker images are available
 #   - peer-image - ensures the peer-image is available (for behave, etc)
 #   - ca-image - ensures the ca-image is available (for behave, etc)
@@ -39,7 +41,9 @@ EXECUTABLES = go docker
 K := $(foreach exec,$(EXECUTABLES),\
 	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH: Check dependencies")))
 
-all: peer membersrvc unit-test behave
+all: peer membersrvc checks
+
+checks: unit-test behave linter
 
 .PHONY: peer
 peer: base-image
@@ -66,6 +70,10 @@ behave-deps: images peer
 behave: behave-deps
 	@echo "Running behave tests"
 	@cd bddtests; behave $(BEHAVE_OPTS)
+
+linter:
+	@echo "LINT: Running code checks.."
+	@echo "LINT: No errors found"
 
 .peerimage-dummy: .baseimage-dummy
 	go test $(PKGNAME)/core/container -run=BuildImage_Peer

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -80,8 +80,6 @@ usermod -a -G docker vagrant # Add vagrant user to the docker group
 # Test docker
 docker run --rm busybox echo All good
 
-/hyperledger/scripts/provision/docker.sh $BASEIMAGE_RELEASE
-
 # Run our common setup
 /hyperledger/scripts/provision/common.sh
 
@@ -111,10 +109,6 @@ PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 #install golang deps
 ./installGolang.sh
 
-# Run go install - CGO flags for RocksDB
-cd $GOPATH/src/github.com/hyperledger/fabric/peer
-CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
-
 # Copy protobuf dir so we can build the protoc-gen-go binary. Then delete the directory.
 mkdir -p $GOPATH/src/github.com/golang/protobuf/
 cp -r $GOPATH/src/github.com/hyperledger/fabric/vendor/github.com/golang/protobuf/ $GOPATH/src/github.com/golang/
@@ -143,3 +137,7 @@ cat <<EOF >/etc/profile.d/vagrant-devenv.sh
 export PATH=\$PATH:/hyperledger/devenv/tools
 export VAGRANT=1
 EOF
+
+# Build the actual hyperledger peer
+cd $GOPATH/src/github.com/hyperledger/fabric
+make clean peer

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -680,13 +680,13 @@ You can interface with the peer process from a Node.js application. One way to a
 1. Build and install the [fabric core](https://github.com/hyperledger/fabric/blob/master/README.md#building-the-fabric-core-).
 
     ```
-    cd /opt/gopath/src/github.com/hyperledger/fabric/peer
-    go build
+    cd /opt/gopath/src/github.com/hyperledger/fabric
+    make peer
     ```
 
 2. Run a local peer node only (not a complete network) with:
 
-    `./peer`
+    `cd peer; ./peer`
 
 3. Set up a test blockchain data structure (with 5 blocks only) by running a test from within Vagrant as follows. Subsequently restart the peer process.
 

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -23,9 +23,9 @@ From your command line terminal, move to the `devenv` subdirectory of your works
 
 To set up the local development environment with security enabled, you must first build and run the <b>Certificate Authority (CA)</b> server:
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
-    go build
-    ./membersrvc
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make membersrvc
+    (cd membersrvc; ./membersrvc)
 
 Running the above commands builds and runs the CA server with the default setup, which is defined in the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) configuration file. The default configuration includes multiple users who are already registered with the CA; these users are listed in the 'users' section of the configuration file. To register additional users with the CA for testing, modify the 'users' section of the [membersrvc.yaml](https://github.com/hyperledger/fabric/blob/master/membersrvc/membersrvc.yaml) file to include additional enrollmentID and enrollmentPW pairs. Note the integer that precedes the enrollmentPW. That integer indicates the role of the user, where 1 = client, 2 = non-validating peer, 4 = validating peer, and 8 = auditor.
 
@@ -38,9 +38,10 @@ From your command line terminal, move to the `devenv` subdirectory of your works
 
 Build and run the peer process to enable security and privacy after setting <b>security.enabled</b> and <b>security.privacy</b> settings to 'true'.
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/peer
-    go build
-    ./peer peer --peer-chaincodedev   
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make peer
+    cd ./peer
+    ./peer peer --peer-chaincodedev
 
 Alternatively, enable security and privacy on the peer with environment variables:
 

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -26,8 +26,8 @@ From within the VM, you can build, run, and test your environment.
 
 #### 1. Go build
 ```
-cd $GOPATH/src/github.com/hyperledger/fabric/peer
-go build
+cd $GOPATH/src/github.com/hyperledger/fabric
+make peer
 ```
 
 #### 2. Run/Execute
@@ -87,15 +87,15 @@ You must also run the Node.js unit tests to insure that the Node.js client SDK i
 [Behave](http://pythonhosted.org/behave/) tests will setup networks of peers with different security and consensus configurations and verify that transactions run properly. To run these tests
 
 ```
-cd $GOPATH/src/github.com/hyperledger/fabric/bddtests
-behave
+cd $GOPATH/src/github.com/hyperledger/fabric
+make behave
 ```
 Some of the Behave tests run inside Docker containers. If a test fails and you want to have the logs from the Docker containers, run the tests with this option
 ```
 behave -D logs=Y
 ```
 
-Note, you must run the unit tests first to build the necessary `peer` and `member services` docker images. These images can also be individually built when `go test` is called with the following parameters:
+Note, in order to run behave directly, you must run 'make images' first to build the necessary `peer` and `member services` docker images. These images can also be individually built when `go test` is called with the following parameters:
 ```
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Obcca
@@ -119,8 +119,8 @@ INSTALL_PATH=/usr/local make install-shared
 ```
 - Execute the following commands:
 ```
-cd $GOPATH/src/github.com/hyperledger/fabric/peer
-CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install
+cd $GOPATH/src/github.com/hyperledger/fabric
+make
 ```
 - Make sure that the Docker daemon initialization includes the options
 ```

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -68,12 +68,10 @@ The `peer` command will initiate a peer process, with which one can interact by 
 New code must be accompanied by test cases both in unit and Behave tests.
 
 #### 3.1 Go Unit Tests
-To run all unit tests, in one window, run `./peer peer`. In a second window
+Use the following sequence to run all unit tests
 
     cd $GOPATH/src/github.com/hyperledger/fabric
-    go test -timeout=20m $(go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/)
-
-Note that the first time the tests are run, they can take some time due to the need to download a docker image that is about 1GB in size. This is why the timeout flag is added to the above command.
+    make unit-test
 
 To run a specific test use the `-run RE` flag where RE is a regular expression that matches the test case name. To run tests with verbose output use the `-v` flag. For example, to run the `TestGetFoo` test case, change to the directory containing the `foo_test.go` and call/excecute
 

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -177,7 +177,8 @@ See [specific logging control](logging-control.md) instructions when running the
 If you modify any `.proto` files, run the following command to generate/update the respective `.pb.go` files.
 
 ```
-$GOPATH/src/github.com/hyperledger/fabric/devenv/compile_protos.sh
+cd $GOPATH/src/github.com/hyperledger/fabric
+make protos
 ```
 
 ## Adding or updating Go packages <a name="vendoring"></a>

--- a/docs/dev-setup/obcca-setup.md
+++ b/docs/dev-setup/obcca-setup.md
@@ -62,12 +62,12 @@ When the CA is started for the first time, it will generate all of its required 
 
 The CA can be built with the following command executed in the `membersrvc` directory:
 
-    cd $GOPATH/src/github.com/hyperledger/fabric/membersrvc
-    go build
+    cd $GOPATH/src/github.com/hyperledger/fabric
+    make membersrvc
 
-The CA can be started with the following command executed in the directory where the CA binary is located:
+The CA can be started with the following command executed in the directory where the CA binary is located (cd ./membersrvc):
 
     ./membersrvc
 
-	
+
 The CA looks for an `membersrvc.yaml` configuration file in the same location as the server binary.  If the CA is started for the first time, it creates all its required state (e.g., internal databases, CA certificates, blockchain keys, etc.) and write each state to the directory given in the CA configuration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

```
This patch adds a top-level makefile for managing builds and dependencies
```
## Motivation and Context

```
Our current environment relies heavily on vagrant performing a good deal of the
preparation such that we can perform operations like "cd peer; go build".  One
minor problem is that a common vagrant-based workflow is to subsequently update
the code and rebuild without necessarily rebuilding the vagrant environment
(e.g. git pull && go build).  Any dependency changes in the underlying code
may not be properly satisfied with such a workflow.

To make matters more complicated, many other environments outside vagrant
exist (e.g. TravisCI, non vagrant based development environments, production
deployments, etc).  These environments are even more adversely affected with
extrinsic dependencies.  Work has been done (see the ./scripts/provisioning
area for an example) to try to help unify the different environments to
a single source of truth.  Despite this, we still struggle to provide a smooth
experience because these mechanisms need to be understood by all and
incorporated into the relevant workflows.  Often times, developers/users
don't even know these problems/mechanisms exist until they find things broken
in typically non-obvious ways.

Whats needed is an easy way to operate with a more self-contained approach
such that we can support the "git pull && do-it" type workflow.  However,
we also need to observe that the "go" tooling is probably ill equiped for
anything except the most basic of pure go development:  It intentionally
doesn't support external hooks, etc, as you would find in a general build
framework like Make or Maven.  Once you have a polyglot and/or dependencies
on external facilities (e.g. docker, protobuf, etc) starts to feel more
closer to "gcc" than to "make".

This isn't necessarily a bad thing, but trying to centralize our tooling
on a "go" tool based workflow I suspect is a large part of the current pain
being felt.  Instead, lets embrace it for what I believe it was intended
to do really well (compile go code), and augment it with a tool that
is better suited to managing a polyglot/external-dep universe, of which
golang is just one part.

There are many build frameworks to choose from, but Make is ubiquitous,
well understood, and well suited to the task.  I therefore think
it makes a perfectly reasonable approach to serve as the centerpoint
of our build system.

The intention is that developers/packagers/etc migrate to using make
in conjunction with the targets listed above rather than the raw commands
that have been historically employed.  While the old methods should
continue to work, the new workflow can incorporate more automation that
will help keep the build process running smoothly and adapting to future
requirements without users needing to be aware.  In this new model, the
typical workflow would become:

     git pull && make clean peer

This should generally allow most things to either be:

     a) automatically managed

      OR

     b) cleanly reported when automation cannot solve the problem (e.g.
        external dependencies that need to be manually installed).

I believe this should lay the groundwork for a vast improvement over the
current process.
```
## How Has This Been Tested?

Booted a clean vagrant environment, and using the new facilities:

make unit-test
make behave

All passed without any errors.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
