### PR TITLE
Added REST address and TLS status to log message when REST server starts

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -1699,7 +1699,7 @@ func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
 // middleware and routes.
 func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
 	// Initialize the REST service object
-	restLogger.Info("Initializing the REST service...")
+	restLogger.Info("Initializing the REST service on %s, TLS is %s.", viper.GetString("rest.address"), (map[bool]string{true: "enabled", false: "disabled"})[peer.TlsEnabled()])
 	router := web.New(ServerOpenchainREST{})
 
 	// Record the pointer to the underlying ServerOpenchain and Devops objects.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

I added the REST address and TLS status to the log message printed when the REST server starts
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

I found it helpful to have this information confirmed in the logs. 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

I have run the modified code and observed that the message is printed correctly.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ x] Either no new documentation is required by this change, OR I added new doc
- [ x] Either no new tests are required by this change, OR I added new tests
- [ x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: bcbrock@us.ibm.com
