### PR TITLE
Fix 1430

### DIFF
--- a/consensus/helper/engine.go
+++ b/consensus/helper/engine.go
@@ -29,16 +29,19 @@ import (
 	"sync"
 )
 
+// EngineImpl implements a struct to hold consensus.Consenter, PeerEndpoint and MessageFan
 type EngineImpl struct {
 	consenter    consensus.Consenter
 	peerEndpoint *pb.PeerEndpoint
 	consensusFan *util.MessageFan
 }
 
+// GetHandlerFactory returns new NewConsensusHandler
 func (eng *EngineImpl) GetHandlerFactory() peer.HandlerFactory {
 	return NewConsensusHandler
 }
 
+// ProcessTransactionMsg processes a Message in context of a Transaction
 func (eng *EngineImpl) ProcessTransactionMsg(msg *pb.Message, tx *pb.Transaction) (response *pb.Response) {
 	//TODO: Do we always verify security, or can we supply a flag on the invoke ot this functions so to bypass check for locally generated transactions?
 	if tx.Type == pb.Transaction_CHAINCODE_QUERY {
@@ -95,6 +98,7 @@ func getEngineImpl() *EngineImpl {
 	return engine
 }
 
+// GetEngine returns initialized peer.Engine
 func GetEngine(coord peer.MessageHandlerCoordinator) (peer.Engine, error) {
 	var err error
 	engineOnce.Do(func() {

--- a/consensus/helper/handler.go
+++ b/consensus/helper/handler.go
@@ -38,6 +38,7 @@ func init() {
 }
 
 const (
+	// DefaultConsensusQueueSize value of 1000
 	DefaultConsensusQueueSize int = 1000
 )
 

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -393,6 +393,7 @@ func (h *Helper) GetRemoteStateDeltas(replicaID *pb.PeerID, start, finish uint64
 	})
 }
 
+// GetBlockchainInfoBlob marshals a ledger's BlockchainInfo into a protobuf
 func (h *Helper) GetBlockchainInfoBlob() []byte {
 	ledger, _ := ledger.GetLedger()
 	info, _ := ledger.GetBlockchainInfo()
@@ -400,6 +401,7 @@ func (h *Helper) GetBlockchainInfoBlob() []byte {
 	return rawInfo
 }
 
+// GetBlockHeadMetadata returns metadata from block at the head of the blockchain
 func (h *Helper) GetBlockHeadMetadata() ([]byte, error) {
 	ledger, err := ledger.GetLedger()
 	if err != nil {
@@ -413,19 +415,23 @@ func (h *Helper) GetBlockHeadMetadata() ([]byte, error) {
 	return block.ConsensusMetadata, nil
 }
 
+// SkipTo skips ahead to the block identified by tag (blockNumber)
 func (h *Helper) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
 	info := &pb.BlockchainInfo{}
 	proto.Unmarshal(id, info)
 	h.sts.AddTarget(info.Height-1, info.CurrentBlockHash, peers, tag)
 }
 
+// Initiated does nothing ATM
 func (h *Helper) Initiated() {
 }
 
+// Completed updates state on Consenter
 func (h *Helper) Completed(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}) {
 	h.consenter.StateUpdate(m.(uint64), bh)
 }
 
+// Errored logs a warning
 func (h *Helper) Errored(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}, e error) {
 	if seqNo, ok := m.(uint64); !ok {
 		logger.Warning("state transfer reported error for block %d, seqNo %d: %s", bn, seqNo, e)


### PR DESCRIPTION
clean golint warnings in consensus/helper
## Description

Cleaned up:
engine.go:32:6: exported type EngineImpl should have comment or be unexported
engine.go:38:1: exported method EngineImpl.GetHandlerFactory should have comment or be unexported
engine.go:42:1: exported method EngineImpl.ProcessTransactionMsg should have comment or be unexported
engine.go:98:1: exported function GetEngine should have comment or be unexported
handler.go:41:2: exported const DefaultConsensusQueueSize should have comment (or a comment on this block) or be unexported
helper.go:396:1: exported method Helper.GetBlockchainInfoBlob should have comment or be unexported
helper.go:403:1: exported method Helper.GetBlockHeadMetadata should have comment or be unexported
helper.go:416:1: exported method Helper.SkipTo should have comment or be unexported
helper.go:422:1: exported method Helper.Initiated should have comment or be unexported
helper.go:425:1: exported method Helper.Completed should have comment or be unexported
helper.go:429:1: exported method Helper.Errored should have comment or be unexported
## Motivation and Context

Fixes #1430
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Christopher Ferris chrisfer@us.ibm.com
