### PR TITLE
marshal chaincode return message as payload to calling chaincode

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -327,7 +327,7 @@ func (chaincodeSupport *ChaincodeSupport) launchAndWaitForRegister(ctxt context.
 	return alreadyRunning, err
 }
 
-//StopChaincode stops a chaincode if running
+//Stop stops a chaincode if running
 func (chaincodeSupport *ChaincodeSupport) Stop(context context.Context, cds *pb.ChaincodeDeploymentSpec) error {
 	chaincode := cds.ChaincodeSpec.ChaincodeID.Name
 	if chaincode == "" {
@@ -359,7 +359,7 @@ func (chaincodeSupport *ChaincodeSupport) Stop(context context.Context, cds *pb.
 	return err
 }
 
-// LaunchChaincode will launch the chaincode if not running (if running return nil) and will wait for handler of the chaincode to get into FSM ready state.
+// Launch will launch the chaincode if not running (if running return nil) and will wait for handler of the chaincode to get into FSM ready state.
 func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.Transaction) (*pb.ChaincodeID, *pb.ChaincodeInput, error) {
 	//build the chaincode
 	var cID *pb.ChaincodeID
@@ -497,7 +497,7 @@ func (chaincodeSupport *ChaincodeSupport) getVMType(cds *pb.ChaincodeDeploymentS
 	return container.DOCKER, nil
 }
 
-// DeployChaincode deploys the chaincode if not in development mode where user is running the chaincode.
+// Deploy deploys the chaincode if not in development mode where user is running the chaincode.
 func (chaincodeSupport *ChaincodeSupport) Deploy(context context.Context, t *pb.Transaction) (*pb.ChaincodeDeploymentSpec, error) {
 	//build the chaincode
 	cds := &pb.ChaincodeDeploymentSpec{}
@@ -595,9 +595,8 @@ func (chaincodeSupport *ChaincodeSupport) Execute(ctxt context.Context, chaincod
 	var ccresp *pb.ChaincodeMessage
 	select {
 	case ccresp = <-notfy:
-		if ccresp.Type == pb.ChaincodeMessage_ERROR || ccresp.Type == pb.ChaincodeMessage_QUERY_ERROR {
-			err = fmt.Errorf(string(ccresp.Payload))
-		}
+		//response is sent to user or calling chaincode. ChaincodeMessage_ERROR and ChaincodeMessage_QUERY_ERROR
+		//are typically treated as error
 	case <-time.After(timeout):
 		err = fmt.Errorf("Timeout expired while executing transaction")
 	}

--- a/core/chaincode/exectransaction.go
+++ b/core/chaincode/exectransaction.go
@@ -128,8 +128,8 @@ func Execute(ctxt context.Context, chain *ChaincodeSupport, t *pb.Transaction) (
 
 //ExecuteTransactions - will execute transactions on the array one by one
 //will return an array of errors one for each transaction. If the execution
-//succeeded, array element will be nil. returns []byte of state hash or 
-//error 
+//succeeded, array element will be nil. returns []byte of state hash or
+//error
 func ExecuteTransactions(ctxt context.Context, cname ChainName, xacts []*pb.Transaction) (stateHash []byte, txerrs []error, err error) {
 	var chain = GetChain(cname)
 	if chain == nil {

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -694,6 +695,116 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	closeListenerAndSleep(lis)
 }
 
+// Test the execution of a chaincode that invokes another chaincode with wrong parameters. Should receive error from
+// from the called chaincode
+func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			grpclog.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:40303"
+
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		t.Fail()
+		t.Logf("Error starting peer listener %s", err)
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
+
+	go grpcServer.Serve(lis)
+
+	var ctxt = context.Background()
+
+	// Deploy first chaincode
+	url1 := "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
+
+	cID1 := &pb.ChaincodeID{Path: url1}
+	f := "init"
+	args := []string{"a", "100", "b", "200"}
+
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+
+	_, err = deploy(ctxt, spec1)
+	chaincodeID1 := spec1.ChaincodeID.Name
+	if err != nil {
+		t.Fail()
+		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	time.Sleep(time.Second)
+
+	// Deploy second chaincode
+	url2 := "github.com/hyperledger/fabric/examples/chaincode/go/passthru"
+
+	cID2 := &pb.ChaincodeID{Path: url2}
+	f = "init"
+	args = []string{""}
+
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+
+	_, err = deploy(ctxt, spec2)
+	chaincodeID2 := spec2.ChaincodeID.Name
+	if err != nil {
+		t.Fail()
+		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	time.Sleep(time.Second)
+
+	// Invoke second chaincode, which will inturn invoke the first chaincode but pass bad params
+	f = chaincodeID1
+	args = []string{"invoke", "a"} //expect {"invoke", "a","b","10"}
+
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	// Invoke chaincode
+	_, _, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_INVOKE)
+
+	if err == nil {
+		t.Fail()
+		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	if strings.Index(err.Error(), "Incorrect number of arguments. Expecting 3") < 0 {
+		t.Fail()
+		t.Logf("Unexpected error %s", err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	closeListenerAndSleep(lis)
+}
+
 // Test the execution of a chaincode query that queries another chaincode.
 func TestChaincodeQueryChaincode(t *testing.T) {
 	var opts []grpc.ServerOption
@@ -825,6 +936,116 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil || result != 300 {
 		t.Fail()
 		t.Logf("Incorrect final value after query for <%s>: %s", chaincodeID1, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	closeListenerAndSleep(lis)
+}
+
+// Test the execution of a chaincode that queries another chaincode with invalid parameter. Should receive error from
+// from the called chaincode
+func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			grpclog.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:40303"
+
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		t.Fail()
+		t.Logf("Error starting peer listener %s", err)
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
+
+	go grpcServer.Serve(lis)
+
+	var ctxt = context.Background()
+
+	// Deploy first chaincode
+	url1 := "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
+
+	cID1 := &pb.ChaincodeID{Path: url1}
+	f := "init"
+	args := []string{"a", "100", "b", "200"}
+
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+
+	_, err = deploy(ctxt, spec1)
+	chaincodeID1 := spec1.ChaincodeID.Name
+	if err != nil {
+		t.Fail()
+		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	time.Sleep(time.Second)
+
+	// Deploy second chaincode
+	url2 := "github.com/hyperledger/fabric/examples/chaincode/go/passthru"
+
+	cID2 := &pb.ChaincodeID{Path: url2}
+	f = "init"
+	args = []string{""}
+
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+
+	_, err = deploy(ctxt, spec2)
+	chaincodeID2 := spec2.ChaincodeID.Name
+	if err != nil {
+		t.Fail()
+		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	time.Sleep(time.Second)
+
+	// Invoke second chaincode, which will inturn invoke the first chaincode but pass bad params
+	f = chaincodeID1
+	args = []string{"query", "c"} //expect {"query", "a"}
+
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	// Invoke chaincode
+	_, _, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_QUERY)
+
+	if err == nil {
+		t.Fail()
+		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	if strings.Index(err.Error(), "Nil amount for c") < 0 {
+		t.Fail()
+		t.Logf("Unexpected error %s", err)
 		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
 		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
 		closeListenerAndSleep(lis)

--- a/examples/chaincode/go/passthru/passthru.go
+++ b/examples/chaincode/go/passthru/passthru.go
@@ -1,0 +1,77 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+// PassthruChaincode passes thru invoke and query to another chaincode where
+//     called ChaincodeID = function
+//     called chaincode's function = args[0]
+//     called chaincode's args = args[1:]
+type PassthruChaincode struct {
+}
+
+//Init func will return error if function has string "error" anywhere
+func (p *PassthruChaincode) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+
+	if strings.Index(function, "error") >= 0 {
+		return nil, errors.New(function)
+	}
+	return []byte(function), nil
+}
+
+//helper
+func (p *PassthruChaincode) iq(invoke bool, stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	if function == "" {
+		return nil, errors.New("Chaincode ID not provided")
+	}
+	chaincodeID := function
+
+	var f string
+	var cargs []string
+	if len(args) > 0 {
+		f = args[0]
+		cargs = args[1:]
+	}
+
+	if invoke {
+		return stub.InvokeChaincode(chaincodeID, f, cargs)
+	} else {
+		return stub.QueryChaincode(chaincodeID, f, cargs)
+	}
+}
+
+func (p *PassthruChaincode) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	return p.iq(true, stub, function, args)
+}
+
+func (p *PassthruChaincode) Query(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	return p.iq(false, stub, function, args)
+}
+
+func main() {
+	err := shim.Start(new(PassthruChaincode))
+	if err != nil {
+		fmt.Printf("Error starting Passthru chaincode: %s", err)
+	}
+}


### PR DESCRIPTION
Chaincode calling chaincode treated all errors - fabric as well as error returned from called chaincode - as errors. This caused calling chaincode to error out. 
## Description

chaincode_support.go - Chaincode's execute method returns response and error. It used to introspect response and if a chaincode error,  set the returned error as well. This is unnecessary as the fabric treats chaincode errors correctly anyway. By not setting the error in the first place the way is paved for chaincode-calling-chaincode path. 

With Execute not returning error for everything, rest of the fix can rely upon nil error to marshalls the response from the called chaincode in the peer and unmarshalls it in the calling shim. The response is then checked for error in calling chaincode.
## Motivation and Context

Conflating fabric errors with chaincode errors causes these to be indistiguishable in the called chaincode. Called chaincode treats all errors as Fabric errors and exit with error.  The fix disambiguates the two cases and the shim correctly  looks for fabric errors, chaincode errors and chaincode success responses.

Fixes #1425
## How Has This Been Tested?

Tested with testcase supplied in #1425 
Added unit tests
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
