### PR TITLE
Remove helper dependencies from statetransfer

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -71,6 +71,7 @@ type Executor interface {
 	SkipTo(tag uint64, id []byte, peers []*pb.PeerID)
 }
 
+// StatePersistor is used to store consensus state which should survive a process crash
 type StatePersistor interface {
 	StoreState(key string, value []byte) error
 	ReadState(key string) ([]byte, error)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -17,7 +17,6 @@ limitations under the License.
 package consensus
 
 import (
-	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -61,28 +60,6 @@ type ReadOnlyLedger interface {
 	GetBlockHeadMetadata() ([]byte, error)
 }
 
-// UtilLedger contains additional useful utility functions for interrogating the blockchain
-type UtilLedger interface {
-	HashBlock(block *pb.Block) ([]byte, error)
-	VerifyBlockchain(start, finish uint64) (uint64, error)
-}
-
-// WritableLedger is useful for updating the blockchain during state transfer
-type WritableLedger interface {
-	PutBlock(blockNumber uint64, block *pb.Block) error
-	ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error
-	CommitStateDelta(id interface{}) error
-	RollbackStateDelta(id interface{}) error
-	EmptyState() error
-}
-
-// Ledger is an unrestricted union of reads, utilities, and updates
-type Ledger interface {
-	ReadOnlyLedger
-	UtilLedger
-	WritableLedger
-}
-
 // Executor is used to invoke transactions, potentially modifying the backing ledger
 type Executor interface {
 	BeginTxBatch(id interface{}) error
@@ -92,13 +69,6 @@ type Executor interface {
 	PreviewCommitTxBatch(id interface{}, metadata []byte) ([]byte, error)
 
 	SkipTo(tag uint64, id []byte, peers []*pb.PeerID)
-}
-
-// RemoteLedgers is used to interrogate the blockchain of other replicas
-type RemoteLedgers interface {
-	GetRemoteBlocks(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncBlocks, error)
-	GetRemoteStateSnapshot(replicaID *pb.PeerID) (<-chan *pb.SyncStateSnapshot, error)
-	GetRemoteStateDeltas(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncStateDeltas, error)
 }
 
 type StatePersistor interface {
@@ -113,7 +83,6 @@ type Stack interface {
 	NetworkStack
 	SecurityUtils
 	Executor
-	Ledger
-	RemoteLedgers
+	ReadOnlyLedger
 	StatePersistor
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -56,7 +56,7 @@ type SecurityUtils interface {
 type ReadOnlyLedger interface {
 	GetBlock(id uint64) (block *pb.Block, err error)
 	GetCurrentStateHash() (stateHash []byte, err error)
-	GetBlockchainSize() (uint64, error)
+	GetBlockchainSize() uint64
 	GetBlockchainInfoBlob() []byte
 	GetBlockHeadMetadata() ([]byte, error)
 }

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -54,7 +54,7 @@ func NewHelper(mhc peer.MessageHandlerCoordinator) *Helper {
 		secOn:       viper.GetBool("security.enabled"),
 		secHelper:   mhc.GetSecHelper(),
 	}
-	h.sts = statetransfer.NewStateTransferState(h)
+	h.sts = statetransfer.NewStateTransferState(mhc)
 	h.sts.Initiate(nil)
 	h.sts.RegisterListener(h)
 	return h
@@ -278,12 +278,8 @@ func (h *Helper) GetCurrentStateHash() (stateHash []byte, err error) {
 }
 
 // GetBlockchainSize returns the current size of the blockchain
-func (h *Helper) GetBlockchainSize() (uint64, error) {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return 0, fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.GetBlockchainSize(), nil
+func (h *Helper) GetBlockchainSize() uint64 {
+	return h.coordinator.GetBlockchainSize()
 }
 
 // HashBlock returns the hash of the included block, useful for mocking

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode"
 	crypto "github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 	"github.com/hyperledger/fabric/core/peer"
 	pb "github.com/hyperledger/fabric/protos"
 )
@@ -280,113 +279,6 @@ func (h *Helper) GetCurrentStateHash() (stateHash []byte, err error) {
 // GetBlockchainSize returns the current size of the blockchain
 func (h *Helper) GetBlockchainSize() uint64 {
 	return h.coordinator.GetBlockchainSize()
-}
-
-// HashBlock returns the hash of the included block, useful for mocking
-func (h *Helper) HashBlock(block *pb.Block) ([]byte, error) {
-	return block.GetHash()
-}
-
-// PutBlock inserts a raw block into the blockchain at the specified index, nearly no error checking is performed
-func (h *Helper) PutBlock(blockNumber uint64, block *pb.Block) error {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.PutRawBlock(block, blockNumber)
-}
-
-// ApplyStateDelta applies a state delta to the current state
-// The result of this function can be retrieved using GetCurrentStateDelta
-// To commit the result, call CommitStateDelta, or to roll it back
-// call RollbackStateDelta
-func (h *Helper) ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.ApplyStateDelta(id, delta)
-}
-
-// CommitStateDelta makes the result of ApplyStateDelta permanent
-// and releases the resources necessary to rollback the delta
-func (h *Helper) CommitStateDelta(id interface{}) error {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.CommitStateDelta(id)
-}
-
-// RollbackStateDelta undoes the results of ApplyStateDelta to revert
-// the current state back to the state before ApplyStateDelta was invoked
-func (h *Helper) RollbackStateDelta(id interface{}) error {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.RollbackStateDelta(id)
-}
-
-// EmptyState completely empties the state and prepares it to restore a snapshot
-func (h *Helper) EmptyState() error {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.DeleteALLStateKeysAndValues()
-}
-
-// VerifyBlockchain checks the integrity of the blockchain between indices start and finish,
-// returning the first block who's PreviousBlockHash field does not match the hash of the previous block
-func (h *Helper) VerifyBlockchain(start, finish uint64) (uint64, error) {
-	ledger, err := ledger.GetLedger()
-	if err != nil {
-		return finish, fmt.Errorf("Failed to get the ledger :%v", err)
-	}
-	return ledger.VerifyChain(start, finish)
-}
-
-func (h *Helper) getRemoteLedger(peerID *pb.PeerID) (peer.RemoteLedger, error) {
-	remoteLedger, err := h.coordinator.GetRemoteLedger(peerID)
-	if nil != err {
-		return nil, fmt.Errorf("Error retrieving the remote ledger for the given handle '%s' : %s", peerID, err)
-	}
-
-	return remoteLedger, nil
-}
-
-// GetRemoteBlocks will return a channel to stream blocks from the desired replicaID
-func (h *Helper) GetRemoteBlocks(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncBlocks, error) {
-	remoteLedger, err := h.getRemoteLedger(replicaID)
-	if nil != err {
-		return nil, err
-	}
-	return remoteLedger.RequestBlocks(&pb.SyncBlockRange{
-		Start: start,
-		End:   finish,
-	})
-}
-
-// GetRemoteStateSnapshot will return a channel to stream a state snapshot from the desired replicaID
-func (h *Helper) GetRemoteStateSnapshot(replicaID *pb.PeerID) (<-chan *pb.SyncStateSnapshot, error) {
-	remoteLedger, err := h.getRemoteLedger(replicaID)
-	if nil != err {
-		return nil, err
-	}
-	return remoteLedger.RequestStateSnapshot()
-}
-
-// GetRemoteStateDeltas will return a channel to stream a state snapshot deltas from the desired replicaID
-func (h *Helper) GetRemoteStateDeltas(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncStateDeltas, error) {
-	remoteLedger, err := h.getRemoteLedger(replicaID)
-	if nil != err {
-		return nil, err
-	}
-	return remoteLedger.RequestStateDeltas(&pb.SyncBlockRange{
-		Start: start,
-		End:   finish,
-	})
 }
 
 func (h *Helper) GetBlockchainInfoBlob() []byte {

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -714,8 +714,7 @@ func (op *obcSieve) commit() {
 
 func (op *obcSieve) restoreBlockNumber() {
 	var err error
-	op.blockNumber, err = op.stack.GetBlockchainSize()
-	op.blockNumber-- // The highest block number is one less than the size
+	op.blockNumber = op.stack.GetBlockchainSize() - 1 // The highest block number is one less than the size
 	if err != nil {
 		logger.Error("Sieve replica %d could not update its blockNumber", op.id)
 		return

--- a/consensus/obcpbft/obc-sieve_test.go
+++ b/consensus/obcpbft/obc-sieve_test.go
@@ -74,8 +74,7 @@ func TestSieveNetwork(t *testing.T) {
 
 	for _, ep := range net.endpoints {
 		cep := ep.(*consumerEndpoint)
-		blockchainSize, _ := cep.consumer.(*obcSieve).stack.GetBlockchainSize()
-		blockchainSize--
+		blockchainSize := cep.consumer.(*obcSieve).stack.GetBlockchainSize() - 1
 		if blockchainSize != 2 {
 			t.Errorf("Replica %d has incorrect blockchain size; is %d, should be 2", cep.id, blockchainSize)
 		}
@@ -127,8 +126,7 @@ func TestSieveNoDecision(t *testing.T) {
 
 	for _, ep := range net.endpoints {
 		cep := ep.(*consumerEndpoint)
-		newBlocks, _ := cep.consumer.(*obcSieve).stack.GetBlockchainSize() // Doesn't fail
-		newBlocks--
+		newBlocks := cep.consumer.(*obcSieve).stack.GetBlockchainSize() - 1
 		if newBlocks != 1 {
 			t.Errorf("replica %d executed %d requests, expected %d",
 				cep.id, newBlocks, 1)
@@ -176,7 +174,7 @@ func TestSieveReqBackToBack(t *testing.T) {
 
 	for _, ep := range net.endpoints {
 		cep := ep.(*consumerEndpoint)
-		newBlocks, _ := cep.consumer.(*obcSieve).stack.GetBlockchainSize() // Doesn't fail
+		newBlocks := cep.consumer.(*obcSieve).stack.GetBlockchainSize()
 		newBlocks--
 		if newBlocks != 2 {
 			t.Errorf("Replica %d executed %d requests, expected %d",

--- a/consensus/obcpbft/statetransfer_test.go
+++ b/consensus/obcpbft/statetransfer_test.go
@@ -96,7 +96,7 @@ func executeStateTransfer(sts *StateTransferState, ml *MockLedger, blockNumber, 
 		// Do nothing, continue the test
 	}
 
-	if size, _ := ml.GetBlockchainSize(); size != blockNumber+1 { // Will never fail
+	if size := ml.GetBlockchainSize(); size != blockNumber+1 {
 		return fmt.Errorf("Blockchain should be caught up to block %d, but is only %d tall", blockNumber, size)
 	}
 
@@ -295,7 +295,7 @@ func TestCatchupSyncBlocksAllErrors(t *testing.T) {
 			// Do nothing, continue the test
 		}
 
-		if size, _ := ml.GetBlockchainSize(); size != blockNumber+1 { // Will never fail
+		if size := ml.GetBlockchainSize(); size != blockNumber+1 {
 			t.Fatalf("Blockchain should be caught up to block %d, but is only %d tall", blockNumber, size)
 		}
 

--- a/consensus/statetransfer/statetransfer.go
+++ b/consensus/statetransfer/statetransfer.go
@@ -45,6 +45,7 @@ func init() {
 // public methods and structure definitions
 // =============================================================================
 
+// PartialStack is a subset of peer.MessageHandlerCoordinator functionality which is necessary to perform state transfer
 type PartialStack interface {
 	peer.BlockChainAccessor
 	peer.BlockChainModifier
@@ -54,6 +55,7 @@ type PartialStack interface {
 	GetRemoteLedger(receiver *protos.PeerID) (peer.RemoteLedger, error)
 }
 
+// Listener is an interface which allows for other modules to register to receive events about the progress of state transfer
 type Listener interface {
 	Initiated()                                                   // Called when the state transfer thread starts a new state transfer
 	Errored(uint64, []byte, []*protos.PeerID, interface{}, error) // Called when an error is encountered during state transfer, only the error is guaranteed to be set, other fields will be set on a best effort basis

--- a/consensus/statetransfer/statetransfer.go
+++ b/consensus/statetransfer/statetransfer.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger/fabric/consensus"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
+	"github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
@@ -46,9 +46,12 @@ func init() {
 // =============================================================================
 
 type PartialStack interface {
-	consensus.Ledger
-	consensus.RemoteLedgers
-	consensus.Inquirer
+	peer.BlockChainAccessor
+	peer.BlockChainModifier
+	peer.BlockChainUtil
+	GetPeers() (*protos.PeersMessage, error)
+	GetPeerEndpoint() (*protos.PeerEndpoint, error)
+	GetRemoteLedger(receiver *protos.PeerID) (peer.RemoteLedger, error)
 }
 
 type Listener interface {
@@ -285,12 +288,14 @@ func ThreadlessNewStateTransferState(stack PartialStack) *StateTransferState {
 	sts.stateTransferListenersLock = &sync.Mutex{}
 
 	sts.stack = stack
-	sts.id, _, err = stack.GetNetworkHandles()
+	ep, err := stack.GetPeerEndpoint()
 
 	if nil != err {
 		logger.Debug("Error resolving our own PeerID, this shouldn't happen")
 		sts.id = &protos.PeerID{"ERROR_RESOLVING_ID"}
 	}
+
+	sts.id = ep.ID
 
 	sts.asynchronousTransferInProgress = false
 
@@ -412,21 +417,19 @@ func (sts *StateTransferState) tryOverPeers(passedPeerIDs []*protos.PeerID, do f
 
 	if nil == passedPeerIDs {
 		logger.Debug("%v tryOverPeers, no peerIDs given, discovering", sts.id)
-		self, network, err := sts.stack.GetNetworkInfo()
-		if nil != err {
-			return fmt.Errorf("Error attempting to get network info: %s", err)
+
+		peersMsg, err := sts.stack.GetPeers()
+		if err != nil {
+			return fmt.Errorf("Couldn't retrieve list of peers: %v", err)
 		}
-
-		for _, endpoint := range network {
-			if endpoint.Type != protos.PeerEndpoint_VALIDATOR {
-				continue
+		peers := peersMsg.GetPeers()
+		for _, endpoint := range peers {
+			if endpoint.Type == protos.PeerEndpoint_VALIDATOR {
+				if endpoint.ID.Name == sts.id.Name {
+					continue
+				}
+				peerIDs = append(peerIDs, endpoint.ID)
 			}
-
-			if endpoint == self {
-				continue
-			}
-
-			peerIDs = append(peerIDs, endpoint.ID)
 		}
 
 		logger.Debug("%v discovered %d peerIDs", sts.id, len(peerIDs))
@@ -468,7 +471,7 @@ func (sts *StateTransferState) syncBlocks(highBlock, lowBlock uint64, highHash [
 	var block *protos.Block
 
 	err := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
-		blockChan, err := sts.stack.GetRemoteBlocks(peerID, blockCursor, lowBlock)
+		blockChan, err := sts.GetRemoteBlocks(peerID, blockCursor, lowBlock)
 		if nil != err {
 			logger.Warning("%v failed to get blocks from %d to %d from %v: %s",
 				sts.id, blockCursor, lowBlock, peerID, err)
@@ -513,7 +516,7 @@ func (sts *StateTransferState) syncBlocks(highBlock, lowBlock uint64, highHash [
 					if !sts.RecoverDamage {
 
 						// If we are not supposed to be destructive in our recovery, check to make sure this block doesn't already exist
-						if oldBlock, err := sts.stack.GetBlock(blockCursor); err == nil && oldBlock != nil {
+						if oldBlock, err := sts.stack.GetBlockByNumber(blockCursor); err == nil && oldBlock != nil {
 							oldBlockHash, err := sts.stack.HashBlock(oldBlock)
 							if nil == err {
 								if !bytes.Equal(oldBlockHash, validBlockHash) {
@@ -560,11 +563,7 @@ func (sts *StateTransferState) syncBlockchainToCheckpoint(blockSyncReq *blockSyn
 
 	logger.Debug("%v is processing a blockSyncReq to block %d", sts.id, blockSyncReq.blockNumber)
 
-	blockchainSize, err := sts.stack.GetBlockchainSize()
-
-	if nil != err {
-		panic("We can't determine how long our blockchain is, this is irrecoverable")
-	}
+	blockchainSize := sts.stack.GetBlockchainSize()
 
 	if blockSyncReq.blockNumber+1 < blockchainSize {
 		if !sts.RecoverDamage {
@@ -599,16 +598,13 @@ func (sts *StateTransferState) syncBlockchainToCheckpoint(blockSyncReq *blockSyn
 func (sts *StateTransferState) VerifyAndRecoverBlockchain() bool {
 
 	if 0 == len(sts.validBlockRanges) {
-		size, err := sts.stack.GetBlockchainSize()
-		if nil != err {
-			panic("We cannot determine how long our blockchain is, this is irrecoverable")
-		}
+		size := sts.stack.GetBlockchainSize()
 		if 0 == size {
 			logger.Warning("%v has no blocks in its blockchain, including the genesis block", sts.id)
 			return false
 		}
 
-		block, err := sts.stack.GetBlock(size - 1)
+		block, err := sts.stack.GetBlockByNumber(size - 1)
 		if nil != err {
 			logger.Warning("%v could not retrieve its head block %d: %s", sts.id, size, err)
 			return false
@@ -643,7 +639,7 @@ func (sts *StateTransferState) VerifyAndRecoverBlockchain() bool {
 			// Ranges are not distinct (or are adjacent), we will collapse them or discard the lower if it does not chain
 			if sts.validBlockRanges[1].lowBlock < lowBlock {
 				// Range overlaps or is adjacent
-				block, err := sts.stack.GetBlock(lowBlock - 1) // Subtraction is safe here, lowBlock > 0
+				block, err := sts.stack.GetBlockByNumber(lowBlock - 1) // Subtraction is safe here, lowBlock > 0
 				if nil != err {
 					logger.Warning("%v could not retrieve block %d which it believed to be valid: %s", sts.id, lowBlock-1, err)
 				} else {
@@ -690,7 +686,7 @@ func (sts *StateTransferState) VerifyAndRecoverBlockchain() bool {
 
 		sts.validBlockRanges[0].lowBlock = targetBlock
 
-		block, err := sts.stack.GetBlock(targetBlock)
+		block, err := sts.stack.GetBlockByNumber(targetBlock)
 		if nil != err {
 			logger.Warning("%v could not retrieve block %d which it believed to be valid: %s", sts.id, lowBlock-1, err)
 			return false
@@ -780,11 +776,7 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 
 		logger.Debug("%v completed state transfer to block %d", sts.id, *currentStateBlockNumber)
 	} else {
-		*currentStateBlockNumber, err = sts.stack.GetBlockchainSize()
-		if nil != err {
-			panic(fmt.Errorf("Cannot get our blockchain size, this is irrecoverable: %s", err))
-		}
-		*currentStateBlockNumber-- // The block height is one more than the latest block number
+		*currentStateBlockNumber = sts.stack.GetBlockchainSize() - 1 // The block height is one more than the latest block number
 	}
 
 	// TODO, eventually we should allow lower block numbers and rewind transactions as needed
@@ -859,7 +851,7 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 
 	}
 
-	block, err := sts.stack.GetBlock(*currentStateBlockNumber)
+	block, err := sts.stack.GetBlockByNumber(*currentStateBlockNumber)
 	if nil != err {
 		*blocksValid = false
 		return fmt.Errorf("%v believed its state for block %d to be valid, but it could not retrieve it : %s", sts.id, *currentStateBlockNumber, err)
@@ -993,7 +985,7 @@ func (sts *StateTransferState) playStateUpToBlockNumber(fromBlockNumber, toBlock
 	currentBlock := fromBlockNumber
 	err := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
 
-		deltaMessages, err := sts.stack.GetRemoteStateDeltas(peerID, currentBlock, toBlockNumber)
+		deltaMessages, err := sts.GetRemoteStateDeltas(peerID, currentBlock, toBlockNumber)
 		if err != nil {
 			return fmt.Errorf("%v received an error while trying to get the state deltas for blocks %d through %d from %d", sts.id, fromBlockNumber, toBlockNumber, peerID)
 		}
@@ -1019,7 +1011,7 @@ func (sts *StateTransferState) playStateUpToBlockNumber(fromBlockNumber, toBlock
 
 				success := false
 
-				testBlock, err := sts.stack.GetBlock(deltaMessage.Range.End)
+				testBlock, err := sts.stack.GetBlockByNumber(deltaMessage.Range.End)
 
 				if nil != err {
 					logger.Warning("%v could not retrieve block %d, though it should be present", sts.id, deltaMessage.Range.End)
@@ -1083,7 +1075,7 @@ func (sts *StateTransferState) syncStateSnapshot(minBlockNumber uint64, peerIDs 
 			logger.Error("Could not empty the current state: %s", err)
 		}
 
-		stateChan, err := sts.stack.GetRemoteStateSnapshot(peerID)
+		stateChan, err := sts.GetRemoteStateSnapshot(peerID)
 
 		if err != nil {
 			return err
@@ -1127,4 +1119,39 @@ func (sts *StateTransferState) syncStateSnapshot(minBlockNumber uint64, peerIDs 
 	})
 
 	return currentStateBlock, ok
+}
+
+// The below were stolen from helper.go, they should eventually be removed there, and probably made private here
+
+// GetRemoteBlocks will return a channel to stream blocks from the desired replicaID
+func (sts *StateTransferState) GetRemoteBlocks(replicaID *protos.PeerID, start, finish uint64) (<-chan *protos.SyncBlocks, error) {
+	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
+	if nil != err {
+		return nil, err
+	}
+	return remoteLedger.RequestBlocks(&protos.SyncBlockRange{
+		Start: start,
+		End:   finish,
+	})
+}
+
+// GetRemoteStateSnapshot will return a channel to stream a state snapshot from the desired replicaID
+func (sts *StateTransferState) GetRemoteStateSnapshot(replicaID *protos.PeerID) (<-chan *protos.SyncStateSnapshot, error) {
+	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
+	if nil != err {
+		return nil, err
+	}
+	return remoteLedger.RequestStateSnapshot()
+}
+
+// GetRemoteStateDeltas will return a channel to stream a state snapshot deltas from the desired replicaID
+func (sts *StateTransferState) GetRemoteStateDeltas(replicaID *protos.PeerID, start, finish uint64) (<-chan *protos.SyncStateDeltas, error) {
+	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
+	if nil != err {
+		return nil, err
+	}
+	return remoteLedger.RequestStateDeltas(&protos.SyncBlockRange{
+		Start: start,
+		End:   finish,
+	})
 }

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -268,6 +268,12 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 		}
 	}
 
+	ledgerPtr, err := ledger.GetLedger()
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
+	}
+	peer.ledgerWrapper = &ledgerWrapper{ledger: ledgerPtr}
+
 	peer.engine, err = engFactory(peer)
 	if err != nil {
 		return nil, err
@@ -277,11 +283,6 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 		return nil, errors.New("Cannot supply nil handler factory")
 	}
 
-	ledgerPtr, err := ledger.GetLedger()
-	if err != nil {
-		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
-	}
-	peer.ledgerWrapper = &ledgerWrapper{ledger: ledgerPtr}
 	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
 	return peer, nil
 }

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -268,6 +268,7 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 		}
 	}
 
+	// Initialize the ledger before the engine, as consensus may want to begin interrogating the ledger immediately
 	ledgerPtr, err := ledger.GetLedger()
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
@@ -655,31 +656,31 @@ func (p *PeerImpl) VerifyBlockchain(start, finish uint64) (uint64, error) {
 // To commit the result, call CommitStateDelta, or to roll it back
 // call RollbackStateDelta
 func (p *PeerImpl) ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error {
-	p.ledgerWrapper.RLock()
-	defer p.ledgerWrapper.RUnlock()
+	p.ledgerWrapper.Lock()
+	defer p.ledgerWrapper.Unlock()
 	return p.ledgerWrapper.ledger.ApplyStateDelta(id, delta)
 }
 
 // CommitStateDelta makes the result of ApplyStateDelta permanent
 // and releases the resources necessary to rollback the delta
 func (p *PeerImpl) CommitStateDelta(id interface{}) error {
-	p.ledgerWrapper.RLock()
-	defer p.ledgerWrapper.RUnlock()
+	p.ledgerWrapper.Lock()
+	defer p.ledgerWrapper.Unlock()
 	return p.ledgerWrapper.ledger.CommitStateDelta(id)
 }
 
 // RollbackStateDelta undoes the results of ApplyStateDelta to revert
 // the current state back to the state before ApplyStateDelta was invoked
 func (p *PeerImpl) RollbackStateDelta(id interface{}) error {
-	p.ledgerWrapper.RLock()
-	defer p.ledgerWrapper.RUnlock()
+	p.ledgerWrapper.Lock()
+	defer p.ledgerWrapper.Unlock()
 	return p.ledgerWrapper.ledger.RollbackStateDelta(id)
 }
 
 // EmptyState completely empties the state and prepares it to restore a snapshot
 func (p *PeerImpl) EmptyState() error {
-	p.ledgerWrapper.RLock()
-	defer p.ledgerWrapper.RUnlock()
+	p.ledgerWrapper.Lock()
+	defer p.ledgerWrapper.Unlock()
 	return p.ledgerWrapper.ledger.DeleteALLStateKeysAndValues()
 }
 
@@ -699,8 +700,8 @@ func (p *PeerImpl) GetStateDelta(blockNumber uint64) (*statemgmt.StateDelta, err
 
 // PutBlock inserts a raw block into the blockchain at the specified index, nearly no error checking is performed
 func (p *PeerImpl) PutBlock(blockNumber uint64, block *pb.Block) error {
-	p.ledgerWrapper.RLock()
-	defer p.ledgerWrapper.RUnlock()
+	p.ledgerWrapper.Lock()
+	defer p.ledgerWrapper.Unlock()
 	return p.ledgerWrapper.ledger.PutRawBlock(block, blockNumber)
 }
 

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -70,6 +70,23 @@ type RemoteLedger interface {
 // BlockChainAccessor interface for retreiving blocks by block number
 type BlockChainAccessor interface {
 	GetBlockByNumber(blockNumber uint64) (*pb.Block, error)
+	GetBlockchainSize() uint64
+	GetCurrentStateHash() (stateHash []byte, err error)
+}
+
+// BlockchainModifier interface for applying changes to the block chain
+type BlockChainModifier interface {
+	ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error
+	RollbackStateDelta(id interface{}) error
+	CommitStateDelta(id interface{}) error
+	EmptyState() error
+	PutBlock(blockNumber uint64, block *pb.Block) error
+}
+
+// BlockchainUtil interface for interrogating the block chain
+type BlockChainUtil interface {
+	HashBlock(block *pb.Block) ([]byte, error)
+	VerifyBlockchain(start, finish uint64) (uint64, error)
 }
 
 // StateAccessor interface for retreiving blocks by block number
@@ -92,6 +109,8 @@ type MessageHandlerCoordinator interface {
 	Peer
 	SecurityAccessor
 	BlockChainAccessor
+	BlockChainModifier
+	BlockChainUtil
 	StateAccessor
 	RegisterHandler(messageHandler MessageHandler) error
 	DeregisterHandler(messageHandler MessageHandler) error
@@ -291,7 +310,6 @@ func (p *PeerImpl) ProcessTransaction(ctx context.Context, tx *pb.Transaction) (
 	return p.ExecuteTransaction(tx), err
 }
 
-
 // GetPeers returns the currently registered PeerEndpoints
 func (p *PeerImpl) GetPeers() (*pb.PeersMessage, error) {
 	p.handlerMap.Lock()
@@ -408,7 +426,7 @@ func (p *PeerImpl) cloneHandlerMap(typ pb.PeerEndpoint_Type) map[pb.PeerID]Messa
 // Broadcast will broadcast to all registered PeerEndpoints if the type is PeerEndpoint_UNDEFINED
 func (p *PeerImpl) Broadcast(msg *pb.Message, typ pb.PeerEndpoint_Type) []error {
 	cloneMap := p.cloneHandlerMap(typ)
-	errorsFromHandlers := make(chan error,len(cloneMap))
+	errorsFromHandlers := make(chan error, len(cloneMap))
 	var bcWG sync.WaitGroup
 
 	start := time.Now()
@@ -424,7 +442,7 @@ func (p *PeerImpl) Broadcast(msg *pb.Message, typ pb.PeerEndpoint_Type) []error 
 				toPeerEndpoint, _ := msgHandler.To()
 				errorsFromHandlers <- fmt.Errorf("Error broadcasting msg (%s) to PeerEndpoint (%s): %s", msg.Type, toPeerEndpoint, err)
 			}
-			peerLogger.Debug("Sending %d bytes to %s took %v",len(msg.Payload),host.Address,time.Since(t1));
+			peerLogger.Debug("Sending %d bytes to %s took %v", len(msg.Payload), host.Address, time.Since(t1))
 
 		}(msgHandler)
 
@@ -433,11 +451,11 @@ func (p *PeerImpl) Broadcast(msg *pb.Message, typ pb.PeerEndpoint_Type) []error 
 	close(errorsFromHandlers)
 	var returnedErrors []error
 	for err := range errorsFromHandlers {
-		returnedErrors = append(returnedErrors,err)
+		returnedErrors = append(returnedErrors, err)
 	}
 
 	elapsed := time.Since(start)
-	peerLogger.Debug("Broadcast took %v",elapsed)
+	peerLogger.Debug("Broadcast took %v", elapsed)
 
 	return returnedErrors
 }
@@ -604,6 +622,66 @@ func (p *PeerImpl) GetBlockByNumber(blockNumber uint64) (*pb.Block, error) {
 	return p.ledgerWrapper.ledger.GetBlockByNumber(blockNumber)
 }
 
+// GetBlockchainSize returns the height/length of the blockchain
+func (p *PeerImpl) GetBlockchainSize() uint64 {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.GetBlockchainSize()
+}
+
+// GetCurrentStateHash returns the current non-committed hash of the in memory state
+func (p *PeerImpl) GetCurrentStateHash() (stateHash []byte, err error) {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.GetTempStateHash()
+}
+
+// HashBlock returns the hash of the included block, useful for mocking
+func (p *PeerImpl) HashBlock(block *pb.Block) ([]byte, error) {
+	return block.GetHash()
+}
+
+// VerifyBlockchain checks the integrity of the blockchain between indices start and finish,
+// returning the first block who's PreviousBlockHash field does not match the hash of the previous block
+func (p *PeerImpl) VerifyBlockchain(start, finish uint64) (uint64, error) {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.VerifyChain(start, finish)
+}
+
+// ApplyStateDelta applies a state delta to the current state
+// The result of this function can be retrieved using GetCurrentStateDelta
+// To commit the result, call CommitStateDelta, or to roll it back
+// call RollbackStateDelta
+func (p *PeerImpl) ApplyStateDelta(id interface{}, delta *statemgmt.StateDelta) error {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.ApplyStateDelta(id, delta)
+}
+
+// CommitStateDelta makes the result of ApplyStateDelta permanent
+// and releases the resources necessary to rollback the delta
+func (p *PeerImpl) CommitStateDelta(id interface{}) error {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.CommitStateDelta(id)
+}
+
+// RollbackStateDelta undoes the results of ApplyStateDelta to revert
+// the current state back to the state before ApplyStateDelta was invoked
+func (p *PeerImpl) RollbackStateDelta(id interface{}) error {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.RollbackStateDelta(id)
+}
+
+// EmptyState completely empties the state and prepares it to restore a snapshot
+func (p *PeerImpl) EmptyState() error {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.DeleteALLStateKeysAndValues()
+}
+
 // GetStateSnapshot return the state snapshot
 func (p *PeerImpl) GetStateSnapshot() (*state.StateSnapshot, error) {
 	p.ledgerWrapper.RLock()
@@ -616,6 +694,13 @@ func (p *PeerImpl) GetStateDelta(blockNumber uint64) (*statemgmt.StateDelta, err
 	p.ledgerWrapper.RLock()
 	defer p.ledgerWrapper.RUnlock()
 	return p.ledgerWrapper.ledger.GetStateDelta(blockNumber)
+}
+
+// PutBlock inserts a raw block into the blockchain at the specified index, nearly no error checking is performed
+func (p *PeerImpl) PutBlock(blockNumber uint64, block *pb.Block) error {
+	p.ledgerWrapper.RLock()
+	defer p.ledgerWrapper.RUnlock()
+	return p.ledgerWrapper.ledger.PutRawBlock(block, blockNumber)
 }
 
 // NewOpenchainDiscoveryHello constructs a new HelloMessage for sending
@@ -643,7 +728,7 @@ func (p *PeerImpl) GetSecHelper() crypto.Peer {
 }
 
 // signMessage modifies the passed in Message by setting the Signature based upon the Payload.
-func (p *PeerImpl) signMessageMutating(msg *pb.Message) (error) {
+func (p *PeerImpl) signMessageMutating(msg *pb.Message) error {
 	if SecurityEnabled() {
 		sig, err := p.secHelper.Sign(msg.Payload)
 		if err != nil {


### PR DESCRIPTION
This is the first of several PRs decoupling statetransfer from consensus.
## Description

State transfer needs to be moved from `consensus/statetransfer` to `core/peer/statetransfer`.  This first changeset decouples statetransfer from `consensus/helper/helper.go` and instead uses the interfaces provided in `peer/peer.go`.
## Motivation and Context

State transfer was originally developed as part of PBFT, as it became more complex, it was realized the code could be more generally useful, and was pulled out of pbft and into consensus.  As more applications of state transfer became apparent, such as performing state transfer to a non-validating peer which does not participate in consensus, it became apparent that state transfer should be moved from `consensus` and into `peer`.

Because statetransfer is no longer a part of consensus, the related APIs have been removed from the `consensus.Stack` interface, simplifying the consensus plugin API surface noticeably.

Although it does not fix, it contributes to #645 
## How Has This Been Tested?

Since this PR adds no new feature and exercises the same underlying APIs (though accesses them slightly differently) the existing unit and behave tests are sufficient to verify its correctness.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] I have run [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
- [X] If applicable, I have updated the documentation accordingly.
- [X] If applicable, I have added tests to cover my changes.

@corecode @tuand27613 @kchristidis Review is welcome, though consensus expertise is not needed.

@jeffgarratt Since the bulk of the code additions are into `peer.go` I'd love your vote approval.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
