### PR TITLE
Update travis docker port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,12 @@ script:
 
  - echo "Executing Behave test scripts"
  - cd $HOME/gopath/src/github.com/hyperledger/fabric
- - sed -i -e 's/172.17.0.1:4243\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
+ - sed -i -e 's/172.17.0.1:2375\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
  - make behave BEHAVE_OPTS="-D logs=Y -o testsummary.log"
  - make linter
 
 after_failure:
- 
+
  - |
    echo "Click below links to view behave container log files"
    cd $HOME/gopath/src/github.com/hyperledger/fabric


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Update the docker behave port in .travis.yml to match the new default from https://github.com/hyperledger/fabric/pull/1422
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Try to get Travis behave tests passing. They are currently failing, but passing locally.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Will be tested by the travis automated build
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: sheehan@us.ibm.com
