### PR TITLE
peer: Fix possible nil dereference in PeerImpl Unicast

### DIFF
--- a/core/peer/peer_test.go
+++ b/core/peer/peer_test.go
@@ -49,6 +49,15 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestMissingMessageHandlerUnicast(t *testing.T) {
+	emptyHandlerMap := handlerMap{m: make(map[pb.PeerID]MessageHandler)}
+	peerImpl := PeerImpl{handlerMap: &emptyHandlerMap}
+	err := peerImpl.Unicast(nil, &pb.PeerID{})
+	if err == nil {
+		t.Error("Expected error with bad receiver handle, but there was none")
+	}
+}
+
 func performChat(t testing.TB, conn *grpc.ClientConn) error {
 	serverClient := pb.NewPeerClient(conn)
 	stream, err := serverClient.Chat(context.Background())


### PR DESCRIPTION
## Description

In `PeerImpl`'s `Unicast` function, if the `receiveHandle` is not in the `handlerMap`, we'll try to call `SendMessage` on a nil, which will panic.  I'm not sure there's a way to actually trigger this bug but it seems cleaner this way.

The new extracted `getMessageHandler` function also takes care of unlocking with `defer`, which is safer than the previous code (against possible future changes).
## Motivation and Context

Possible panic if a bad `receiveHandle` is passed to the exported `Unicast` function.
## How Has This Been Tested?

Passes all unit tests on vagrant.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ ] If applicable, I have updated the documentation accordingly. <- N/A
- [x] If applicable, I have added tests to cover my changes.

Signed-off-by: Dov Murik <dmurik@us.ibm.com>
