### PR TITLE
Rename ChaincodeSpec.ctor to ChaincodeSpec.input

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -31,7 +31,7 @@ Feature: lanching 3 peers
     Given we compose "docker-compose-1.yml"
       When requesting "/chain" from "vp0"
       Then I should get a JSON response with "height" = "1"
-      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/map" with ctor "init" to "vp0"
+      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/map" with input "init" to "vp0"
       ||
       ||
 
@@ -90,7 +90,7 @@ Feature: lanching 3 peers
     Given we compose "docker-compose-1.yml"
       When requesting "/chain" from "vp0"
       Then I should get a JSON response with "height" = "1"
-      When I deploy chaincode "github.com/hyperledger/fabric/bddtests/chaincode/go/table" with ctor "init" to "vp0"
+      When I deploy chaincode "github.com/hyperledger/fabric/bddtests/chaincode/go/table" with input "init" to "vp0"
       ||
       ||
       Then I should have received a chaincode name
@@ -319,7 +319,7 @@ Feature: lanching 3 peers
 	    Given we compose "docker-compose-1.yml"
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
 	    Then I should have received a chaincode name
@@ -360,7 +360,7 @@ Feature: lanching 3 peers
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
 
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
 	    Then I should have received a chaincode name
@@ -401,7 +401,7 @@ Feature: lanching 3 peers
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
         And I wait "2" seconds
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
 	    Then I should have received a chaincode name
@@ -453,7 +453,7 @@ Feature: lanching 3 peers
 
 
             # Deploy
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
                     | arg1 |  arg2 | arg3 | arg4 |
                     |  a   |  100  |  b   |  200 |
 	        Then I should have received a chaincode name
@@ -534,7 +534,7 @@ Feature: lanching 3 peers
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"
         And I wait "2" seconds
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
 		     | arg1 |  arg2 | arg3 | arg4 |
 		     |  a   |  100  |  b   |  200 |
 	    Then I should have received a chaincode name
@@ -599,7 +599,7 @@ Feature: lanching 3 peers
        Then I should get a JSON response with "height" = "1"
 
       # Deploy
-      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
          | arg1 |  arg2 | arg3 | arg4 |
          |  a   |  100  |  b   |  200 |
        Then I should have received a chaincode name
@@ -662,7 +662,7 @@ Feature: lanching 3 peers
      Then I should get a JSON response with "height" = "1"
 
     # Deploy
-    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
        | arg1 |  arg2 | arg3 | arg4 |
        |  a   |  100  |  b   |  200 |
      Then I should have received a chaincode name
@@ -723,7 +723,7 @@ Feature: lanching 3 peers
           Then I should get a JSON response with "height" = "1"
 
          # Deploy
-         When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+         When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
             | arg1 |  arg2 | arg3 | arg4 |
             |  a   |  100  |  b   |  200 |
           Then I should have received a chaincode name
@@ -769,7 +769,7 @@ Feature: lanching 3 peers
 
 
       # Deploy
-      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "nvp0"
+      When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "nvp0"
                     | arg1 |  arg2 | arg3 | arg4 |
                     |  a   |  100  |  b   |  200 |
       Then I should have received a chaincode name
@@ -798,7 +798,7 @@ Feature: lanching 3 peers
 	        Then I should get a JSON response with "height" = "1"
 
             # Deploy
-	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with input "init" to "vp0"
                     | arg1 |  arg2 | arg3 | arg4 |
                     |  a   |  100  |  b   |  200 |
 	        Then I should have received a chaincode name

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -159,14 +159,14 @@ def step_impl(context, seconds):
     time.sleep(float(seconds))
 
 
-@when(u'I deploy chaincode "{chaincodePath}" with ctor "{ctor}" to "{containerName}"')
-def step_impl(context, chaincodePath, ctor, containerName):
+@when(u'I deploy chaincode "{chaincodePath}" with input "{input}" to "{containerName}"')
+def step_impl(context, chaincodePath, input, containerName):
     ipAddress = ipFromContainerNamePart(containerName, context.compose_containers)
     request_url = buildUrl(context, ipAddress, "/devops/deploy")
     print("Requesting path = {0}".format(request_url))
     args = []
     if 'table' in context:
-	   # There is ctor arguments
+	   # There is input arguments
 	   args = context.table[0].cells
     typeGolang = 1
 
@@ -177,8 +177,8 @@ def step_impl(context, chaincodePath, ctor, containerName):
             "path" : chaincodePath,
             "name" : ""
         },
-        "ctorMsg":  {
-            "function" : ctor,
+        "input":  {
+            "function" : input,
             "args" : args
         },
         #"secureContext" : "binhn"
@@ -227,13 +227,13 @@ def step_impl(context, chaincodeName, functionName, containerName):
 
 def invokeChaincode(context, devopsFunc, functionName, containerName):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
-    # Update hte chaincodeSpec ctorMsg for invoke
+    # Update hte chaincodeSpec input for invoke
     args = []
     if 'table' in context:
-       # There is ctor arguments
+       # There is input arguments
        args = context.table[0].cells
-    context.chaincodeSpec['ctorMsg']['function'] = functionName
-    context.chaincodeSpec['ctorMsg']['args'] = args
+    context.chaincodeSpec['input']['function'] = functionName
+    context.chaincodeSpec['input']['args'] = args
     # Invoke the POST
     chaincodeInvocationSpec = {
         "chaincodeSpec" : context.chaincodeSpec
@@ -381,13 +381,13 @@ def step_impl(context, seconds):
 def step_impl(context, chaincodeName, functionName):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
     assert 'compose_containers' in context, "compose_containers not found in context"
-    # Update the chaincodeSpec ctorMsg for invoke
+    # Update the chaincodeSpec input for invoke
     args = []
     if 'table' in context:
-       # There is ctor arguments
+       # There is input arguments
        args = context.table[0].cells
-    context.chaincodeSpec['ctorMsg']['function'] = functionName
-    context.chaincodeSpec['ctorMsg']['args'] = args #context.table[0].cells if ('table' in context) else []
+    context.chaincodeSpec['input']['function'] = functionName
+    context.chaincodeSpec['input']['args'] = args #context.table[0].cells if ('table' in context) else []
     # Invoke the POST
     chaincodeInvocationSpec = {
         "chaincodeSpec" : context.chaincodeSpec
@@ -412,9 +412,9 @@ def step_impl(context, chaincodeName, functionName, value):
     aliases =  context.table.headings
     containerDataList = getContainerDataValuesFromContext(context, aliases, lambda containerData: containerData)
 
-    # Update the chaincodeSpec ctorMsg for invoke
-    context.chaincodeSpec['ctorMsg']['function'] = functionName
-    context.chaincodeSpec['ctorMsg']['args'] = [value]
+    # Update the chaincodeSpec input for invoke
+    context.chaincodeSpec['input']['function'] = functionName
+    context.chaincodeSpec['input']['args'] = [value]
     # Invoke the POST
     # Make deep copy of chaincodeSpec as we will be changing the SecurityContext per call.
     chaincodeInvocationSpec = {

--- a/bddtests/utxo.feature
+++ b/bddtests/utxo.feature
@@ -20,7 +20,7 @@ Feature: utxo
       And I wait "1" seconds
       When requesting "/chain" from "vp0"
       Then I should get a JSON response with "height" = "1"
-      When I deploy chaincode "github.com/openblockchain/obc-peer/examples/chaincode/go/utxo" with ctor "init" to "vp0"
+      When I deploy chaincode "github.com/openblockchain/obc-peer/examples/chaincode/go/utxo" with input "init" to "vp0"
       ||
       ||
 

--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -371,7 +371,7 @@ func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.
 			return nil, nil, err
 		}
 		cID = cds.ChaincodeSpec.ChaincodeID
-		cMsg = cds.ChaincodeSpec.CtorMsg
+		cMsg = cds.ChaincodeSpec.Input
 		f = &cMsg.Function
 		initargs = cMsg.Args
 	} else if t.Type == pb.Transaction_CHAINCODE_INVOKE || t.Type == pb.Transaction_CHAINCODE_QUERY {
@@ -381,7 +381,7 @@ func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.
 			return nil, nil, err
 		}
 		cID = ci.ChaincodeSpec.ChaincodeID
-		cMsg = ci.ChaincodeSpec.CtorMsg
+		cMsg = ci.ChaincodeSpec.Input
 	} else {
 		chaincodeSupport.runningChaincodes.Unlock()
 		return nil, nil, fmt.Errorf("invalid transaction type: %d", t.Type)

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -177,18 +177,18 @@ func TestExecuteDeployTransaction(t *testing.T) {
 	url := "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01"
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
-	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Path: url}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Path: url}, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	_, err = deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		t.Fail()
 		t.Logf("Error deploying <%s>: %s", chaincodeID, err)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -237,7 +237,7 @@ func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args 
 
 	f := "init"
 	argsDeploy := []string{"a", "100", "b", "200"}
-	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: argsDeploy}}
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: argsDeploy}}
 	_, err := deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
@@ -247,7 +247,7 @@ func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args 
 	time.Sleep(time.Second)
 
 	f = "invoke"
-	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	uuid, _, err := invoke(ctxt, spec, pb.Transaction_CHAINCODE_INVOKE)
 	if err != nil {
 		return fmt.Errorf("Error invoking <%s>: %s", chaincodeID, err)
@@ -261,7 +261,7 @@ func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args 
 	// Test for delete state
 	f = "delete"
 	delArgs := []string{"a"}
-	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: delArgs}}
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: delArgs}}
 	uuid, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_INVOKE)
 	if err != nil {
 		return fmt.Errorf("Error deleting state in <%s>: %s", chaincodeID, err)
@@ -318,7 +318,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 		t.Logf("Invoke test passed")
 	}
 
-	GetChain(DefaultChain).Stop(ctxt,  &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 	closeListenerAndSleep(lis)
 }
@@ -335,12 +335,12 @@ func exec(ctxt context.Context, chaincodeID string, numTrans int, numQueries int
 			f := "invoke"
 			args := []string{"a", "b", "10"}
 
-			spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: chaincodeID}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+			spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: chaincodeID}, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 		} else {
 			f := "query"
 			args := []string{"a"}
 
-			spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: chaincodeID}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+			spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: chaincodeID}, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 		}
 
 		_, _, err := invoke(ctxt, spec, typ)
@@ -409,14 +409,14 @@ func TestExecuteQuery(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -447,7 +447,7 @@ func TestExecuteQuery(t *testing.T) {
 	//end := getNowMillis()
 	//fmt.Fprintf(os.Stderr, "Ending: %d\n", end)
 	//fmt.Fprintf(os.Stderr, "Elapsed : %d millis\n", end-start)
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -498,7 +498,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 		errStr := err.Error()
 		t.Logf("Got error %s\n", errStr)
 		t.Logf("InvalidInvoke test passed")
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID:chaincodeID}})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 		closeListenerAndSleep(lis)
 		return
@@ -507,7 +507,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 	t.Fail()
 	t.Logf("Error invoking transaction %s", err)
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID:chaincodeID}})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 	closeListenerAndSleep(lis)
 }
@@ -553,14 +553,14 @@ func TestExecuteInvalidQuery(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100"}
 
-	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -570,7 +570,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 	f = "query"
 	args = []string{"b", "200"}
 
-	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// This query should fail as it attempts to put state
 	_, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
 
@@ -579,7 +579,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 		t.Logf("This query should not have succeeded as it attempts to put state")
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -625,14 +625,14 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec1)
 	chaincodeID1 := spec1.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -646,15 +646,15 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	f = "init"
 	args = []string{"e", "0"}
 
-	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec2)
 	chaincodeID2 := spec2.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -665,7 +665,7 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	f = "invoke"
 	args = []string{"e", "1"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// Invoke chaincode
 	var uuid string
 	uuid, _, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_INVOKE)
@@ -673,8 +673,8 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -684,14 +684,14 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -738,14 +738,14 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec1)
 	chaincodeID1 := spec1.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -759,15 +759,15 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	f = "init"
 	args = []string{""}
 
-	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec2)
 	chaincodeID2 := spec2.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -778,15 +778,15 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	f = chaincodeID1
 	args = []string{"invoke", "a"} //expect {"invoke", "a","b","10"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// Invoke chaincode
 	_, _, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_INVOKE)
 
 	if err == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -794,14 +794,14 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	if strings.Index(err.Error(), "Incorrect number of arguments. Expecting 3") < 0 {
 		t.Fail()
 		t.Logf("Unexpected error %s", err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -847,14 +847,14 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec1)
 	chaincodeID1 := spec1.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -868,15 +868,15 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f = "init"
 	args = []string{"sum", "0"}
 
-	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec2)
 	chaincodeID2 := spec2.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -888,7 +888,7 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f = "invoke"
 	args = []string{chaincodeID1, "sum"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// Invoke chaincode
 	var retVal []byte
 	_, retVal, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_INVOKE)
@@ -896,8 +896,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -907,8 +907,8 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil || result != 300 {
 		t.Fail()
 		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -918,15 +918,15 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f = "query"
 	args = []string{chaincodeID1, "sum"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// Invoke chaincode
 	_, retVal, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_QUERY)
 
 	if err != nil {
 		t.Fail()
 		t.Logf("Error querying <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -936,14 +936,14 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	if err != nil || result != 300 {
 		t.Fail()
 		t.Logf("Incorrect final value after query for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -990,14 +990,14 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec1)
 	chaincodeID1 := spec1.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1011,15 +1011,15 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	f = "init"
 	args = []string{""}
 
-	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 
 	_, err = deploy(ctxt, spec2)
 	chaincodeID2 := spec2.ChaincodeID.Name
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1030,15 +1030,15 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	f = chaincodeID1
 	args = []string{"query", "c"} //expect {"query", "a"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, Input: &pb.ChaincodeInput{Function: f, Args: args}}
 	// Invoke chaincode
 	_, _, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_QUERY)
 
 	if err == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1046,14 +1046,14 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	if strings.Index(err.Error(), "Nil amount for c") < 0 {
 		t.Fail()
 		t.Logf("Unexpected error %s", err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -1098,7 +1098,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 	url := "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
 
 	args := []string{"greeting", "hello world"}
-	cds := &pb.ChaincodeDeploymentSpec{ExecEnv:1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Args: args}}}
+	cds := &pb.ChaincodeDeploymentSpec{ExecEnv: 1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, Input: &pb.ChaincodeInput{Args: args}}}
 	_, err = deploy2(ctxt, cds)
 	chaincodeID := cds.ChaincodeSpec.ChaincodeID.Name
 	if err != nil {

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -1163,13 +1163,13 @@ func (handler *Handler) setChaincodeSecurityContext(tx *pb.Transaction, msg *pb.
 				return err
 			}
 
-			ctorMsgRaw, err := proto.Marshal(cis.ChaincodeSpec.GetCtorMsg())
+			inputRaw, err := proto.Marshal(cis.ChaincodeSpec.GetInput())
 			if err != nil {
-				chaincodeLogger.Debug("Failed getting ctorMsgRaw [%s]", err)
+				chaincodeLogger.Debug("Failed getting input [%s]", err)
 				return err
 			}
 
-			msg.SecurityContext.Payload = ctorMsgRaw
+			msg.SecurityContext.Payload = inputRaw
 		}
 		msg.SecurityContext.TxTimestamp = tx.Timestamp
 	}

--- a/core/chaincode/platforms/car/hash.go
+++ b/core/chaincode/platforms/car/hash.go
@@ -30,15 +30,15 @@ import (
 //NOTE: for dev mode, user builds and runs chaincode manually. The name provided
 //by the user is equivalent to the path. This method will treat the name
 //as codebytes and compute the hash from it. ie, user cannot run the chaincode
-//with the same (name, ctor, args)
+//with the same (name, input, args)
 func generateHashcode(spec *pb.ChaincodeSpec, path string) (string, error) {
 
-	ctor := spec.CtorMsg
-	if ctor == nil || ctor.Function == "" {
-		return "", fmt.Errorf("Cannot generate hashcode from empty ctor")
+	input := spec.Input
+	if input == nil || input.Function == "" {
+		return "", fmt.Errorf("Cannot generate hashcode from empty chaincode input")
 	}
 
-	hash := util.GenerateHashFromSignature(spec.ChaincodeID.Path, ctor.Function, ctor.Args)
+	hash := util.GenerateHashFromSignature(spec.ChaincodeID.Path, input.Function, input.Args)
 
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/core/chaincode/platforms/car/test/car_test.go
+++ b/core/chaincode/platforms/car/test/car_test.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hyperledger/fabric/core/container"
 	"github.com/hyperledger/fabric/core/config"
+	"github.com/hyperledger/fabric/core/container"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -50,7 +50,7 @@ func TestCar_BuildImage(t *testing.T) {
 	}
 
 	chaincodePath := cwd + "/org.hyperledger.chaincode.example02-0.1-SNAPSHOT.car"
-	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_CAR, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, CtorMsg: &pb.ChaincodeInput{Function: "f"}}
+	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_CAR, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, Input: &pb.ChaincodeInput{Function: "f"}}
 	if _, err := vm.BuildChaincodeContainer(spec); err != nil {
 		t.Fail()
 		t.Log(err)

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -194,7 +194,7 @@ func getCodeFromFS(path string) (codegopath string, err error) {
 //NOTE: for dev mode, user builds and runs chaincode manually. The name provided
 //by the user is equivalent to the path. This method will treat the name
 //as codebytes and compute the hash from it. ie, user cannot run the chaincode
-//with the same (name, ctor, args)
+//with the same (name, input, args)
 func generateHashcode(spec *pb.ChaincodeSpec, tw *tar.Writer) (string, error) {
 	if spec == nil {
 		return "", fmt.Errorf("Cannot generate hashcode from nil spec")
@@ -205,9 +205,9 @@ func generateHashcode(spec *pb.ChaincodeSpec, tw *tar.Writer) (string, error) {
 		return "", fmt.Errorf("Cannot generate hashcode from empty chaincode path")
 	}
 
-	ctor := spec.CtorMsg
-	if ctor == nil || ctor.Function == "" {
-		return "", fmt.Errorf("Cannot generate hashcode from empty ctor")
+	input := spec.Input
+	if input == nil || input.Function == "" {
+		return "", fmt.Errorf("Cannot generate hashcode from empty chaincode input")
 	}
 
 	//code root will point to the directory where the code exists
@@ -248,7 +248,7 @@ func generateHashcode(spec *pb.ChaincodeSpec, tw *tar.Writer) (string, error) {
 		return "", fmt.Errorf("code does not exist %s", err)
 	}
 
-	hash := util.GenerateHashFromSignature(actualcodepath, ctor.Function, ctor.Args)
+	hash := util.GenerateHashFromSignature(actualcodepath, input.Function, input.Args)
 
 	hash, err = hashFilesInDir(codegopath+"/src/", actualcodepath, hash, tw)
 	if err != nil {

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -746,7 +746,7 @@ func (handler *Handler) handleInvokeChaincode(chaincodeName string, function str
 
 	chaincodeID := &pb.ChaincodeID{Name: chaincodeName}
 	input := &pb.ChaincodeInput{Function: function, Args: args}
-	payload := &pb.ChaincodeSpec{ChaincodeID: chaincodeID, CtorMsg: input}
+	payload := &pb.ChaincodeSpec{ChaincodeID: chaincodeID, Input: input}
 	payloadBytes, err := proto.Marshal(payload)
 	if err != nil {
 		return nil, errors.New("Failed to process invoke chaincode request")
@@ -807,7 +807,7 @@ func (handler *Handler) handleInvokeChaincode(chaincodeName string, function str
 func (handler *Handler) handleQueryChaincode(chaincodeName string, function string, args []string, uuid string) ([]byte, error) {
 	chaincodeID := &pb.ChaincodeID{Name: chaincodeName}
 	input := &pb.ChaincodeInput{Function: function, Args: args}
-	payload := &pb.ChaincodeSpec{ChaincodeID: chaincodeID, CtorMsg: input}
+	payload := &pb.ChaincodeSpec{ChaincodeID: chaincodeID, Input: input}
 	payloadBytes, err := proto.Marshal(payload)
 	if err != nil {
 		return nil, errors.New("Failed to process query chaincode request")

--- a/core/container/vm_test.go
+++ b/core/container/vm_test.go
@@ -99,7 +99,7 @@ func TestVM_BuildImage_ChaincodeLocal(t *testing.T) {
 	}
 	// Build the spec
 	chaincodePath := "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01"
-	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, CtorMsg: &pb.ChaincodeInput{Function: "f"}}
+	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, Input: &pb.ChaincodeInput{Function: "f"}}
 	if _, err := vm.BuildChaincodeContainer(spec); err != nil {
 		t.Fail()
 		t.Log(err)
@@ -116,7 +116,7 @@ func TestVM_BuildImage_ChaincodeRemote(t *testing.T) {
 	}
 	// Build the spec
 	chaincodePath := "https://github.com/prjayach/chaincode_examples/chaincode_example02"
-	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, CtorMsg: &pb.ChaincodeInput{Function: "f"}}
+	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG, ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, Input: &pb.ChaincodeInput{Function: "f"}}
 	if _, err := vm.BuildChaincodeContainer(spec); err != nil {
 		t.Fail()
 		t.Log(err)

--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"crypto/rand"
+
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	"github.com/hyperledger/fabric/core/util"
@@ -125,7 +126,7 @@ func TestParallelInitClose(t *testing.T) {
 					ChaincodeSpec: &obc.ChaincodeSpec{
 						Type:                 obc.ChaincodeSpec_GOLANG,
 						ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-						CtorMsg:              nil,
+						Input:                nil,
 						ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 					},
 				}
@@ -975,7 +976,7 @@ func BenchmarkTransactionCreation(b *testing.B) {
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1210,7 +1211,7 @@ func createConfidentialDeployTransaction(t *testing.T) (*obc.Transaction, *obc.T
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 		EffectiveDate: nil,
@@ -1232,7 +1233,7 @@ func createConfidentialExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1252,7 +1253,7 @@ func createConfidentialQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Tr
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1272,7 +1273,7 @@ func createConfidentialTCertHDeployTransaction(t *testing.T) (*obc.Transaction, 
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 		EffectiveDate: nil,
@@ -1319,7 +1320,7 @@ func createConfidentialTCertHExecuteTransaction(t *testing.T) (*obc.Transaction,
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1364,7 +1365,7 @@ func createConfidentialTCertHQueryTransaction(t *testing.T) (*obc.Transaction, *
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1409,7 +1410,7 @@ func createConfidentialECertHDeployTransaction(t *testing.T) (*obc.Transaction, 
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 		EffectiveDate: nil,
@@ -1456,7 +1457,7 @@ func createConfidentialECertHExecuteTransaction(t *testing.T) (*obc.Transaction,
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1501,7 +1502,7 @@ func createConfidentialECertHQueryTransaction(t *testing.T) (*obc.Transaction, *
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_CONFIDENTIAL,
 		},
 	}
@@ -1546,7 +1547,7 @@ func createPublicDeployTransaction(t *testing.T) (*obc.Transaction, *obc.Transac
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_PUBLIC,
 		},
 		EffectiveDate: nil,
@@ -1568,7 +1569,7 @@ func createPublicExecuteTransaction(t *testing.T) (*obc.Transaction, *obc.Transa
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_PUBLIC,
 		},
 	}
@@ -1588,7 +1589,7 @@ func createPublicQueryTransaction(t *testing.T) (*obc.Transaction, *obc.Transact
 		ChaincodeSpec: &obc.ChaincodeSpec{
 			Type:                 obc.ChaincodeSpec_GOLANG,
 			ChaincodeID:          &obc.ChaincodeID{Path: "Contract001"},
-			CtorMsg:              nil,
+			Input:                nil,
 			ConfidentialityLevel: obc.ConfidentialityLevel_PUBLIC,
 		},
 	}

--- a/core/ledger/blockchain_test.go
+++ b/core/ledger/blockchain_test.go
@@ -33,7 +33,7 @@ func TestBlockChain_SingleBlock(t *testing.T) {
 	// Create the Chaincode specification
 	chaincodeSpec := &protos.ChaincodeSpec{Type: protos.ChaincodeSpec_GOLANG,
 		ChaincodeID: &protos.ChaincodeID{Path: "Contracts"},
-		CtorMsg:     &protos.ChaincodeInput{Function: "Initialize", Args: []string{"param1"}}}
+		Input:       &protos.ChaincodeInput{Function: "Initialize", Args: []string{"param1"}}}
 	chaincodeDeploymentSepc := &protos.ChaincodeDeploymentSpec{ChaincodeSpec: chaincodeSpec}
 	uuid := testutil.GenerateUUID(t)
 	newChaincodeTx, err := protos.NewChaincodeDeployTransaction(chaincodeDeploymentSepc, uuid)

--- a/core/ledger/genesis/genesis.go
+++ b/core/ledger/genesis/genesis.go
@@ -150,7 +150,7 @@ func MakeGenesis() error {
 							ctorArgsStringArray = append(ctorArgsStringArray, ctorArgs[j].(string))
 						}
 					}
-					spec = protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value[chaincodeType]), ChaincodeID: chaincodeID, CtorMsg: &protos.ChaincodeInput{Args: ctorArgsStringArray}}
+					spec = protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value[chaincodeType]), ChaincodeID: chaincodeID, Input: &protos.ChaincodeInput{Args: ctorArgsStringArray}}
 				}
 
 				transaction, _, deployErr := DeployLocal(context.Background(), &spec, genesisBlockExists)
@@ -246,7 +246,7 @@ func deployUpdateValidityPeriodChaincode(gbexists bool) (*protos.Transaction, er
 		ChaincodeID: &protos.ChaincodeID{Path: vpChaincodePath,
 			Name: "",
 		},
-		CtorMsg: &protos.ChaincodeInput{Function: vpFunction,
+		Input: &protos.ChaincodeInput{Function: vpFunction,
 			Args: vpCtorArgsStringArray,
 		},
 	}

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -737,11 +737,11 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 		}
 	}
 
-	// Check that the CtorMsg is not left blank.
-	if (spec.CtorMsg == nil) || (spec.CtorMsg.Function == "") {
+	// Check that the Input is not left blank.
+	if (spec.Input == nil) || (spec.Input.Function == "") {
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
-		restLogger.Error("{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
+		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
+		restLogger.Error("{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
 
 		return
 	}
@@ -873,11 +873,11 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 		return
 	}
 
-	// Check that the CtorMsg is not left blank.
-	if (spec.ChaincodeSpec.CtorMsg == nil) || (spec.ChaincodeSpec.CtorMsg.Function == "") {
+	// Check that the Input is not left blank.
+	if (spec.ChaincodeSpec.Input == nil) || (spec.ChaincodeSpec.Input.Function == "") {
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
-		restLogger.Error("{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
+		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
+		restLogger.Error("{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
 
 		return
 	}
@@ -1009,11 +1009,11 @@ func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 		return
 	}
 
-	// Check that the CtorMsg is not left blank.
-	if (spec.ChaincodeSpec.CtorMsg == nil) || (spec.ChaincodeSpec.CtorMsg.Function == "") {
+	// Check that the Input is not left blank.
+	if (spec.ChaincodeSpec.Input == nil) || (spec.ChaincodeSpec.Input.Function == "") {
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
-		restLogger.Error("{\"Error\": \"Payload must contain a CtorMsg with a Chaincode function name.\"}")
+		fmt.Fprintf(rw, "{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
+		restLogger.Error("{\"Error\": \"Payload must contain a Input with a Chaincode function name.\"}")
 
 		return
 	}
@@ -1369,11 +1369,11 @@ func (s *ServerOpenchainREST) processChaincodeDeploy(spec *pb.ChaincodeSpec) rpc
 		}
 	}
 
-	// Check that the CtorMsg is not left blank.
-	if (spec.CtorMsg == nil) || (spec.CtorMsg.Function == "") {
+	// Check that the Input is not left blank.
+	if (spec.Input == nil) || (spec.Input.Function == "") {
 		// Format the error appropriately for further processing
-		error := formatRPCError(InvalidParams.Code, InvalidParams.Message, "Payload must contain a CtorMsg with a Chaincode function name.")
-		restLogger.Error("Payload must contain a CtorMsg with a Chaincode function name.")
+		error := formatRPCError(InvalidParams.Code, InvalidParams.Message, "Payload must contain a Input with a Chaincode function name.")
+		restLogger.Error("Payload must contain a Input with a Chaincode function name.")
 
 		return error
 	}
@@ -1497,11 +1497,11 @@ func (s *ServerOpenchainREST) processChaincodeInvokeOrQuery(method string, spec 
 		return error
 	}
 
-	// Check that the CtorMsg is not left blank.
-	if (spec.ChaincodeSpec.CtorMsg == nil) || (spec.ChaincodeSpec.CtorMsg.Function == "") {
+	// Check that the Input is not left blank.
+	if (spec.ChaincodeSpec.Input == nil) || (spec.ChaincodeSpec.Input.Function == "") {
 		// Format the error appropriately for further processing
-		error := formatRPCError(InvalidParams.Code, InvalidParams.Message, "Payload must contain a CtorMsg with a Chaincode function name.")
-		restLogger.Error("Payload must contain a CtorMsg with a Chaincode function name.")
+		error := formatRPCError(InvalidParams.Code, InvalidParams.Message, "Payload must contain a Input with a Chaincode function name.")
+		restLogger.Error("Payload must contain a Input with a Chaincode function name.")
 
 		return error
 	}

--- a/core/rest/rest_api.json
+++ b/core/rest/rest_api.json
@@ -564,7 +564,7 @@
                     "$ref": "#/definitions/ChaincodeID",
                     "description": "Unique Chaincode identifier."
                 },
-                "ctorMsg": {
+                "input": {
                     "$ref": "#/definitions/ChaincodeInput",
                     "description": "Specific function to execute within the Chaincode."
                 },

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -66,13 +66,13 @@ Command | **stdout** result in the event of success
 
 Deploy creates the docker image for the chaincode and subsequently deploys the package to the validating peer. An example is below.
 
-`./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'`
+`./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'`
 
 The response to the chaincode deploy command will contain the chaincode identifier (hash) which will be required on subsequent `chaincode invoke` and `chaincode query` commands in order to identify the deployed chaincode.
 
 With security enabled, modify the command to include the -u parameter passing the username of a logged in user as follows:
 
-`./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'`
+`./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'`
 
 ### Verify Results
 
@@ -224,7 +224,7 @@ message ChaincodeSpec {
 
     Type type = 1;
     ChaincodeID chaincodeID = 2;
-    ChaincodeInput ctorMsg = 3;
+    ChaincodeInput input = 3;
     int32 timeout = 4;
     string secureContext = 5;
     ConfidentialityLevel confidentialityLevel = 6;
@@ -259,7 +259,7 @@ An example of a valid ChaincodeSpec message for a deployment transaction is show
     "chaincodeID":{
         "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "100", "b", "200"]
     }
@@ -275,7 +275,7 @@ An example of a valid ChaincodeInvocationSpec message for an invocation transact
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg":{
+      "input":{
           "function":"invoke",
           "args":["a", "b", "10"]
       }
@@ -292,7 +292,7 @@ With security enabled, modify each of the above payloads to include the secureCo
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg":{
+      "input":{
           "function":"invoke",
           "args":["a", "b", "10"]
       },
@@ -353,7 +353,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "1000", "b", "2000"]
     }
@@ -377,7 +377,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "path":"github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "1000", "b", "2000"]
     },
@@ -415,7 +415,7 @@ Chaincode Invocation Request without security enabled:
       "chaincodeID":{
           "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
       },
-      "ctorMsg": {
+      "input": {
          "function":"invoke",
          "args":["a", "b", "100"]
       }
@@ -437,7 +437,7 @@ Chaincode Invocation Request with security enabled (add `secureContext` element)
       "chaincodeID":{
           "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
       },
-      "ctorMsg": {
+      "input": {
          "function":"invoke",
          "args":["a", "b", "100"]
       },
@@ -475,7 +475,7 @@ Chaincode Query Request without security enabled:
       "chaincodeID":{
           "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
       },
-      "ctorMsg": {
+      "input": {
          "function":"query",
          "args":["a"]
       }
@@ -497,7 +497,7 @@ Chaincode Query Request with security enabled (add `secureContext` element):
       "chaincodeID":{
           "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
       },
-      "ctorMsg": {
+      "input": {
          "function":"query",
          "args":["a"]
       },

--- a/docs/API/Samples/Sample_1.js
+++ b/docs/API/Samples/Sample_1.js
@@ -18,7 +18,7 @@ var api_url = 'http://localhost:5554/rest_api.json';
 //      deleteUserRegistration
 //      getUserEnrollmentCertificate
 //      getPeers
-//      
+//
 
 // Initialize the Swagger-based client, passing in the API URL
 var swagger = new client({
@@ -41,40 +41,40 @@ var swagger = new client({
 // Sample script to trigger APIs exposed in Swagger through Node.js
 function runSwaggerAPITest() {
     console.log("Running Swagger API test...\n");
-    
+
     // GET /chain -- retrieve blockchain information
     swagger.Blockchain.getChain({},{responseContentType: 'application/json'}, function(Blockchain){
         console.log("----- Blockchain Retrieved: -----\n");
         console.log(Blockchain);
         console.log("----------\n\n");
     });
-    
+
     // GET /chain/blocks/0 -- retrieve block information for block 0
     swagger.Block.getBlock({'Block': '0'},{responseContentType: 'application/json'}, function(Block){
         console.log("----- Block Retrieved: -----\n");
         console.log(Block);
         console.log("----------\n\n");
     });
-    
+
     // GET /chain/blocks/5 -- retrieve block information for block 5
     swagger.Block.getBlock({'Block': '5'},{responseContentType: 'application/json'}, function(Block){
         console.log("----- Block Retrieved: -----\n");
         console.log(Block);
         console.log("----------\n\n");
     });
-    
+
     // Compose the payload for chaincode deploy transaction
     var chaincodeSpec = {
         "type": "GOLANG",
         "chaincodeID":{
             "path":"github.com/openblockchain/obc-peer/openchain/example/chaincode/chaincode_example02"
         },
-        "ctorMsg": {
+        "input": {
             "function":"init",
             "args":["a", "100", "b", "200"]
         }
     };
-    
+
     // POST /devops/deploy -- deploy the sample chaincode
     // name (hash) returned is:
     // bb540edfc1ee2ac0f5e2ec6000677f4cd1c6728046d5e32dede7fea11a42f86a6943b76a8f9154f4792032551ed320871ff7b7076047e4184292e01e3421889c
@@ -82,7 +82,7 @@ function runSwaggerAPITest() {
         console.log("----- Chaincode Deployed: -----\n");
         console.log(Devops);
         console.log("----------\n\n");
-        
+
         // Compose a payload for chaincode invocation transaction
         var chaincodeInvocationSpec = {
             "chaincodeSpec": {
@@ -90,19 +90,19 @@ function runSwaggerAPITest() {
                 "chaincodeID":{
                     "name":"bb540edfc1ee2ac0f5e2ec6000677f4cd1c6728046d5e32dede7fea11a42f86a6943b76a8f9154f4792032551ed320871ff7b7076047e4184292e01e3421889c"
                 },
-                "ctorMsg": {
+                "input": {
                     "function":"invoke",
                     "args":["a", "b", "10"]
                 }
             }
         };
-        
+
         // POST /devops/invoke -- invoke the sample chaincode
         swagger.Devops.chaincodeInvoke({'ChaincodeInvocationSpec': chaincodeInvocationSpec},{responseContentType: 'application/json'}, function(Devops){
             console.log("----- Devops Invoke Triggered: -----\n");
             console.log(Devops);
             console.log("----------\n\n");
-            
+
             // Compose a payload for chaincode query transaction
             chaincodeInvocationSpec = {
                 "chaincodeSpec": {
@@ -110,13 +110,13 @@ function runSwaggerAPITest() {
                     "chaincodeID":{
                         "name":"bb540edfc1ee2ac0f5e2ec6000677f4cd1c6728046d5e32dede7fea11a42f86a6943b76a8f9154f4792032551ed320871ff7b7076047e4184292e01e3421889c"
                     },
-                    "ctorMsg": {
+                    "input": {
                         "function":"query",
                         "args":["a"]
                     }
                 }
             };
-            
+
             // POST /devops/query -- query the sample chaincode for variable "a"
             // Must introduce a wait here, to insure that the invocation transaction had completed, as it returns immediately at runtime
             setTimeout(function() {

--- a/docs/API/SandboxSetup.md
+++ b/docs/API/SandboxSetup.md
@@ -114,7 +114,7 @@ POST localhost:3000/registrar
 First, send a chaincode deploy transaction, only once, to the validating peer. The CLI connects to the validating peer using the properties defined in the core.yaml file. **Note:** The deploy transaction typically requires a 'path' parameter to locate, build, and deploy the chaincode. However, because these instructions are specific to local development mode and the chaincode is deployed manually, the 'name' parameter is used instead.
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric/peer
-./peer chaincode deploy -n mycc -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+./peer chaincode deploy -n mycc -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
 Alternatively, you can run the chaincode deploy transaction through the REST API. Note, that you should use port 5000 if you are sending the REST request from inside Vagrant and port 3000 (or another port number that you have configured) if you are sending the REST request from outside Vagrant.
@@ -131,7 +131,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "name": "mycc"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "100", "b", "200"]
     }
@@ -154,7 +154,7 @@ POST host:port/chaincode
 
 **Note:** When security is enabled, modify the CLI command and the REST API payload to pass the <b>enrollmentID</b> of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [note on security functionality](#note-on-security-functionality). On the CLI, the <b>enrollmentID</b> is passed with the <b>-u</b> parameter; in the REST API, the <b>enrollmentID</b> is passed with the <b>'secureContext'</b> element.
 
- 	  ./peer chaincode deploy -u jim -n mycc -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+ 	  ./peer chaincode deploy -u jim -n mycc -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 
 <b>REST Request:</b>
 ```
@@ -168,7 +168,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "name": "mycc"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "100", "b", "200"]
     },
@@ -187,7 +187,7 @@ The deploy transaction initializes the chaincode by executing a target initializ
 
 Run the chaincode invoking transaction on the CLI as many times as desired. The <b>-n</b> argument should match the value provided in the chaincode window (started in Vagrant terminal 2):
 
-	./peer chaincode invoke -l golang -n mycc -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+	./peer chaincode invoke -l golang -n mycc -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 
 Alternatively, run the chaincode invoking transaction through the REST API. Note, that you should use port 5000 if you are sending the REST request from inside Vagrant and port 3000 (or another port number that you have configured) if you are sending the REST request from outside Vagrant.
 
@@ -203,7 +203,7 @@ POST host:port/chaincode
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg": {
+      "input": {
          "function":"invoke",
          "args":["a", "b", "10"]
       }
@@ -226,7 +226,7 @@ POST host:port/chaincode
 
 **Note:** When security is enabled, modify the CLI command and REST API payload to pass the <b>enrollmentID</b> of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [note on security functionality](#note-on-security-functionality). On the CLI, the <b>enrollmentID</b> is passed with the <b>-u</b> parameter; in the REST API, the <b>enrollmentID</b> is passed with the <b>'secureContext'</b> element.
 
-	 ./peer chaincode invoke -u jim -l golang -n mycc -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+	 ./peer chaincode invoke -u jim -l golang -n mycc -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 
 <b> REST Request:</b>
 ```
@@ -240,7 +240,7 @@ POST host:port/chaincode
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg": {
+      "input": {
          "function":"invoke",
          "args":["a", "b", "10"]
       },
@@ -259,7 +259,7 @@ The invoking transaction runs the specified chaincode function name "invoke" wit
 
 Run a query on the chaincode to retrieve the desired values. The <b>-n</b> argument should match the value provided in the chaincode window (started in Vagrant terminal 2):
 
-    ./peer chaincode query -l golang -n mycc -c '{"Function": "query", "Args": ["b"]}'
+    ./peer chaincode query -l golang -n mycc -i '{"Function": "query", "Args": ["b"]}'
 
 The response should be similar to the following:
 
@@ -283,7 +283,7 @@ POST host:port/chaincode
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg": {
+      "input": {
          "function":"query",
          "args":["a"]
       }
@@ -306,7 +306,7 @@ POST host:port/chaincode
 
 **Note:** When security is enabled, modify the CLI command and REST API payload to pass the <b>enrollmentID</b> of a logged in user. To log in a registered user through the CLI or the REST API, follow the instructions in the [note on security functionality](#note-on-security-functionality). On the CLI, the <b>enrollmentID</b> is passed with the <b>-u</b> parameter; in the REST API, the <b>enrollmentID</b> is passed with the <b>'secureContext'</b> element:
 
-    ./peer chaincode query -u jim -l golang -n mycc -c '{"Function": "query", "Args": ["b"]}'
+    ./peer chaincode query -u jim -l golang -n mycc -i '{"Function": "query", "Args": ["b"]}'
 
 <b>REST Request:</b>
 ```
@@ -320,7 +320,7 @@ POST host:port/chaincode
       "chaincodeID":{
           "name":"mycc"
       },
-      "ctorMsg": {
+      "input": {
          "function":"query",
          "args":["a"]
       },

--- a/docs/dev-setup/devnet-setup.md
+++ b/docs/dev-setup/devnet-setup.md
@@ -76,13 +76,13 @@ Now deploy the chaincode to the network. We can deploy to any validating peer by
 
 ```
 cd $GOPATH/src/github.com/hyperledger/fabric/peer
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
 With security enabled, modify the command as follows:
 
 ```
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
 You can watch for the message "Received build request for chaincode spec" on the output screen of all validating peers.
@@ -100,25 +100,25 @@ and then replace `<name_value_returned_from_deploy_command>` in the examples bel
 We can run an invoke transaction to move 10 units from 'a' to 'b':
 
 ```
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n <name_value_returned_from_deploy_command> -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n <name_value_returned_from_deploy_command> -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 ```
 
 With security enabled, modify the command as follows:
 
 ```
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -u jim -n <name_value_returned_from_deploy_command> -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -u jim -n <name_value_returned_from_deploy_command> -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 ```
 
 We can also run a query to see the current value 'a' has:
 
 ```
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode query -l golang -n <name_value_returned_from_deploy_command> -c '{"Function": "query", "Args": ["a"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode query -l golang -n <name_value_returned_from_deploy_command> -i '{"Function": "query", "Args": ["a"]}'
 ```
 
 With security enabled, modify the command as follows:
 
 ```
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode query -u jim -l golang -n <name_value_returned_from_deploy_command> -c '{"Function": "query", "Args": ["a"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode query -u jim -l golang -n <name_value_returned_from_deploy_command> -i '{"Function": "query", "Args": ["a"]}'
 ```
 
 ### Using Consensus Plugin

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -382,7 +382,7 @@ message ChaincodeSpec {
     }
     Type type = 1;
     ChaincodeID chaincodeID = 2;
-    ChaincodeInput ctorMsg = 3;
+    ChaincodeInput input = 3;
     int32 timeout = 4;
     string secureContext = 5;
     ConfidentialityLevel confidentialityLevel = 6;
@@ -402,7 +402,7 @@ message ChaincodeInput {
 
 **Definition of fields:**
 - `chaincodeID` - The chaincode source code path and name.
-- `ctorMsg` - Function name and argument parameters to call.
+- `input` - Function name and argument parameters to call.
 - `timeout` - Time in milliseconds to execute the transaction.
 - `confidentialityLevel` - Confidentiality level of this transaction.
 - `secureContext` - Security context of the transactor.
@@ -2663,7 +2663,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "path":"github.com/hyperledger/fabic/examples/chaincode/go/chaincode_example02"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "1000", "b", "2000"]
     }
@@ -2698,7 +2698,7 @@ POST host:port/chaincode
     "chaincodeID":{
         "path":"github.com/hyperledger/fabic/examples/chaincode/go/chaincode_example02"
     },
-    "ctorMsg": {
+    "input": {
         "function":"init",
         "args":["a", "1000", "b", "2000"]
     },
@@ -2724,7 +2724,7 @@ POST host:port/chaincode
     "chaincodeID":{
       "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
     },
-  	"ctorMsg": {
+  	"input": {
     	"function":"invoke",
       	"args":["a", "b", "100"]
   	}
@@ -2757,7 +2757,7 @@ Invoke Request with security enabled:
     "chaincodeID":{
       "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
     },
-  	"ctorMsg": {
+  	"input": {
     	"function":"invoke",
       	"args":["a", "b", "100"]
   	},
@@ -2783,7 +2783,7 @@ POST host:port/chaincode/
     "chaincodeID":{
       "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
     },
-  	"ctorMsg": {
+  	"input": {
     	"function":"query",
       	"args":["a"]
   	}
@@ -2816,7 +2816,7 @@ Query Request with security enabled:
     "chaincodeID":{
       "name":"52b0d803fc395b5e34d8d4a7cd69fb6aa00099b8fabed83504ac1c5d61a425aca5b3ad3bf96643ea4fdaac132c417c37b00f88fa800de7ece387d008a76d3586"
     },
-  	"ctorMsg": {
+  	"input": {
     	"function":"query",
       	"args":["a"]
   	},
@@ -3128,13 +3128,13 @@ You can also pass a password for the user with `-p` parameter. An example is bel
 The CLI `deploy` command creates the docker image for the chaincode and subsequently deploys the package to the validating peer. An example is below.
 
 ```
-./peer chaincode deploy -p github.com/hyperledger/fabric/example/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+./peer chaincode deploy -p github.com/hyperledger/fabric/example/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
 With security enabled, the command must be modified to pass an enrollment id of a logged in user with the `-u` parameter. An example is below.
 
 ```
-./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/example/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/example/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
 #### 6.3.1.4 chaincode invoke
@@ -3142,13 +3142,13 @@ With security enabled, the command must be modified to pass an enrollment id of 
 The CLI `invoke` command executes a specified function within the target chaincode. An example is below.
 
 ```
-./peer chaincode invoke -n <name_value_returned_from_deploy_command> -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+./peer chaincode invoke -n <name_value_returned_from_deploy_command> -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 ```
 
 With security enabled, the command must be modified to pass an enrollment id of a logged in user with the `-u` parameter. An example is below.
 
 ```
-./peer chaincode invoke -u jim -n <name_value_returned_from_deploy_command> -c '{"Function": "invoke", "Args": ["a", "b", "10"]}'
+./peer chaincode invoke -u jim -n <name_value_returned_from_deploy_command> -i '{"Function": "invoke", "Args": ["a", "b", "10"]}'
 ```
 
 #### 6.3.1.5 chaincode query
@@ -3156,13 +3156,13 @@ With security enabled, the command must be modified to pass an enrollment id of 
 The CLI `query` command triggers a specified query method within the target chaincode. The response that is returned depends on the chaincode implementation. An example is below.
 
 ```
-./peer chaincode query -l golang -n <name_value_returned_from_deploy_command> -c '{"Function": "query", "Args": ["a"]}'
+./peer chaincode query -l golang -n <name_value_returned_from_deploy_command> -i '{"Function": "query", "Args": ["a"]}'
 ```
 
 With security enabled, the command must be modified to pass an enrollment id of a logged in user with the `-u` parameter. An example is below.
 
 ```
-./peer chaincode query -u jim -l golang -n <name_value_returned_from_deploy_command> -c '{"Function": "query", "Args": ["a"]}'
+./peer chaincode query -u jim -l golang -n <name_value_returned_from_deploy_command> -i '{"Function": "query", "Args": ["a"]}'
 ```
 
 

--- a/examples/chaincode/go/asset_management/app/app_internal.go
+++ b/examples/chaincode/go/asset_management/app/app_internal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/chaincode/platforms"
@@ -125,7 +126,7 @@ func deployInternal(deployer crypto.Client, adminCert crypto.CertificateHandler)
 		Type:        1,
 		ChaincodeID: &pb.ChaincodeID{Path: "github.com/hyperledger/fabric/examples/chaincode/go/asset_management"},
 		//ChaincodeID:          &pb.ChaincodeID{Name: chaincodeName},
-		CtorMsg:              &pb.ChaincodeInput{Function: "init", Args: []string{}},
+		Input:                &pb.ChaincodeInput{Function: "init", Args: []string{}},
 		Metadata:             adminCert.GetCertificate(),
 		ConfidentialityLevel: confidentialityLevel,
 	}
@@ -184,7 +185,7 @@ func assignOwnershipInternal(invoker crypto.Client, invokerCert crypto.Certifica
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: chaincodeName},
-		CtorMsg:              chaincodeInput,
+		Input:                chaincodeInput,
 		Metadata:             sigma, // Proof of identity
 		ConfidentialityLevel: confidentialityLevel,
 	}
@@ -233,7 +234,7 @@ func transferOwnershipInternal(owner crypto.Client, ownerCert crypto.Certificate
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: chaincodeName},
-		CtorMsg:              chaincodeInput,
+		ChaincodeInput:       chaincodeInput,
 		Metadata:             sigma, // Proof of identity
 		ConfidentialityLevel: confidentialityLevel,
 	}
@@ -257,7 +258,7 @@ func whoIsTheOwner(invoker crypto.Client, asset string) (transaction *pb.Transac
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: chaincodeName},
-		CtorMsg:              chaincodeInput,
+		ChaincodeInput:       chaincodeInput,
 		ConfidentialityLevel: confidentialityLevel,
 	}
 

--- a/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles_test.go
+++ b/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles_test.go
@@ -22,6 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
@@ -36,9 +40,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/grpclog"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	"reflect"
 )
@@ -161,7 +162,7 @@ func deploy(admCert crypto.CertificateHandler) error {
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
-		CtorMsg:              &pb.ChaincodeInput{Function: "init", Args: []string{}},
+		Input:                &pb.ChaincodeInput{Function: "init", Args: []string{}},
 		Metadata:             []byte("assigner"),
 		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
 	}
@@ -224,7 +225,7 @@ func assignOwnership(admCert crypto.CertificateHandler, asset string, newOwnerCe
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
-		CtorMsg:              chaincodeInput,
+		Input:                chaincodeInput,
 		Metadata:             sigma, // Proof of identity
 		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
 	}
@@ -284,7 +285,7 @@ func transferOwnership(owner crypto.Client, ownerCert crypto.CertificateHandler,
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
-		CtorMsg:              chaincodeInput,
+		Input:                chaincodeInput,
 		Metadata:             sigma, // Proof of identity
 		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
 	}
@@ -319,7 +320,7 @@ func whoIsTheOwner(asset string) ([]byte, error) {
 	spec := &pb.ChaincodeSpec{
 		Type:                 1,
 		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
-		CtorMsg:              chaincodeInput,
+		Input:                chaincodeInput,
 		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
 	}
 

--- a/examples/events/block-listener/README.md
+++ b/examples/events/block-listener/README.md
@@ -25,22 +25,20 @@ Event client should output "Event Address: 172.17.0.2:31315" and wait for events
 ## Create a deploy transaction
 Submit a transaction to deploy chaincode_example02.
 
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -i '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 
 Notice success transaction in the events client.
 
 ## Create an invoke transaction - good
 Send a valid invoke transaction to chaincode_example02.
 
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n 1edd7021ab71b766f4928a9ef91182c018dffb86fef7a4b5a5516ac590a87957e21a62d939df817f5105f524abddcddfc7b1a60d780f02d8235bd7af9db81b66 -c '{"Function":"invoke", "Args": ["a","b","10"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n 1edd7021ab71b766f4928a9ef91182c018dffb86fef7a4b5a5516ac590a87957e21a62d939df817f5105f524abddcddfc7b1a60d780f02d8235bd7af9db81b66 -i '{"Function":"invoke", "Args": ["a","b","10"]}'
 
 Notice success transaction in events client.
 
 ## Create an invoke transaction - bad
 Send an invoke transaction with invalid parameters to chaincode_example02.
 
-CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n 1edd7021ab71b766f4928a9ef91182c018dffb86fef7a4b5a5516ac590a87957e21a62d939df817f5105f524abddcddfc7b1a60d780f02d8235bd7af9db81b66 -c '{"Function":"invoke", "Args": ["a","b"]}'
+CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode invoke -n 1edd7021ab71b766f4928a9ef91182c018dffb86fef7a4b5a5516ac590a87957e21a62d939df817f5105f524abddcddfc7b1a60d780f02d8235bd7af9db81b66 -i '{"Function":"invoke", "Args": ["a","b"]}'
 
 Notice error transaction in events client.
-
-

--- a/membersrvc/ca/validity_period.go
+++ b/membersrvc/ca/validity_period.go
@@ -58,7 +58,7 @@ func updateValidityPeriod() {
 	initialize()
 
 	for {
-		chaincodeInvocation.ChaincodeSpec.CtorMsg.Args[0] = strconv.FormatInt(time.Now().Unix(), 10)
+		chaincodeInvocation.ChaincodeSpec.Input.Args[0] = strconv.FormatInt(time.Now().Unix(), 10)
 
 		err := invokeChaincode(chaincodeInvocation)
 		if err != nil && !invocationErrorAlreadyReported {
@@ -127,7 +127,7 @@ func invokeChaincode(chaincodeInvSpec *obc.ChaincodeInvocationSpec) error {
 func createChaincodeInvocation(validityPeriod string, token string) *obc.ChaincodeInvocationSpec {
 	spec := &obc.ChaincodeSpec{Type: obc.ChaincodeSpec_GOLANG,
 		ChaincodeID: &obc.ChaincodeID{Name: viper.GetString("pki.validity-period.chaincodeHash")},
-		CtorMsg: &obc.ChaincodeInput{Function: function,
+		Input: &obc.ChaincodeInput{Function: function,
 			Args: []string{validityPeriod},
 		},
 	}

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -258,7 +258,7 @@ func queryChaincode(chaincodeInvSpec *pb.ChaincodeInvocationSpec, t *testing.T) 
 func createChaincodeInvocationForQuery(arguments []string, chaincodeHash string, token string) *pb.ChaincodeInvocationSpec {
 	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG,
 		ChaincodeID: &pb.ChaincodeID{Name: chaincodeHash},
-		CtorMsg: &pb.ChaincodeInput{Function: "query",
+		Input: &pb.ChaincodeInput{Function: "query",
 			Args: arguments,
 		},
 	}

--- a/peer/main.go
+++ b/peer/main.go
@@ -165,14 +165,14 @@ var (
 
 // Chaincode-related variables.
 var (
-	chaincodeLang     string
-	chaincodeCtorJSON string
-	chaincodePath     string
-	chaincodeName     string
-	chaincodeDevMode  bool
-	chaincodeUsr      string
-	chaincodeQueryRaw bool
-	chaincodeQueryHex bool
+	chaincodeLang      string
+	chaincodeInputJSON string
+	chaincodePath      string
+	chaincodeName      string
+	chaincodeDevMode   bool
+	chaincodeUsr       string
+	chaincodeQueryRaw  bool
+	chaincodeQueryHex  bool
 )
 
 var chaincodeCmd = &cobra.Command{
@@ -279,7 +279,7 @@ func main() {
 	mainCmd.AddCommand(networkCmd)
 
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeLang, "lang", "l", "golang", fmt.Sprintf("Language the %s is written in", chainFuncName))
-	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeCtorJSON, "ctor", "c", "{}", fmt.Sprintf("Constructor message for the %s in JSON format", chainFuncName))
+	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeInputJSON, "input", "i", "{}", fmt.Sprintf("Input for the %s in JSON format", chainFuncName))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodePath, "path", "p", undefinedParamValue, fmt.Sprintf("Path to %s", chainFuncName))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeName, "name", "n", undefinedParamValue, fmt.Sprintf("Name of the chaincode returned by the deploy transaction"))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeUsr, "username", "u", undefinedParamValue, fmt.Sprintf("Username for chaincode operations when security is enabled"))
@@ -721,9 +721,9 @@ func checkChaincodeCmdParams(cmd *cobra.Command) (err error) {
 	// unmarshaled into a pb.ChaincodeInput. To better understand what's going
 	// on here with JSON parsing see http://blog.golang.org/json-and-go -
 	// Generic JSON with interface{}
-	if chaincodeCtorJSON != "{}" {
+	if chaincodeInputJSON != "{}" {
 		var f interface{}
-		err = json.Unmarshal([]byte(chaincodeCtorJSON), &f)
+		err = json.Unmarshal([]byte(chaincodeInputJSON), &f)
 		if err != nil {
 			err = fmt.Errorf("Chaincode argument error: %s", err)
 			return
@@ -773,13 +773,13 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 	}
 	// Build the spec
 	input := &pb.ChaincodeInput{}
-	if err = json.Unmarshal([]byte(chaincodeCtorJSON), &input); err != nil {
+	if err = json.Unmarshal([]byte(chaincodeInputJSON), &input); err != nil {
 		err = fmt.Errorf("Chaincode argument error: %s", err)
 		return
 	}
 	chaincodeLang = strings.ToUpper(chaincodeLang)
 	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_Type(pb.ChaincodeSpec_Type_value[chaincodeLang]),
-		ChaincodeID: &pb.ChaincodeID{Path: chaincodePath, Name: chaincodeName}, CtorMsg: input}
+		ChaincodeID: &pb.ChaincodeID{Path: chaincodePath, Name: chaincodeName}, Input: input}
 
 	// If security is enabled, add client login token
 	if core.SecurityEnabled() {
@@ -864,13 +864,13 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 	}
 	// Build the spec
 	input := &pb.ChaincodeInput{}
-	if err = json.Unmarshal([]byte(chaincodeCtorJSON), &input); err != nil {
+	if err = json.Unmarshal([]byte(chaincodeInputJSON), &input); err != nil {
 		err = fmt.Errorf("Chaincode argument error: %s", err)
 		return
 	}
 	chaincodeLang = strings.ToUpper(chaincodeLang)
 	spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_Type(pb.ChaincodeSpec_Type_value[chaincodeLang]),
-		ChaincodeID: &pb.ChaincodeID{Name: chaincodeName}, CtorMsg: input}
+		ChaincodeID: &pb.ChaincodeID{Name: chaincodeName}, Input: input}
 
 	// If security is enabled, add client login token
 	if core.SecurityEnabled() {

--- a/protos/block_test.go
+++ b/protos/block_test.go
@@ -28,16 +28,6 @@ import (
 func Test_Block_CreateNew(t *testing.T) {
 
 	chaincodePath := "contract_001"
-	/*
-		input := &pb.ChaincodeInput{Function: "invoke", Args: {"arg1","arg2"}}
-		spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG,
-			ChaincodeID: &pb.ChaincodeID{Path: chaincodePath}, CtorMsg: input}
-
-		// Build the ChaincodeInvocationSpec message
-		chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
-
-		data, err := proto.Marshal(chaincodeInvocationSpec)
-	*/
 	var data []byte
 	cidBytes, err := proto.Marshal(&ChaincodeID{Path: chaincodePath})
 	if err != nil {

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -194,7 +194,7 @@ func (*ChaincodeInput) ProtoMessage()    {}
 type ChaincodeSpec struct {
 	Type                 ChaincodeSpec_Type   `protobuf:"varint,1,opt,name=type,enum=protos.ChaincodeSpec_Type" json:"type,omitempty"`
 	ChaincodeID          *ChaincodeID         `protobuf:"bytes,2,opt,name=chaincodeID" json:"chaincodeID,omitempty"`
-	CtorMsg              *ChaincodeInput      `protobuf:"bytes,3,opt,name=ctorMsg" json:"ctorMsg,omitempty"`
+	Input                *ChaincodeInput      `protobuf:"bytes,3,opt,name=input" json:"input,omitempty"`
 	Timeout              int32                `protobuf:"varint,4,opt,name=timeout" json:"timeout,omitempty"`
 	SecureContext        string               `protobuf:"bytes,5,opt,name=secureContext" json:"secureContext,omitempty"`
 	ConfidentialityLevel ConfidentialityLevel `protobuf:"varint,6,opt,name=confidentialityLevel,enum=protos.ConfidentialityLevel" json:"confidentialityLevel,omitempty"`
@@ -212,9 +212,9 @@ func (m *ChaincodeSpec) GetChaincodeID() *ChaincodeID {
 	return nil
 }
 
-func (m *ChaincodeSpec) GetCtorMsg() *ChaincodeInput {
+func (m *ChaincodeSpec) GetInput() *ChaincodeInput {
 	if m != nil {
-		return m.CtorMsg
+		return m.Input
 	}
 	return nil
 }

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -65,7 +65,7 @@ message ChaincodeSpec {
 
     Type type = 1;
     ChaincodeID chaincodeID = 2;
-    ChaincodeInput ctorMsg = 3;
+    ChaincodeInput input = 3;
     int32 timeout = 4;
     string secureContext = 5;
     ConfidentialityLevel confidentialityLevel = 6;

--- a/protos/transaction.go
+++ b/protos/transaction.go
@@ -18,6 +18,7 @@ package protos
 
 import (
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/util"
 )
@@ -45,20 +46,7 @@ func NewTransaction(chaincodeID ChaincodeID, uuid string, function string, argum
 	transaction.ChaincodeID = data
 	transaction.Uuid = uuid
 	transaction.Timestamp = util.CreateUtcTimestamp()
-	/*
-		// Build the spec
-		spec := &pb.ChaincodeSpec{Type: pb.ChaincodeSpec_GOLANG,
-			ChaincodeID: chaincodeID, ChaincodeInput: &pb.ChaincodeInput{Function: function, Args: arguments}}
 
-		// Build the ChaincodeInvocationSpec message
-		invocation := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
-
-		data, err := proto.Marshal(invocation)
-		if err != nil {
-			return nil, fmt.Errorf("Could not marshal payload for chaincode invocation: %s", err)
-		}
-		transaction.Payload = data
-	*/
 	return transaction, nil
 }
 
@@ -76,10 +64,7 @@ func NewChaincodeDeployTransaction(chaincodeDeploymentSpec *ChaincodeDeploymentS
 		}
 		transaction.ChaincodeID = data
 	}
-	//if chaincodeDeploymentSpec.ChaincodeSpec.GetCtorMsg() != nil {
-	//	transaction.Function = chaincodeDeploymentSpec.ChaincodeSpec.GetCtorMsg().Function
-	//	transaction.Args = chaincodeDeploymentSpec.ChaincodeSpec.GetCtorMsg().Args
-	//}
+
 	data, err := proto.Marshal(chaincodeDeploymentSpec)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Error mashalling payload for chaincode deployment: %s", err))

--- a/sdk/node/protos/chaincode.proto
+++ b/sdk/node/protos/chaincode.proto
@@ -65,7 +65,7 @@ message ChaincodeSpec {
 
     Type type = 1;
     ChaincodeID chaincodeID = 2;
-    ChaincodeInput ctorMsg = 3;
+    ChaincodeInput input = 3;
     int32 timeout = 4;
     string secureContext = 5;
     ConfidentialityLevel confidentialityLevel = 6;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This change renames `ChaincodeSpec.ctor` to `ChaincodeSpec.Input` in `chaincode.proto`. This causes API changes when deploying, invoking, or querying a transaction. The changes are to the REST API, the gRPC API, and the CLI where `ctor` `c` has been renamed to `input` `i`. All documentation has been updated to reflect these changes.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

This is part of issue #1183. The goal is to have a cleaner and more understandable API. `ctorMsg` is a leftover from the days when `ChaincodeSpec` was intended to define a chaincode. At some point this was overloaded and also used for invocation. At this point, we have decided to use `ChaincodeSpec` for all elements that are common between `ChaincodeDeploymentSpec` and `ChaincodeInvocationSpec`. Specific elements will be moved to either `ChaincodeDeploymentSpec` or `ChaincodeInvocationSpec`.

While breaking API changes are unfortunate, this change should result in a better user experience over the long run.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

The tests have all been run and passed. There are no new tests because there are no feature changes. Some tests were modified to support the new API.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: sheehan@us.ibm.com
