### PR TITLE
Fix statetransfer failure on back to back execution

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -23,8 +23,9 @@ import (
 // Consenter is used to receive messages from the network
 // Every consensus plugin needs to implement this interface
 type Consenter interface {
-	RecvMsg(msg *pb.Message, senderHandle *pb.PeerID) error
-	StateUpdate(tag uint64, id []byte)
+	RecvMsg(msg *pb.Message, senderHandle *pb.PeerID) error // Called serially with incoming messages from gRPC
+	StateUpdated(tag uint64, id []byte)                     // Called when state transfer completes, serial with StateUpdating
+	StateUpdating(tag uint64, id []byte)                    // Called when SkipTo causes state transfer to start serial with StateUpdated
 }
 
 // Inquirer is used to retrieve info about the validating network

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -54,7 +54,6 @@ func NewHelper(mhc peer.MessageHandlerCoordinator) *Helper {
 		secHelper:   mhc.GetSecHelper(),
 	}
 	h.sts = statetransfer.NewStateTransferState(mhc)
-	h.sts.Initiate(nil)
 	h.sts.RegisterListener(h)
 	return h
 }
@@ -311,7 +310,7 @@ func (h *Helper) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
 }
 
 // Initiated is called when state transfer is kicked off, this occurs if SkipTo is invoked while statetransfer is not currently running
-func (h *Helper) Initiated() {
+func (h *Helper) Initiated(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}) {
 	h.consenter.StateUpdating(m.(uint64), bh)
 }
 

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -303,23 +303,24 @@ func (h *Helper) GetBlockHeadMetadata() ([]byte, error) {
 	return block.ConsensusMetadata, nil
 }
 
-// SkipTo skips ahead to the block identified by tag (blockNumber)
+// SkipTo is invoked to tell state transfer of a possible sync target, if state transfer is not already executing, it is initiated
 func (h *Helper) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
 	info := &pb.BlockchainInfo{}
 	proto.Unmarshal(id, info)
 	h.sts.AddTarget(info.Height-1, info.CurrentBlockHash, peers, tag)
 }
 
-// Initiated does nothing ATM
+// Initiated is called when state transfer is kicked off, this occurs if SkipTo is invoked while statetransfer is not currently running
 func (h *Helper) Initiated() {
+	h.consenter.StateUpdating(m.(uint64), bh)
 }
 
-// Completed updates state on Consenter
+// Completed is called when state transfer finishes moving the state to some point added via SkipTo
 func (h *Helper) Completed(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}) {
-	h.consenter.StateUpdate(m.(uint64), bh)
+	h.consenter.StateUpdated(m.(uint64), bh)
 }
 
-// Errored logs a warning
+// Errored is called when state transfer encounters an error, this is not necessarily fatal
 func (h *Helper) Errored(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}, e error) {
 	if seqNo, ok := m.(uint64); !ok {
 		logger.Warning("state transfer reported error for block %d, seqNo %d: %s", bn, seqNo, e)

--- a/consensus/noops/noops.go
+++ b/consensus/noops/noops.go
@@ -112,9 +112,14 @@ func (i *Noops) RecvMsg(msg *pb.Message, senderHandle *pb.PeerID) error {
 	return nil
 }
 
-// StateUpdate does nothing
-func (i *Noops) StateUpdate(seqNo uint64, id []byte) {
-	// ignored
+// StateUpdating is called once state transfer is initiated, currently unused
+func (i *Noops) StateUpdating(seqNo uint64, id []byte) {
+	// ignored as it is never initiated
+}
+
+// StateUpdated is called once state transfer finishes, currently unused
+func (i *Noops) StateUpdated(seqNo uint64, id []byte) {
+	// ignored as it is never initiated
 }
 
 func (i *Noops) broadcastConsensusMsg(msg *pb.Message) error {

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -38,8 +38,9 @@ func (ce *consumerEndpoint) stop() {
 }
 
 func (ce *consumerEndpoint) isBusy() bool {
-	if ce.consumer.getPBFTCore().timerActive || ce.consumer.getPBFTCore().currentExec != nil {
-		ce.net.debugMsg("Reporting busy because of timer or currentExec\n")
+	pbft := ce.consumer.getPBFTCore()
+	if pbft.timerActive || pbft.skipInProgress || pbft.currentExec != nil {
+		ce.net.debugMsg("Reporting busy because of timer or skipInProgress or currentExec\n")
 		return true
 	}
 
@@ -70,17 +71,28 @@ type completeStack struct {
 	*noopSecurity
 	*MockLedger
 	mockPersist
+	skipTarget chan struct{}
 }
 
+const MaxStateTransferTime int = 200
+
 func (cs *completeStack) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
-	go func() {
-		// State transfer takes time, not simulating this hides bugs
-		time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
-		meta := &Metadata{tag}
-		metaRaw, _ := proto.Marshal(meta)
-		cs.simulateStateTransfer(metaRaw, id, peers)
-		cs.consumer.StateUpdate(tag, id)
-	}()
+	select {
+	// This guarantees the first SkipTo call is the one that's queued, whereas a mutex can be raced for
+	case cs.skipTarget <- struct{}{}:
+		go func() {
+			cs.consumer.StateUpdating(tag, id)
+			// State transfer takes time, not simulating this hides bugs
+			time.Sleep(time.Duration((MaxStateTransferTime/2)+rand.Intn(MaxStateTransferTime/2)) * time.Millisecond)
+			meta := &Metadata{tag}
+			metaRaw, _ := proto.Marshal(meta)
+			cs.simulateStateTransfer(metaRaw, id, peers)
+			cs.consumer.StateUpdated(tag, id)
+			<-cs.skipTarget // Basically like releasing a mutex
+		}()
+	default:
+		cs.net.debugMsg("Ignoring skipTo because one is already in progress\n")
+	}
 }
 
 type pbftConsumer interface {
@@ -120,6 +132,7 @@ func makeConsumerNetwork(N int, makeConsumer func(id uint64, config *viper.Viper
 			consumerEndpoint: ce,
 			noopSecurity:     &noopSecurity{},
 			MockLedger:       ml,
+			skipTarget:       make(chan struct{}, 1),
 		}
 
 		ce.consumer = makeConsumer(id, loadConfig(), cs)

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package obcpbft
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/hyperledger/fabric/consensus"
 	pb "github.com/hyperledger/fabric/protos"
 
@@ -71,6 +74,8 @@ type completeStack struct {
 
 func (cs *completeStack) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
 	go func() {
+		// State transfer takes time, not simulating this hides bugs
+		time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
 		meta := &Metadata{tag}
 		metaRaw, _ := proto.Marshal(meta)
 		cs.simulateStateTransfer(metaRaw, id, peers)

--- a/consensus/obcpbft/mock_ledger_test.go
+++ b/consensus/obcpbft/mock_ledger_test.go
@@ -278,7 +278,7 @@ func (mock *MockLedger) simulateStateTransfer(meta []byte, id []byte, peers []*p
 	fmt.Printf("TEST LEDGER skipping to %+v, %+v", meta, info)
 	p := 0
 	if mock.blockHeight >= info.Height {
-		panic("Asked to skip to a block lower than our current height")
+		panic(fmt.Sprintf("Asked to skip to a block (%d) which is lower than our current height of %d", info.Height, mock.blockHeight))
 	}
 	for n := mock.blockHeight; n < info.Height; n++ {
 		block, err := remoteLedger.GetBlock(n)

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -30,8 +30,6 @@ import (
 
 type obcBatch struct {
 	obcGeneric
-	stack consensus.Stack
-	pbft  *pbftCore
 
 	batchSize        int
 	batchStore       []*Request
@@ -64,8 +62,7 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	var err error
 
 	op := &obcBatch{
-		obcGeneric: obcGeneric{stack},
-		stack:      stack,
+		obcGeneric: obcGeneric{stack: stack},
 	}
 
 	op.persistForward.persistor = stack
@@ -109,12 +106,7 @@ func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
 	return nil
 }
 
-// StateUpdate is a signal from the stack that it has fast-forwarded its state
-func (op *obcBatch) StateUpdate(seqNo uint64, id []byte) {
-	op.pbft.stateUpdate(seqNo, id)
-}
-
-// implements complaintHandler
+// Complain is necessary to implement complaintHandler
 func (op *obcBatch) Complain(hash string, req *Request, primaryFail bool) {
 	op.custodyTimerChan <- custodyInfo{hash, req, primaryFail}
 }

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -28,8 +28,6 @@ import (
 
 type obcClassic struct {
 	obcGeneric
-	stack consensus.Stack
-	pbft  *pbftCore
 
 	persistForward
 
@@ -38,8 +36,7 @@ type obcClassic struct {
 
 func newObcClassic(id uint64, config *viper.Viper, stack consensus.Stack) *obcClassic {
 	op := &obcClassic{
-		obcGeneric: obcGeneric{stack},
-		stack:      stack,
+		obcGeneric: obcGeneric{stack: stack},
 	}
 
 	op.persistForward.persistor = stack
@@ -82,11 +79,6 @@ func (op *obcClassic) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error 
 	op.pbft.receive(ocMsg.Payload, senderID)
 
 	return nil
-}
-
-// StateUpdate is a signal from the stack that it has fast-forwarded its state
-func (op *obcClassic) StateUpdate(seqNo uint64, id []byte) {
-	op.pbft.stateUpdate(seqNo, id)
 }
 
 // Close tells us to release resources we are holding

--- a/consensus/obcpbft/obc-pbft.go
+++ b/consensus/obcpbft/obc-pbft.go
@@ -18,10 +18,10 @@ package obcpbft
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/hyperledger/fabric/consensus"
 	pb "github.com/hyperledger/fabric/protos"
@@ -81,8 +81,8 @@ func loadConfig() (config *viper.Viper) {
 	// Path to look for the config file in based on GOPATH
 	gopath := os.Getenv("GOPATH")
 	for _, p := range filepath.SplitList(gopath) {
-	    obcpbftpath := filepath.Join(p, "src/github.com/hyperledger/fabric/consensus/obcpbft")
-	    config.AddConfigPath(obcpbftpath)
+		obcpbftpath := filepath.Join(p, "src/github.com/hyperledger/fabric/consensus/obcpbft")
+		config.AddConfigPath(obcpbftpath)
 	}
 
 	err := config.ReadInConfig()
@@ -127,6 +127,7 @@ func getValidatorHandles(ids []uint64) (handles []*pb.PeerID) {
 
 type obcGeneric struct {
 	stack consensus.Stack
+	pbft  *pbftCore
 }
 
 func (op *obcGeneric) skipTo(seqNo uint64, id []byte, replicas []uint64) {
@@ -145,4 +146,14 @@ func (op *obcGeneric) getLastSeqNo() (uint64, error) {
 	meta := &Metadata{}
 	proto.Unmarshal(raw, meta)
 	return meta.SeqNo, nil
+}
+
+// StateUpdated is a signal from the stack that it has fast-forwarded its state
+func (op *obcGeneric) StateUpdated(seqNo uint64, id []byte) {
+	op.pbft.stateUpdated(seqNo, id)
+}
+
+// StateUpdating is a signal from the stack that state transfer has started
+func (op *obcGeneric) StateUpdating(seqNo uint64, id []byte) {
+	op.pbft.stateUpdating(seqNo, id)
 }

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -82,12 +82,13 @@ type checkpointMessage struct {
 
 type pbftCore struct {
 	// internal data
-	internalLock     sync.Mutex
-	executing        bool                    // signals that application is executing
-	closed           chan struct{}           // informs the main thread to exit (never written to, only closed)
-	incomingChan     chan *pbftMessage       // informs the main thread of new messages
-	stateUpdateChan  chan *checkpointMessage // informs the main thread the state has updated (via state transfer)
-	execCompleteChan chan struct{}           // informs the main thread an execution has finished
+	internalLock      sync.Mutex
+	executing         bool                    // signals that application is executing
+	closed            chan struct{}           // informs the main thread to exit (never written to, only closed)
+	incomingChan      chan *pbftMessage       // informs the main thread of new messages
+	stateUpdatedChan  chan *checkpointMessage // informs the main thread the state has updated (via state transfer)
+	stateUpdatingChan chan *checkpointMessage // informs the main thread the state update has started (via state transfer)
+	execCompleteChan  chan struct{}           // informs the main thread an execution has finished
 
 	idleChan   chan struct{} // Used to detect idleness for testing
 	injectChan chan func()   // Used as a hack to inject work onto the PBFT thread, to be removed eventually
@@ -185,7 +186,8 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack) *pbftCore 
 	instance.consumer = consumer
 	instance.closed = make(chan struct{})
 	instance.incomingChan = make(chan *pbftMessage)
-	instance.stateUpdateChan = make(chan *checkpointMessage)
+	instance.stateUpdatedChan = make(chan *checkpointMessage)
+	instance.stateUpdatingChan = make(chan *checkpointMessage)
 	instance.execCompleteChan = make(chan struct{})
 	instance.idleChan = make(chan struct{})
 	instance.injectChan = make(chan func())
@@ -281,12 +283,16 @@ func (instance *pbftCore) main() {
 		case msg := <-instance.incomingChan:
 			logger.Debug("Replica %d received incoming message from %v", instance.id, msg.sender)
 			instance.recvMsg(msg.msg, msg.sender)
-		case update := <-instance.stateUpdateChan:
+		case update := <-instance.stateUpdatingChan:
+			instance.skipInProgress = true
+			instance.lastExec = update.seqNo
+			instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
+		case update := <-instance.stateUpdatedChan:
 			seqNo := update.seqNo
 			logger.Info("Replica %d application caught up via state transfer, lastExec now %d", instance.id, seqNo)
 			// XXX create checkpoint
 			instance.lastExec = seqNo
-			instance.moveWatermarks(instance.lastExec) // XXX should be checkpoint, not lastExec
+			instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
 			instance.skipInProgress = false
 			instance.executeOutstanding()
 		case <-instance.execCompleteChan:
@@ -460,9 +466,18 @@ func (instance *pbftCore) receive(msgPayload []byte, senderID uint64) error {
 }
 
 // stateUpdate is an event telling us that the application fast-forwarded its state
-func (instance *pbftCore) stateUpdate(seqNo uint64, id []byte) {
+func (instance *pbftCore) stateUpdated(seqNo uint64, id []byte) {
 	logger.Debug("Replica %d queueing message that it has caught up via state transfer", instance.id)
-	instance.stateUpdateChan <- &checkpointMessage{
+	instance.stateUpdatedChan <- &checkpointMessage{
+		seqNo: seqNo,
+		id:    id,
+	}
+}
+
+// stateUpdate is an event telling us that the application fast-forwarded its state
+func (instance *pbftCore) stateUpdating(seqNo uint64, id []byte) {
+	logger.Debug("Replica %d queueing message that state transfer has been initiated", instance.id)
+	instance.stateUpdatingChan <- &checkpointMessage{
 		seqNo: seqNo,
 		id:    id,
 	}
@@ -1013,8 +1028,8 @@ func (instance *pbftCore) witnessCheckpointWeakCert(chkpt *Checkpoint) {
 	if instance.skipInProgress {
 		logger.Debug("Replica %d is catching up and witnessed a weak certificate for checkpoint %d, weak cert attested to by %d of %d (%v)",
 			instance.id, chkpt.SequenceNumber, i, instance.replicaCount, checkpointMembers)
-		instance.activeView = true // TODO, verify this with experts
-		instance.consumer.skipTo(chkpt.SequenceNumber, snapshotID, checkpointMembers)
+		// The view should not be set to active, this should be handled by the yet unimplimented SUSPECT, see https://github.com/hyperledger/fabric/issues/1120
+		instance.consumer.skipTo(chkpt.SequenceNumber, snapshotID, checkpointMembers) // This will kick off state transfer if it is not already going, but if it is going, we may transfer to an earlier point
 	}
 }
 

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -1013,8 +1013,6 @@ func (instance *pbftCore) witnessCheckpointWeakCert(chkpt *Checkpoint) {
 	if instance.skipInProgress {
 		logger.Debug("Replica %d is catching up and witnessed a weak certificate for checkpoint %d, weak cert attested to by %d of %d (%v)",
 			instance.id, chkpt.SequenceNumber, i, instance.replicaCount, checkpointMembers)
-		instance.moveWatermarks(chkpt.SequenceNumber)
-		instance.lastExec = chkpt.SequenceNumber
 		instance.activeView = true // TODO, verify this with experts
 		instance.consumer.skipTo(chkpt.SequenceNumber, snapshotID, checkpointMembers)
 	}

--- a/consensus/statetransfer/statetransfer.go
+++ b/consensus/statetransfer/statetransfer.go
@@ -62,7 +62,7 @@ type Listener interface {
 	Completed(uint64, []byte, []*protos.PeerID, interface{})      // Called when the state transfer is completed
 }
 
-// This provides a simple base implementation of a state transfer listener which implementors can extend anonymously
+// ProtoListener provides a simple base implementation of a state transfer listener which implementors can extend anonymously
 // Unset fields result in no action for that event
 type ProtoListener struct {
 	InitiatedImpl func(uint64, []byte, []*protos.PeerID, interface{})
@@ -107,7 +107,7 @@ type StateTransferState struct {
 	validBlockRanges     []*blockRange // Used by the block thread to track which pieces of the blockchain have already been hashed
 	RecoverDamage        bool          // Whether state transfer should ever modify or delete existing blocks if they are determined to be corrupted
 
-	initiateStateSync chan *syncMark       // Used to ensure only one state transfer at a time occurs, write to only from the main consensus thread
+	initiateStateSync chan *blockHashReply // Used to ensure only one state transfer at a time occurs, write to only from the main consensus thread
 	blockHashReceiver chan *blockHashReply // Used to process incoming valid block hashes, write only from the state thread
 	blockSyncReq      chan *blockSyncReq   // Used to request a block sync, new requests cause the existing request to abort, write only from the state thread
 
@@ -129,7 +129,7 @@ type StateTransferState struct {
 	stateTransferListenersLock *sync.Mutex // Used to lock the above list when adding a listener
 }
 
-// Adds a target and blocks until that target's success or failure
+// BlockingAddTarget Adds a target and blocks until that target's success or failure
 // If peerIDs is nil, all peers will be considered sync candidates
 // The function returns nil on success or error
 // If state sync completes, but to a different target, this is still considered an error
@@ -154,7 +154,7 @@ func (sts *StateTransferState) BlockingAddTarget(blockNumber uint64, blockHash [
 	return <-result
 }
 
-// Adds a target and blocks until that target's success
+// BlockingUntilSuccessAddTarget adds a target and blocks until that target's success
 // If peerIDs is nil, all peers will be considered sync candidates
 // This call should only be used in scenarios where an error should result in a panic, as this could otherwise cause a deadlock
 func (sts *StateTransferState) BlockingUntilSuccessAddTarget(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID) {
@@ -174,12 +174,12 @@ func (sts *StateTransferState) BlockingUntilSuccessAddTarget(blockNumber uint64,
 	<-result
 }
 
-// Informs the asynchronous sync of a new valid block hash, as well as a list of peers which should be capable of supplying that block
+// AddTarget Informs the asynchronous sync of a new valid block hash, as well as a list of peers which should be capable of supplying that block
 // If the peerIDs are nil, then all peers are assumed to have the given block.  If state transfer has not been initiated already,
 // this will kick state transfer off
 func (sts *StateTransferState) AddTarget(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID, metadata interface{}) {
 	logger.Debug("%v informed of a new block hash for block number %d with peers %v", sts.id, blockNumber, peerIDs)
-	blockHashReply := &blockHashReply{
+	bhr := &blockHashReply{
 		syncMark: syncMark{
 			blockNumber: blockNumber,
 			peerIDs:     peerIDs,
@@ -196,12 +196,15 @@ func (sts *StateTransferState) AddTarget(blockNumber uint64, blockHash []byte, p
 		sts.asynchronousTransferInProgress = true
 		sts.stateTransferListenersLock.Unlock()
 		select {
-		case sts.initiateStateSync <- &syncMark{
-			blockNumber: 0,
-			peerIDs:     peerIDs,
+		case sts.initiateStateSync <- &blockHashReply{
+			syncMark: syncMark{
+				blockNumber: 0,
+				peerIDs:     peerIDs,
+			},
+			blockHash: blockHash,
+			metadata:  metadata,
 		}:
 			logger.Debug("%v initiating a new state transfer request", sts.id)
-			sts.informListeners(blockNumber, blockHash, peerIDs, metadata, nil, Initiated)
 		case <-sts.threadExit:
 			logger.Debug("%v state transfer has been told to exit", sts.id)
 			return
@@ -211,7 +214,7 @@ func (sts *StateTransferState) AddTarget(blockNumber uint64, blockHash []byte, p
 	for {
 		select {
 		// This channel has a buffer of one, so this loop should always exit eventually
-		case sts.blockHashReceiver <- blockHashReply:
+		case sts.blockHashReceiver <- bhr:
 			logger.Debug("%v block hash reply for block %d queued for state transfer", sts.id, blockNumber)
 			return
 
@@ -222,7 +225,7 @@ func (sts *StateTransferState) AddTarget(blockNumber uint64, blockHash []byte, p
 
 }
 
-// The registered interface implementation will be invoked whenever state transfer is initiated or completed, or encounters an error
+// RegisterListener registers a listener which will be invoked whenever state transfer is initiated or completed, or encounters an error
 func (sts *StateTransferState) RegisterListener(listener Listener) {
 	sts.stateTransferListenersLock.Lock()
 	defer func() {
@@ -232,7 +235,7 @@ func (sts *StateTransferState) RegisterListener(listener Listener) {
 	sts.stateTransferListeners = append(sts.stateTransferListeners, listener)
 }
 
-// No longer receive state transfer updates sent to the given function.
+// UnregisterListener unregisters a listener so that it no longer receive state transfer updates
 // Listeners must be comparable in order to be unregistered
 func (sts *StateTransferState) UnregisterListener(listener Listener) {
 	sts.stateTransferListenersLock.Lock()
@@ -251,7 +254,7 @@ func (sts *StateTransferState) UnregisterListener(listener Listener) {
 	}
 }
 
-// This is a simple convenience method, for listeners who wish only to be notified that the state transfer has completed, without any additional information
+// CompletionChannel is a simple convenience method, for listeners who wish only to be notified that the state transfer has completed, without any additional information
 // For more sophisticated information, use the RegisterListener call.  This channel never closes but receives a message every time transfer completes
 func (sts *StateTransferState) CompletionChannel() chan struct{} {
 	complete := make(chan struct{}, 1)
@@ -266,19 +269,19 @@ func (sts *StateTransferState) CompletionChannel() chan struct{} {
 	return complete
 }
 
-// Whether state transfer is currently occuring.  Note, this is not a thread safe call, it is expected
+// InProgress returns whether state transfer is currently occuring.  Note, this is not a thread safe call, it is expected
 // that the caller synchronizes around state transfer if it is to be accessed in a non-serial fashion
 func (sts *StateTransferState) InProgress() bool {
 	return sts.asynchronousTransferInProgress
 }
 
-// Inform state transfer that the current state is invalid.  This will trigger an immediate full state snapshot sync
+// InvalidateState informs state transfer that the current state is invalid.  This will trigger an immediate full state snapshot sync
 // when state transfer is initiated
 func (sts *StateTransferState) InvalidateState() {
 	sts.stateValid = false
 }
 
-// This will send a signal to any running threads to stop, regardless of whether they are stopped
+// Stop sends a signal to any running threads to stop, regardless of whether they are stopped
 // It will never block, and if called before threads start, they will exit at startup
 func (sts *StateTransferState) Stop() {
 	select {
@@ -320,7 +323,7 @@ func threadlessNewStateTransferState(stack PartialStack) *StateTransferState {
 		panic(fmt.Errorf("Must set statetransfer.blocksperrequest to be nonzero"))
 	}
 
-	sts.initiateStateSync = make(chan *syncMark)
+	sts.initiateStateSync = make(chan *blockHashReply)
 	sts.blockHashReceiver = make(chan *blockHashReply, 1)
 	sts.blockSyncReq = make(chan *blockSyncReq)
 
@@ -355,6 +358,7 @@ func threadlessNewStateTransferState(stack PartialStack) *StateTransferState {
 	return sts
 }
 
+// NewStateTransferState constructs a new state transfer state, including its maintenance threads
 func NewStateTransferState(stack PartialStack) *StateTransferState {
 	sts := threadlessNewStateTransferState(stack)
 
@@ -368,12 +372,12 @@ func NewStateTransferState(stack PartialStack) *StateTransferState {
 // custom interfaces and structure definitions
 // =============================================================================
 
-type StateTransferUpdate int
+type stateTransferUpdate int
 
 const (
-	Initiated StateTransferUpdate = iota
-	Errored
-	Completed
+	initiated stateTransferUpdate = iota
+	errored
+	completed
 )
 
 type syncMark struct {
@@ -604,9 +608,7 @@ func (sts *StateTransferState) syncBlockchainToCheckpoint(blockSyncReq *blockSyn
 	}
 }
 
-// This function should never be called directly, its public visibility is purely a side effect
-// of the package scoping of go test
-func (sts *StateTransferState) VerifyAndRecoverBlockchain() bool {
+func (sts *StateTransferState) verifyAndRecoverBlockchain() bool {
 
 	if 0 == len(sts.validBlockRanges) {
 		size := sts.stack.GetBlockchainSize()
@@ -740,7 +742,7 @@ func (sts *StateTransferState) blockThread() {
 			return
 		default:
 			// If there is no checkpoint to sync to, make sure the rest of the chain is valid
-			if !sts.VerifyAndRecoverBlockchain() {
+			if !sts.verifyAndRecoverBlockchain() {
 				// There is more verification to be done, so loop
 				continue
 			}
@@ -770,7 +772,7 @@ func (sts *StateTransferState) blockThread() {
 	}
 }
 
-func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uint64, mark **syncMark, blockHReply **blockHashReply, blocksValid *bool) error {
+func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uint64, mark **blockHashReply, blockHReply **blockHashReply, blocksValid *bool) error {
 	var err error
 
 	if !sts.stateValid {
@@ -778,9 +780,11 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 		*currentStateBlockNumber, err = sts.syncStateSnapshot((*mark).blockNumber, (*mark).peerIDs)
 
 		if nil != err {
-			*mark = &syncMark{ // Let's try to just sync state from anyone, for any sequence number
-				blockNumber: 0,
-				peerIDs:     nil,
+			*mark = &blockHashReply{ // Let's try to just sync state from anyone, for any sequence number
+				syncMark: syncMark{
+					blockNumber: 0,
+					peerIDs:     nil,
+				},
 			}
 			return fmt.Errorf("%v could not retrieve state as recent as %d from any of specified peers", sts.id, (*mark).blockNumber)
 		}
@@ -819,12 +823,12 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 	}
 
 	if !*blocksValid {
-		(*mark) = &((*blockHReply).syncMark) // We now know of a more recent block hash
+		(*mark) = *blockHReply // We now know of a more recent block hash
 
 		blockReplyChannel := make(chan error)
 
 		req := &blockSyncReq{
-			syncMark:       *(*mark),
+			syncMark:       (*mark).syncMark,
 			reportOnBlock:  *currentStateBlockNumber,
 			replyChan:      blockReplyChannel,
 			firstBlockHash: (*blockHReply).blockHash,
@@ -872,12 +876,11 @@ func (sts *StateTransferState) attemptStateTransfer(currentStateBlockNumber *uin
 		if sts.stateValid {
 			sts.stateValid = false
 			return fmt.Errorf("%v believed its state for block %d to be valid, but its hash (%x) did not match the recovered blockchain's (%x)", sts.id, (*currentStateBlockNumber), stateHash, block.StateHash)
-		} else {
-			return fmt.Errorf("%v recovered to an incorrect state at block number %d, (%x %x) retrying", sts.id, *currentStateBlockNumber, stateHash, block.StateHash)
 		}
-	} else {
-		logger.Debug("%v state is now valid", sts.id)
+		return fmt.Errorf("%v recovered to an incorrect state at block number %d, (%x %x) retrying", sts.id, *currentStateBlockNumber, stateHash, block.StateHash)
 	}
+
+	logger.Debug("%v state is now valid", sts.id)
 
 	sts.stateValid = true
 
@@ -900,6 +903,7 @@ func (sts *StateTransferState) stateThread() {
 		select {
 		// Wait for state sync to become necessary
 		case mark := <-sts.initiateStateSync:
+			sts.informListeners(mark.blockNumber, mark.blockHash, mark.peerIDs, mark.metadata, nil, initiated)
 			sts.stateThreadIdle = false
 
 			logger.Debug("%v is initiating state transfer", sts.id)
@@ -911,7 +915,7 @@ func (sts *StateTransferState) stateThread() {
 			for {
 				if err := sts.attemptStateTransfer(&currentStateBlockNumber, &mark, &blockHReply, &blocksValid); err != nil {
 					logger.Error("%s", err)
-					sts.informListeners(0, nil, mark.peerIDs, nil, err, Errored)
+					sts.informListeners(0, nil, mark.peerIDs, nil, err, errored)
 					select {
 					case <-sts.threadExit:
 						logger.Debug("Received request for state thread to exit, aborting state transfer")
@@ -930,7 +934,7 @@ func (sts *StateTransferState) stateThread() {
 
 			sts.asynchronousTransferInProgress = false
 
-			sts.informListeners(blockHReply.blockNumber, blockHReply.blockHash, blockHReply.peerIDs, blockHReply.metadata, nil, Completed)
+			sts.informListeners(blockHReply.blockNumber, blockHReply.blockHash, blockHReply.peerIDs, blockHReply.metadata, nil, completed)
 		case sts.stateThreadIdleChan <- struct{}{}:
 			logger.Debug("%v state thread reporting as idle to unblock someone", sts.id)
 			continue
@@ -942,10 +946,10 @@ func (sts *StateTransferState) stateThread() {
 	}
 }
 
-// Makes a best effort to block until the state transfer is idle
+// blockUntilIdle makes a best effort to block until the state transfer is idle
 // This is not an atomic operation, and no locking is performed
 // so it is possible in rare cases that this may unblock prematurely
-func (sts *StateTransferState) BlockUntilIdle() {
+func (sts *StateTransferState) blockUntilIdle() {
 	logger.Debug("%v caller requesting to block until idle", sts.id)
 	for i := 0; i < 3; i++ {
 		// The goal is that both threads are simulatenously idle
@@ -964,14 +968,14 @@ func (sts *StateTransferState) BlockUntilIdle() {
 	}
 }
 
-// Determines whether state transfer is currently doing nothing
+// isIdle determines whether state transfer is currently doing nothing
 // Note, this is different from state transfer in progress, as for instance
 // block recovery can be being performed in the background
-func (sts *StateTransferState) IsIdle() bool {
+func (sts *StateTransferState) isIdle() bool {
 	return sts.stateThreadIdle && sts.blockThreadIdle
 }
 
-func (sts *StateTransferState) informListeners(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID, metadata interface{}, err error, update StateTransferUpdate) {
+func (sts *StateTransferState) informListeners(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID, metadata interface{}, err error, update stateTransferUpdate) {
 	sts.stateTransferListenersLock.Lock()
 	defer func() {
 		sts.stateTransferListenersLock.Unlock()
@@ -979,11 +983,11 @@ func (sts *StateTransferState) informListeners(blockNumber uint64, blockHash []b
 
 	for _, listener := range sts.stateTransferListeners {
 		switch update {
-		case Initiated:
+		case initiated:
 			listener.Initiated(blockNumber, blockHash, peerIDs, metadata)
-		case Errored:
+		case errored:
 			listener.Errored(blockNumber, blockHash, peerIDs, metadata, err)
-		case Completed:
+		case completed:
 			listener.Completed(blockNumber, blockHash, peerIDs, metadata)
 		}
 	}
@@ -1042,9 +1046,8 @@ func (sts *StateTransferState) playStateUpToBlockNumber(fromBlockNumber, toBlock
 					if nil != sts.stack.RollbackStateDelta(deltaMessage) {
 						sts.InvalidateState()
 						return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, failed to roll back, invalidated state", sts.id, peerID)
-					} else {
-						return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, rolled back", sts.id, peerID)
 					}
+					return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, rolled back", sts.id, peerID)
 
 				}
 

--- a/consensus/statetransfer/statetransfer_test.go
+++ b/consensus/statetransfer/statetransfer_test.go
@@ -417,7 +417,7 @@ func executeBlockRecovery(ml *MockLedger, millisTimeout int, mrls *MockRemoteHas
 	w := make(chan struct{})
 
 	go func() {
-		for !sts.VerifyAndRecoverBlockchain() {
+		for !sts.verifyAndRecoverBlockchain() {
 		}
 		w <- struct{}{}
 	}()
@@ -449,7 +449,7 @@ func executeBlockRecoveryWithPanic(ml *MockLedger, millisTimeout int, mrls *Mock
 			recover()
 			w <- true
 		}()
-		for !sts.VerifyAndRecoverBlockchain() {
+		for !sts.verifyAndRecoverBlockchain() {
 		}
 		w <- false
 	}()
@@ -599,7 +599,7 @@ func TestIdle(t *testing.T) {
 
 	idle := make(chan struct{})
 	go func() {
-		sts.BlockUntilIdle()
+		sts.blockUntilIdle()
 		idle <- struct{}{}
 	}()
 
@@ -609,7 +609,7 @@ func TestIdle(t *testing.T) {
 		t.Fatalf("Timed out waiting for state transfer to become idle")
 	}
 
-	if !sts.IsIdle() {
+	if !sts.isIdle() {
 		t.Fatalf("State transfer unblocked from idle but did not remain that way")
 	}
 }

--- a/consensus/statetransfer/statetransfer_test.go
+++ b/consensus/statetransfer/statetransfer_test.go
@@ -52,7 +52,7 @@ func newTestStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *S
 }
 
 func newTestThreadlessStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *StateTransferState {
-	return ThreadlessNewStateTransferState(newPartialStack(ml, rld))
+	return threadlessNewStateTransferState(newPartialStack(ml, rld))
 }
 
 type MockRemoteHashLedgerDirectory struct {
@@ -83,7 +83,6 @@ func executeStateTransfer(sts *StateTransferState, ml *MockLedger, blockNumber, 
 		mrls.GetMockRemoteLedgerByPeerID(&peerID).blockHeight = blockNumber + 1
 	}
 
-	sts.Initiate(nil)
 	result := sts.CompletionChannel()
 
 	blockHash := SimpleGetBlockHash(blockNumber)
@@ -173,7 +172,6 @@ func TestCatchupWithoutDeltas(t *testing.T) {
 	// Test from blockheight of 1, with valid genesis block
 	ml := NewMockLedger(mrls, func(request mockRequest, peerID *protos.PeerID) mockResponse {
 		if request == SyncDeltas {
-			fmt.Println("ASDF")
 			deltasTransferred = true
 		}
 
@@ -272,8 +270,6 @@ func TestCatchupSyncBlocksAllErrors(t *testing.T) {
 
 		sts.RegisterListener(protoListener)
 
-		sts.Initiate(nil)
-
 		blockHash := SimpleGetBlockHash(blockNumber)
 		sts.AddTarget(blockNumber, blockHash, nil, nil)
 
@@ -284,7 +280,7 @@ func TestCatchupSyncBlocksAllErrors(t *testing.T) {
 		}
 
 		succeeding.triggered = true
-		sts.AddTarget(blockNumber, blockHash, nil, nil)
+		go sts.AddTarget(blockNumber, blockHash, nil, nil)
 
 		<-failChannel // Unblock state transfer
 
@@ -380,7 +376,6 @@ func TestCatchupSimpleSynchronous(t *testing.T) {
 	ml.PutBlock(0, SimpleGetBlock(0))
 	sts := newTestStateTransfer(ml, mrls)
 	defer sts.Stop()
-	sts.Initiate(nil)
 	if err := sts.BlockingAddTarget(7, SimpleGetBlockHash(7), nil); nil != err {
 		t.Fatalf("SimpleSynchronous state transfer failed : %s", err)
 	}
@@ -402,7 +397,6 @@ func TestCatchupSimpleSynchronousSuccess(t *testing.T) {
 	done := make(chan struct{})
 
 	go func() {
-		sts.Initiate(nil)
 		sts.BlockingUntilSuccessAddTarget(7, SimpleGetBlockHash(7), nil)
 		done <- struct{}{}
 	}()
@@ -543,16 +537,14 @@ func TestCatchupCorruptChains(t *testing.T) {
 
 type listenerHelper struct {
 	resultChannel chan struct{}
+	ProtoListener
 }
 
-func (lh *listenerHelper) Initiated() {}
 func (lh *listenerHelper) Errored(bn uint64, bh []byte, pids []*protos.PeerID, md interface{}, err error) {
 	select {
 	case lh.resultChannel <- struct{}{}:
 	default:
 	}
-}
-func (lh *listenerHelper) Completed(bn uint64, bh []byte, pids []*protos.PeerID, md interface{}) {
 }
 
 func TestRegisterUnregisterListener(t *testing.T) {
@@ -564,15 +556,15 @@ func TestRegisterUnregisterListener(t *testing.T) {
 	defer sts.Stop()
 	sts.DiscoveryThrottleTime = 1 * time.Millisecond
 
-	l1 := &listenerHelper{make(chan struct{})}
-	l2 := &listenerHelper{make(chan struct{})}
+	l1 := &listenerHelper{resultChannel: make(chan struct{})}
+	l2 := &listenerHelper{resultChannel: make(chan struct{})}
 
 	sts.RegisterListener(l1)
 	sts.RegisterListener(l2)
 
 	// Will cause an immediate error loop of errors on state sync, as there are no peerIDs
 	sts.InvalidateState()
-	sts.Initiate(nil)
+	sts.AddTarget(10, []byte("DUMMY"), nil, nil)
 
 	select {
 	case <-l1.resultChannel:


### PR DESCRIPTION
## Description

This changeset adds a test case for multiply invoked statetransfer, as well as fixes the logic of state transfer in the pbft test framework.  It also modifies the behavior of state transfer to more closely match the expectations of its new usage in consensus.  Principally, this means eliminating the `Initiate()` call from state transfer and having state transfer implicitly started whenever a target is provided.
## Motivation and Context

In the significant churn from last week, the state transfer logic was damaged.  The logic was changed to initiate state transfer once, then add targets indefinitely.  Once state transfer completed, this would cause state transfer to never complete again.  This was not captured by the existing tests, because they only tested one instance of state transfer.  The included changeset adds a test which includes back to back state transfer.

Fixes half of #1091 (where state transfer was observed not to recover nearly enough blocks)
## How Has This Been Tested?

Ran the unit and behave tests, added new test for multiple invocations of statetransfer.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
