### PR TITLE
Remove gometalinter and add Go specific tools

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ Fixes #
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
-- [ ] I have run [gometalinter](https://github.com/alecthomas/gometalinter), [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and have resolved all errors and warnings.
 - [ ] If applicable, I have updated the documentation accordingly.
 - [ ] If applicable, I have added tests to cover my changes.
+- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code across the community.
 
 Signed-off-by:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ Fixes #
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
-- [ ] If applicable, I have updated the documentation accordingly.
-- [ ] If applicable, I have added tests to cover my changes.
-- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code across the community.
+- [ ] Either no new documentation is required by this change, OR I added new documentation
+- [ ] Either no new tests are required by this change, OR I added new tests
+- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.
 
 Signed-off-by:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This change removes gometalinter from the PR template and adds Go specific tools
[goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
[go vet](https://golang.org/cmd/vet/)
[golint](https://github.com/golang/lint)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

See #1414. The goal is to make contribution to the project as painless as possible while enforcing a minimum standard for code formatting and comments.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

No new tests as this is only a change to a PR template
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ ] I have run [gometalinter](https://github.com/alecthomas/gometalinter), [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and have resolved all errors and warnings.
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

Signed-off-by: sheehan@us.ibm.com

@bcbrock @ghaskins @christo4ferris @muralisrini 
