### PR TITLE
Add a godoc icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hyperledger/fabric.svg?branch=master)](https://travis-ci.org/hyperledger/fabric)
+[![Build Status](https://travis-ci.org/hyperledger/fabric.svg?branch=master)](https://travis-ci.org/hyperledger/fabric) [![GoDoc](https://godoc.org/github.com/hyperledger/fabric?status.svg)](https://godoc.org/github.com/hyperledger/fabric)
 
 # Incubation Notice
 This project is a Hyperledger project in _Incubation_. It was proposed to the community and documented [here](https://goo.gl/RYQZ5N). Information on what _Incubation_ entails can be found in the [Hyperledger Project Lifecycle document](https://goo.gl/4edNRc).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This adds a godoc icon to the README
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

This change allows users to easily access the GoDoc for the Hyperledger Fabric project
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

There are no new test cases as this is only a change to the README
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] I have run [gometalinter](https://github.com/alecthomas/gometalinter), [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and have resolved all errors and warnings.
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

Signed-off-by: sheehan@us.ibm.com

@binhn I know you were discussing how to share GoDocs with users. I think this may be a good approach. We may wish to add links elsewhere to more specific areas of the GoDoc.
