### PR TITLE
fix #1455 provision: use uname -m instead of uname -p

### DIFF
--- a/scripts/provision/docker.sh
+++ b/scripts/provision/docker.sh
@@ -48,7 +48,7 @@
 # ---------------------------------------------------------------------------
 
 NAME=hyperledger/fabric-baseimage
-RELEASE=`uname -p`-$1
+RELEASE=`uname -m`-$1
 FQN=$NAME:$RELEASE
 
 CURDIR=`dirname $0`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Use `uname -m` instead of `uname -p` in the provision script.  Fixes #1455.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Some (non-vagrant) systems do not know `uname -p`.  Use `uname -m` instead in the provision script.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Ran `make clean peer`.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
