### PR TITLE
Rebrand our docker image under the hyperledger name

### DIFF
--- a/consensus/docker-compose-files/Dockerfile
+++ b/consensus/docker-compose-files/Dockerfile
@@ -1,4 +1,4 @@
-from openblockchain/baseimage:latest
+from hyperledger/fabric-baseimage:latest
 
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/hyperledger/db

--- a/core/ledger/genesis/genesis_test.yaml
+++ b/core/ledger/genesis/genesis_test.yaml
@@ -46,7 +46,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from openblockchain/baseimage
+        from hyperledger/fabric-baseimage
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/hyperledger/db
@@ -186,7 +186,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from openblockchain/baseimage
+            from hyperledger/fabric-baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 

--- a/devenv/baseimage/README.md
+++ b/devenv/baseimage/README.md
@@ -1,5 +1,5 @@
 # Baseimage Introduction
-This directory contains the infrastructure for creating a new baseimage used as the basis for various functions within the Hyperledger workflow such as our Vagrant based development environment, chaincode compilation/execution, unit-testing, and even cluster simulation. It is based on ubuntu-14.04 with various opensource projects added such as golang, rocksdb, grpc, and node.js. The actual Hyperledger code is injected just-in-time before deployment.  The resulting images are published to public repositories such as [atlas.hashicorp.com](https://atlas.hashicorp.com/hyperledger/boxes/fabric-baseimage) for consumption by Vagrant/developers and [hub.docker.com](https://hub.docker.com/r/openblockchain/baseimage/) for consumption by docker-based workflows.
+This directory contains the infrastructure for creating a new baseimage used as the basis for various functions within the Hyperledger workflow such as our Vagrant based development environment, chaincode compilation/execution, unit-testing, and even cluster simulation. It is based on ubuntu-14.04 with various opensource projects added such as golang, rocksdb, grpc, and node.js. The actual Hyperledger code is injected just-in-time before deployment.  The resulting images are published to public repositories such as [atlas.hashicorp.com](https://atlas.hashicorp.com/hyperledger/boxes/fabric-baseimage) for consumption by Vagrant/developers and [hub.docker.com](https://hub.docker.com/r/hyperledger/fabric-baseimage/) for consumption by docker-based workflows.
 
 ![Baseimage Architectural Overview](./images/packer-overview.png)
 
@@ -22,7 +22,7 @@ If a component is found to be both broadly applicable and expensive to build JIT
 
 * "make vagrant" will build just the vagrant image and install it into the local environment as "hyperledger/fabric-baseimage:v0", making it suitable to local testing.
   * To utilize the new base image in your local tests, run `vagrant destroy` then `USE_LOCAL_BASEIMAGE=true vagrant up`, also preface `vagrant ssh` as `USE_LOCAL_BASEIMAGE=true vagrant ssh` or simply export that variable, or Vagrant will fail to find the ssh key.
-* "make docker" will build just the docker image and commit it to your local environment as "openblockchain/baseimage"
+* "make docker" will build just the docker image and commit it to your local environment as "hyperledger/fabric-baseimage"
 
 ## Usage Pattern 2 - Release manager promoting a new base image to the public repositories
 

--- a/devenv/baseimage/packer.json
+++ b/devenv/baseimage/packer.json
@@ -98,7 +98,7 @@
                 "only": [
                     "docker"
                 ],
-                "repository": "openblockchain/{{user `artifact`}}",
+                "repository": "hyperledger/fabric-{{user `artifact`}}",
                 "tag": "{{user `release`}}"
             },
             {

--- a/docs/dev-setup/devnet-setup.md
+++ b/docs/dev-setup/devnet-setup.md
@@ -11,7 +11,7 @@ logging output from the `peer` and chaincodes.
 
 ### Setting up Docker image
 To create a Docker image for the `hyperledger/fabric`,
-first clean out any active containers (hyperledger-peer and chaincode) using `docker ps -a` and `docker rm` commands. Second, remove any old images with `docker images` and `docker rmi` commands. **Careful**: do not remove any other images (like busybox or openblockchain/baseimage) as they are needed for a correct execution.
+first clean out any active containers (hyperledger-peer and chaincode) using `docker ps -a` and `docker rm` commands. Second, remove any old images with `docker images` and `docker rmi` commands. **Careful**: do not remove any other images (like busybox or hyperledger/fabric-baseimage) as they are needed for a correct execution.
 
 Now we are ready to build a new docker image:
 

--- a/examples/chaincode/go/utxo/Dockerfile
+++ b/examples/chaincode/go/utxo/Dockerfile
@@ -1,4 +1,4 @@
-from openblockchain/baseimage
+from hyperledger/fabric-baseimage
 
 RUN apt-get update && apt-get install pkg-config autoconf libtool -y
 RUN cd /tmp && git clone https://github.com/bitcoin/secp256k1.git && cd secp256k1/

--- a/examples/chaincode/go/utxo/README.md
+++ b/examples/chaincode/go/utxo/README.md
@@ -20,7 +20,7 @@ cd $GOPATH/src/github.com/hyperledger/fabric/examples/chaincode/go/utxo/
 docker build -t utxo:0.1.0 .
 ```
 
-Next, modify the `core.yaml` file in the obc-peer project to point to the local Docker image that was built in the previous step. In the core.yaml file find `chaincode.golang.Dockerfile` and change it from from `openblockchain/baseimage` to `utxo:0.1.0`
+Next, modify the `core.yaml` file in the obc-peer project to point to the local Docker image that was built in the previous step. In the core.yaml file find `chaincode.golang.Dockerfile` and change it from from `hyperledger/fabric-baseimage` to `utxo:0.1.0`
 
 Start the peer using the following commands
 ```

--- a/membersrvc/Dockerfile
+++ b/membersrvc/Dockerfile
@@ -1,4 +1,4 @@
-from openblockchain/baseimage:latest
+from hyperledger/fabric-baseimage:latest
 # Copy GOPATH src and install Peer
 RUN mkdir -p /var/hyperledger/db
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric/

--- a/membersrvc/ca/ca_test.yaml
+++ b/membersrvc/ca/ca_test.yaml
@@ -57,7 +57,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from openblockchain/baseimage:latest
+        from hyperledger/fabric-baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/hyperledger/db
@@ -239,7 +239,7 @@ chaincode:
 
         # This is the basis for the Golang Dockerfile.  Additional commands will be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from openblockchain/baseimage
+            from hyperledger/fabric-baseimage
             COPY src $GOPATH/src
             WORKDIR $GOPATH
 

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -91,7 +91,7 @@ peer:
     networkId: dev
 
     Dockerfile:  |
-        from openblockchain/baseimage:latest
+        from hyperledger/fabric-baseimage:latest
         # Copy GOPATH src and install Peer
         COPY src $GOPATH/src
         RUN mkdir -p /var/hyperledger/db
@@ -289,7 +289,7 @@ chaincode:
         # This is the basis for the Golang Dockerfile.  Additional commands will
         # be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            from openblockchain/baseimage
+            from hyperledger/fabric-baseimage
             #from utxo:0.1.0
             COPY src $GOPATH/src
             WORKDIR $GOPATH
@@ -299,7 +299,7 @@ chaincode:
         # This is the basis for the CAR Dockerfile.  Additional commands will
         # be appended depedendent upon the chaincode specification.
         Dockerfile:  |
-            FROM openblockchain/baseimage
+            FROM hyperledger/fabric-baseimage
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests

--- a/scripts/provision/docker.sh
+++ b/scripts/provision/docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ---------------------------------------------------------------------------
-# Install the openblockchain/baseimage docker environment
+# Install the hyperledger/fabric-baseimage docker environment
 # ---------------------------------------------------------------------------
 #
 # There are some interesting things to note here:
@@ -47,8 +47,8 @@
 #    is a compromise.
 # ---------------------------------------------------------------------------
 
-NAME=openblockchain/baseimage
-RELEASE=$1
+NAME=hyperledger/fabric-baseimage
+RELEASE=`uname -p`-$1
 FQN=$NAME:$RELEASE
 
 CURDIR=`dirname $0`


### PR DESCRIPTION
Rebrand all remaining baseimage mechanics to the hyperledger name
## Description

This patch introduces a lateral move of the assets on dockerhub from openblockchain/baseimage to hyperledger/fabric-baseimage.

Notable changes aside from the obvious renaming:
- We now use "fabric-baseimage" rather than the more general "baseimage" to reflect there might be other projects under the hyperledger umbrella beside the fabric project.
- We include the $arch in the tag ("x86_64-0.0.9" vs "0.0.9") to lay the groundwork for supporting other architectures.  Today, only x86_64 is available, with others planned for the near future.

Note that the image was, in fact, recompiled rather than copied.  This is because the branding impacts the image with things such as /etc/hyperledger-baseimage-release.  However, it is not believed that the resulting image differed from the original artifact in any substantial way since there have been no relevant changes since v0.0.9.  Therefore, the version number remains unchanged despite a regeneration cycle.
## Motivation and Context

The references to "openblockchain" were a legacy remnant from the project history prior to HL/LF acceptance as an incubated project.  This reference remained longer than most other rebranding efforts because of initial issues with permissions/access to the hyperledger namespace on dockerhub, which has since been resolved.
## How Has This Been Tested?

Standard boot fresh vagrant and run unit-tests/behave.  All passed
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ ] I have run [gometalinter](https://github.com/alecthomas/gometalinter), [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and have resolved all errors and warnings.
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
