### PR TITLE
Fix spurious TestBatchCustody test failure

### DIFF
--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -102,7 +102,11 @@ func TestBatchCustody(t *testing.T) {
 	time.Sleep(6 * time.Second)
 	net.stop()
 
-	for _, inst := range net.endpoints {
+	for i, inst := range net.endpoints {
+		// Don't care about byzantine node 0
+		if i == 0 {
+			continue
+		}
 		inst := inst.(*consumerEndpoint)
 		_, err := inst.consumer.(*obcBatch).stack.GetBlock(1)
 		if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Do not test for the state of the byzantine node.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

`TestBatchCustody` configures replica 0 to only receive messages, but to be unable to send messages.  In a sense, this is byzantine behavior.  Depending on message order, replica 0 may apply all blocks, or it may stay in a view change and not apply the transactions.  Given that replica 0 can be considered byzantine, we should not expect any specific state.  Therefore we should ignore its state when considering whether the test failed or was successful.

This test issue had been introduced in #1277.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Repeated unit tests, bdd tests.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
