### PR TITLE
Empty array support

### DIFF
--- a/core/db/db.go
+++ b/core/db/db.go
@@ -267,7 +267,10 @@ func (openchainDB *OpenchainDB) Get(cfHandler *gorocksdb.ColumnFamilyHandle, key
 		return nil, err
 	}
 	defer slice.Free()
-	data := append([]byte(nil), slice.Data()...)
+	if slice.Data() == nil {
+		return nil, nil
+	}
+	data := makeCopy(slice.Data())
 	return data, nil
 }
 
@@ -364,4 +367,10 @@ func dirEmpty(path string) (bool, error) {
 		return true, nil
 	}
 	return false, err
+}
+
+func makeCopy(src []byte) []byte {
+	dest := make([]byte, len(src))
+	copy(dest, src)
+	return dest
 }

--- a/core/ledger/blockchain_indexes.go
+++ b/core/ledger/blockchain_indexes.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/op/go-logging"
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/protos"
+	"github.com/op/go-logging"
 	"github.com/tecbot/gorocksdb"
 )
 

--- a/core/ledger/blockchain_indexes_async_test.go
+++ b/core/ledger/blockchain_indexes_async_test.go
@@ -18,9 +18,10 @@ package ledger
 
 import (
 	"errors"
-	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"testing"
 	"time"
+
+	"github.com/hyperledger/fabric/core/ledger/testutil"
 )
 
 func TestIndexesAsync_IndexingErrorScenario(t *testing.T) {
@@ -66,7 +67,7 @@ func TestIndexesAsync_ClientWaitScenario(t *testing.T) {
 	go func() {
 		time.Sleep(2 * time.Second)
 		chain.size = chain.size - 1
-		blk,err := buildTestBlock(t)
+		blk, err := buildTestBlock(t)
 		if err != nil {
 			t.Logf("Error building test block: %s", err)
 			t.Fail()

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -207,6 +207,9 @@ func (ledger *Ledger) GetStateRangeScanIterator(chaincodeID string, startKey str
 
 // SetState sets state to given value for chaincodeID and key. Does not immideatly writes to DB
 func (ledger *Ledger) SetState(chaincodeID string, key string, value []byte) error {
+	if key == "" || value == nil {
+		return fmt.Errorf("A nil key or a nil value is not supported. key=%s, value=%#v", key, value)
+	}
 	return ledger.state.Set(chaincodeID, key, value)
 }
 

--- a/core/ledger/ledger.go
+++ b/core/ledger/ledger.go
@@ -40,8 +40,8 @@ var ledgerLogger = logging.MustGetLogger("ledger")
 type ErrorType string
 
 const (
-	//ErrorTypeWrongInput used to indicate the wrong input to ledger method
-	ErrorTypeWrongInput = ErrorType("WrongInput")
+	//ErrorTypeInvalidArgument used to indicate the invalid input to ledger method
+	ErrorTypeInvalidArgument = ErrorType("InvalidArgument")
 	//ErrorTypeOutOfBounds used to indicate that a request is out of bounds
 	ErrorTypeOutOfBounds = ErrorType("OutOfBounds")
 	//ErrorTypeResourceNotFound used to indicate if a resource is not found
@@ -238,7 +238,7 @@ func (ledger *Ledger) GetStateRangeScanIterator(chaincodeID string, startKey str
 // SetState sets state to given value for chaincodeID and key. Does not immideatly writes to DB
 func (ledger *Ledger) SetState(chaincodeID string, key string, value []byte) error {
 	if key == "" || value == nil {
-		return newLedgerError(ErrorTypeWrongInput,
+		return newLedgerError(ErrorTypeInvalidArgument,
 			fmt.Sprintf("An empty string key or a nil value is not supported. Method invoked with key='%s', value='%#v'", key, value))
 	}
 	return ledger.state.Set(chaincodeID, key, value)

--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -902,3 +902,24 @@ func TestCopyState(t *testing.T) {
 	values, _ := l.GetStateMultipleKeys("chaincodeID2", []string{"key1", "key2", "key3"}, true)
 	testutil.AssertEquals(t, values, [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")})
 }
+
+func TestLedgerEmptyArrayValue(t *testing.T) {
+	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
+	l := ledgerTestWrapper.ledger
+	l.BeginTxBatch(1)
+	l.TxBegin("txUUID")
+	l.SetState("chaincodeID1", "key1", []byte{})
+	l.TxFinished("txUUID", true)
+	tx, _ := buildTestTx(t)
+	l.CommitTxBatch(1, []*protos.Transaction{tx}, nil, nil)
+
+	value, _ := l.GetState("chaincodeID1", "key1", true)
+	if value == nil || len(value) != 0 {
+		t.Fatal("An empty array expected in value. Found = %x", value)
+	}
+
+	value, _ = l.GetState("chaincodeID1", "non-existing-key", true)
+	if value != nil {
+		t.Fatal("A nil value expected. Found = %x", value)
+	}
+}

--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -915,11 +915,11 @@ func TestLedgerEmptyArrayValue(t *testing.T) {
 
 	value, _ := l.GetState("chaincodeID1", "key1", true)
 	if value == nil || len(value) != 0 {
-		t.Fatal("An empty array expected in value. Found = %x", value)
+		t.Fatal("An empty array expected in value. Found = %#v", value)
 	}
 
 	value, _ = l.GetState("chaincodeID1", "non-existing-key", true)
 	if value != nil {
-		t.Fatal("A nil value expected. Found = %x", value)
+		t.Fatal("A nil value expected. Found = %#v", value)
 	}
 }

--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -924,7 +924,7 @@ func TestLedgerEmptyArrayValue(t *testing.T) {
 	}
 }
 
-func TestLedgerWrongInput(t *testing.T) {
+func TestLedgerInvalidInput(t *testing.T) {
 	ledgerTestWrapper := createFreshDBAndTestLedgerWrapper(t)
 	l := ledgerTestWrapper.ledger
 	l.BeginTxBatch(1)
@@ -933,8 +933,8 @@ func TestLedgerWrongInput(t *testing.T) {
 	// nil value input
 	err := l.SetState("chaincodeID1", "key1", nil)
 	ledgerErr, ok := err.(*Error)
-	if !(ok && ledgerErr.Type() == ErrorTypeWrongInput) {
-		t.Fatal("A 'LedgerError' of type 'ErrorTypeWrongInput' should have been thrown")
+	if !(ok && ledgerErr.Type() == ErrorTypeInvalidArgument) {
+		t.Fatal("A 'LedgerError' of type 'ErrorTypeInvalidArgument' should have been thrown")
 	} else {
 		t.Logf("An expected error [%s] is received", err)
 	}
@@ -942,8 +942,8 @@ func TestLedgerWrongInput(t *testing.T) {
 	// empty string key
 	err = l.SetState("chaincodeID1", "", []byte("value1"))
 	ledgerErr, ok = err.(*Error)
-	if !(ok && ledgerErr.Type() == ErrorTypeWrongInput) {
-		t.Fatal("A 'LedgerError' of type 'ErrorTypeWrongInput' should have been thrown")
+	if !(ok && ledgerErr.Type() == ErrorTypeInvalidArgument) {
+		t.Fatal("A 'LedgerError' of type 'ErrorTypeInvalidArgument' should have been thrown")
 	}
 
 	l.SetState("chaincodeID1", "key1", []byte("value1"))

--- a/core/ledger/ledger_test_exports.go
+++ b/core/ledger/ledger_test_exports.go
@@ -17,13 +17,15 @@ limitations under the License.
 package ledger
 
 import (
+	"testing"
+
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/testutil"
-	"testing"
 )
 
 var testDBWrapper = db.NewTestDBWrapper()
 
+//InitTestLedger provides a ledger for testing. This method creates a fresh db and constructs a ledger instance on that.
 func InitTestLedger(t *testing.T) *Ledger {
 	testDBWrapper.CreateFreshDB(t)
 	_, err := GetLedger()

--- a/core/ledger/statemgmt/buckettree/bucket_hash.go
+++ b/core/ledger/statemgmt/buckettree/bucket_hash.go
@@ -18,7 +18,6 @@ package buckettree
 
 import (
 	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric/core/ledger/util"
 	openchainUtil "github.com/hyperledger/fabric/core/util"
 )
 
@@ -51,7 +50,7 @@ func (c *bucketHashCalculator) computeCryptoHash() []byte {
 		c.dataNodes = nil
 	}
 	logger.Debug("Hashable content for bucket [%s]: length=%d, contentInStringForm=[%s]", c.bucketKey, len(c.hashingData), string(c.hashingData))
-	if util.IsNil(c.hashingData) {
+	if c.hashingData == nil {
 		return nil
 	}
 	return openchainUtil.ComputeCryptoHash(c.hashingData)

--- a/core/ledger/statemgmt/buckettree/bucket_hash_test.go
+++ b/core/ledger/statemgmt/buckettree/bucket_hash_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package buckettree
 
 import (
-	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/testutil"
 )
 
 func TestBucketHashCalculator(t *testing.T) {

--- a/core/ledger/statemgmt/buckettree/bucket_node.go
+++ b/core/ledger/statemgmt/buckettree/bucket_node.go
@@ -44,7 +44,8 @@ func unmarshalBucketNode(bucketKey *bucketKey, serializedBytes []byte) *bucketNo
 		if err != nil {
 			panic(fmt.Errorf("this error should not occur: %s", err))
 		}
-		if !util.IsNil(childCryptoHash) {
+		// both rocksdb and protobuf convert a nil into a zero length byte-array so nil check would not work
+		if util.NotNilOrEmpty(childCryptoHash) {
 			bucketNode.childrenCryptoHash[i] = childCryptoHash
 		}
 	}
@@ -70,7 +71,7 @@ func (bucketNode *bucketNode) mergeBucketNode(anotherBucketNode *bucketNode) {
 		panic(fmt.Errorf("Nodes with different keys can not be merged. BaseKey=[%#v], MergeKey=[%#v]", bucketNode.bucketKey, anotherBucketNode.bucketKey))
 	}
 	for i, childCryptoHash := range anotherBucketNode.childrenCryptoHash {
-		if !bucketNode.childrenUpdated[i] && util.IsNil(bucketNode.childrenCryptoHash[i]) {
+		if !bucketNode.childrenUpdated[i] {
 			bucketNode.childrenCryptoHash[i] = childCryptoHash
 		}
 	}
@@ -80,7 +81,7 @@ func (bucketNode *bucketNode) computeCryptoHash() []byte {
 	cryptoHashContent := []byte{}
 	numChildren := 0
 	for i, childCryptoHash := range bucketNode.childrenCryptoHash {
-		if util.NotNil(childCryptoHash) {
+		if childCryptoHash != nil {
 			numChildren++
 			logger.Debug("Appending crypto-hash for child bucket = [%s]", bucketNode.bucketKey.getChildKey(i))
 			cryptoHashContent = append(cryptoHashContent, childCryptoHash...)
@@ -102,7 +103,7 @@ func (bucketNode *bucketNode) computeCryptoHash() []byte {
 func (bucketNode *bucketNode) String() string {
 	numChildren := 0
 	for i := range bucketNode.childrenCryptoHash {
-		if util.NotNil(bucketNode.childrenCryptoHash[i]) {
+		if bucketNode.childrenCryptoHash[i] != nil {
 			numChildren++
 		}
 	}
@@ -114,7 +115,7 @@ func (bucketNode *bucketNode) String() string {
 	str = str + "Childern crypto-hashes:\n"
 	for i := range bucketNode.childrenCryptoHash {
 		childCryptoHash := bucketNode.childrenCryptoHash[i]
-		if util.NotNil(childCryptoHash) {
+		if childCryptoHash != nil {
 			str = str + fmt.Sprintf("childNumber={%d}, cryptoHash={%x}\n", i, childCryptoHash)
 		}
 	}

--- a/core/ledger/statemgmt/buckettree/bucket_node.go
+++ b/core/ledger/statemgmt/buckettree/bucket_node.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric/core/ledger/util"
 	openchainUtil "github.com/hyperledger/fabric/core/util"
 )
 
@@ -44,8 +43,8 @@ func unmarshalBucketNode(bucketKey *bucketKey, serializedBytes []byte) *bucketNo
 		if err != nil {
 			panic(fmt.Errorf("this error should not occur: %s", err))
 		}
-		// both rocksdb and protobuf convert a nil into a zero length byte-array so nil check would not work
-		if util.NotNilOrEmpty(childCryptoHash) {
+		//protobuf's buffer.EncodeRawBytes/buffer.DecodeRawBytes convert a nil into a zero length byte-array, so nil check would not work
+		if len(childCryptoHash) != 0 {
 			bucketNode.childrenCryptoHash[i] = childCryptoHash
 		}
 	}

--- a/core/ledger/statemgmt/buckettree/bucket_node_test.go
+++ b/core/ledger/statemgmt/buckettree/bucket_node_test.go
@@ -44,7 +44,9 @@ func TestBucketNodeMerge(t *testing.T) {
 	conf = newConfig(26, 3, fnvHash)
 	bucketNode := newBucketNode(newBucketKey(2, 7))
 	bucketNode.childrenCryptoHash[0] = []byte("cryptoHashChild1")
+	bucketNode.childrenUpdated[0] = true
 	bucketNode.childrenCryptoHash[2] = []byte("cryptoHashChild3")
+	bucketNode.childrenUpdated[2] = true
 
 	dbBucketNode := newBucketNode(newBucketKey(2, 7))
 	dbBucketNode.childrenCryptoHash[0] = []byte("DBcryptoHashChild1")

--- a/core/ledger/statemgmt/buckettree/data_node.go
+++ b/core/ledger/statemgmt/buckettree/data_node.go
@@ -18,8 +18,8 @@ package buckettree
 
 import (
 	"fmt"
+
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
-	"github.com/hyperledger/fabric/core/ledger/util"
 )
 
 type dataNode struct {
@@ -44,7 +44,7 @@ func (dataNode *dataNode) getCompositeKey() []byte {
 }
 
 func (dataNode *dataNode) isDelete() bool {
-	return util.IsNil(dataNode.value)
+	return dataNode.value == nil
 }
 
 func (dataNode *dataNode) getKeyElements() (string, string) {

--- a/core/ledger/statemgmt/buckettree/db_helper.go
+++ b/core/ledger/statemgmt/buckettree/db_helper.go
@@ -28,7 +28,13 @@ func fetchDataNodeFromDB(dataKey *dataKey) (*dataNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	if util.IsNil(nodeBytes) {
+	if nodeBytes == nil {
+		logger.Debug("nodeBytes from db is nil")
+	} else if len(nodeBytes) == 0 {
+		logger.Debug("nodeBytes from db is an empty array")
+	}
+	// key does not exist
+	if nodeBytes == nil {
 		return nil, nil
 	}
 	return unmarshalDataNode(dataKey, nodeBytes), nil
@@ -40,7 +46,7 @@ func fetchBucketNodeFromDB(bucketKey *bucketKey) (*bucketNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	if util.IsNil(nodeBytes) {
+	if util.NilOrEmpty(nodeBytes) {
 		return nil, nil
 	}
 	return unmarshalBucketNode(bucketKey, nodeBytes), nil

--- a/core/ledger/statemgmt/buckettree/db_helper.go
+++ b/core/ledger/statemgmt/buckettree/db_helper.go
@@ -19,7 +19,6 @@ package buckettree
 import (
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
-	"github.com/hyperledger/fabric/core/ledger/util"
 )
 
 func fetchDataNodeFromDB(dataKey *dataKey) (*dataNode, error) {
@@ -46,7 +45,7 @@ func fetchBucketNodeFromDB(bucketKey *bucketKey) (*bucketNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	if util.NilOrEmpty(nodeBytes) {
+	if nodeBytes == nil {
 		return nil, nil
 	}
 	return unmarshalBucketNode(bucketKey, nodeBytes), nil

--- a/core/ledger/statemgmt/buckettree/state_impl.go
+++ b/core/ledger/statemgmt/buckettree/state_impl.go
@@ -240,8 +240,10 @@ func (stateImpl *StateImpl) addDataNodeChangesForPersistence(writeBatch *gorocks
 		dataNodes := stateImpl.dataNodesDelta.getSortedDataNodesFor(affectedBucket)
 		for _, dataNode := range dataNodes {
 			if dataNode.isDelete() {
+				logger.Debug("Deleting data node key = %#v", dataNode.dataKey)
 				writeBatch.DeleteCF(openchainDB.StateCF, dataNode.dataKey.getEncodedBytes())
 			} else {
+				logger.Debug("Adding data node with value = %#v", dataNode.value)
 				writeBatch.PutCF(openchainDB.StateCF, dataNode.dataKey.getEncodedBytes(), dataNode.value)
 			}
 		}

--- a/core/ledger/statemgmt/buckettree/state_impl_test.go
+++ b/core/ledger/statemgmt/buckettree/state_impl_test.go
@@ -380,3 +380,21 @@ func TestStateImpl_DB_Changes(t *testing.T) {
 	bucketNodeFromDB, _ = fetchBucketNodeFromDB(newBucketKey(2, 3))
 	testutil.AssertNil(t, bucketNodeFromDB)
 }
+
+func TestStateImpl_DB_EmptyArrayValues(t *testing.T) {
+	testDBWrapper.CreateFreshDB(t)
+	stateImplTestWrapper := newStateImplTestWrapper(t)
+	stateImpl := stateImplTestWrapper.stateImpl
+	stateDelta := statemgmt.NewStateDelta()
+	stateDelta.Set("chaincode1", "key1", []byte{}, nil)
+	stateImpl.PrepareWorkingSet(stateDelta)
+	stateImplTestWrapper.persistChangesAndResetInMemoryChanges()
+	emptyBytes := stateImplTestWrapper.get("chaincode1", "key1")
+	if emptyBytes == nil || len(emptyBytes) != 0 {
+		t.Fatalf("Expected an empty byte array. found = %#v", emptyBytes)
+	}
+	nilVal := stateImplTestWrapper.get("chaincodeID3", "non-existing-key")
+	if nilVal != nil {
+		t.Fatalf("Expected a nil. found = %#v", nilVal)
+	}
+}

--- a/core/ledger/statemgmt/perf_test.go
+++ b/core/ledger/statemgmt/perf_test.go
@@ -18,9 +18,10 @@ package statemgmt
 
 import (
 	"flag"
+	"testing"
+
 	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"github.com/hyperledger/fabric/core/util"
-	"testing"
 )
 
 func BenchmarkCryptoHash(b *testing.B) {

--- a/core/ledger/statemgmt/pkg_test.go
+++ b/core/ledger/statemgmt/pkg_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package statemgmt
 
 import (
-	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"os"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/testutil"
 )
 
 var testParams []string

--- a/core/ledger/statemgmt/state/config.go
+++ b/core/ledger/statemgmt/state/config.go
@@ -30,7 +30,7 @@ var stateImplConfigs map[string]interface{}
 var deltaHistorySize int
 
 func initConfig() {
-	loadConfigOnce.Do(func(){loadConfig()})
+	loadConfigOnce.Do(func() { loadConfig() })
 }
 
 func loadConfig() {

--- a/core/ledger/statemgmt/state/state.go
+++ b/core/ledger/statemgmt/state/state.go
@@ -194,7 +194,7 @@ func (state *State) CopyState(sourceChaincodeID string, destChaincodeID string) 
 	for itr.Next() {
 		k, v := itr.GetKeyValue()
 		err := state.Set(destChaincodeID, k, v)
-		if err != nil{
+		if err != nil {
 			return err
 		}
 	}
@@ -204,9 +204,9 @@ func (state *State) CopyState(sourceChaincodeID string, destChaincodeID string) 
 // GetMultipleKeys returns the values for the multiple keys.
 func (state *State) GetMultipleKeys(chaincodeID string, keys []string, committed bool) ([][]byte, error) {
 	var values [][]byte
-	for _,k := range keys{
+	for _, k := range keys {
 		v, err := state.Get(chaincodeID, k, committed)
-		if err != nil{
+		if err != nil {
 			return nil, err
 		}
 		values = append(values, v)
@@ -216,9 +216,9 @@ func (state *State) GetMultipleKeys(chaincodeID string, keys []string, committed
 
 // SetMultipleKeys sets the values for the multiple keys.
 func (state *State) SetMultipleKeys(chaincodeID string, kvs map[string][]byte) error {
-	for k,v := range kvs{
+	for k, v := range kvs {
 		err := state.Set(chaincodeID, k, v)
-		if err != nil{
+		if err != nil {
 			return err
 		}
 	}

--- a/core/ledger/statemgmt/state/state_snapshot_test.go
+++ b/core/ledger/statemgmt/state/state_snapshot_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package state
 
 import (
-	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/testutil"
 )
 
 func TestStateSnapshot(t *testing.T) {

--- a/core/ledger/statemgmt/state_delta.go
+++ b/core/ledger/statemgmt/state_delta.go
@@ -168,7 +168,7 @@ func (stateDelta *StateDelta) ComputeCryptoHash() []byte {
 	return util.ComputeCryptoHash(hashingContent)
 }
 
-// Code below is for maintaining state for a chaincode
+//ChaincodeStateDelta maintains state for a chaincode
 type ChaincodeStateDelta struct {
 	ChaincodeID string
 	UpdatedKVs  map[string]*UpdatedValue
@@ -264,26 +264,38 @@ func (stateDelta *StateDelta) Marshal() (b []byte) {
 func (chaincodeStateDelta *ChaincodeStateDelta) marshal(buffer *proto.Buffer) {
 	err := buffer.EncodeVarint(uint64(len(chaincodeStateDelta.UpdatedKVs)))
 	if err != nil {
-		// in protobuf code the error return is always nil
 		panic(fmt.Errorf("This error should not occur: %s", err))
 	}
 	for key, valueHolder := range chaincodeStateDelta.UpdatedKVs {
 		err = buffer.EncodeStringBytes(key)
 		if err != nil {
-			return
-		}
-		err = buffer.EncodeRawBytes(valueHolder.Value)
-		if err != nil {
-			// in protobuf code the error return is always nil
 			panic(fmt.Errorf("This error should not occur: %s", err))
 		}
-		err = buffer.EncodeRawBytes(valueHolder.PreviousValue)
-		if err != nil {
-			// in protobuf code the error return is always nil
-			panic(fmt.Errorf("This error should not occur: %s", err))
-		}
+		chaincodeStateDelta.marshalValueWithMarker(buffer, valueHolder.Value)
+		chaincodeStateDelta.marshalValueWithMarker(buffer, valueHolder.PreviousValue)
 	}
 	return
+}
+
+func (chaincodeStateDelta *ChaincodeStateDelta) marshalValueWithMarker(buffer *proto.Buffer, value []byte) {
+	if value == nil {
+		// Just add a marker that the value is nil
+		err := buffer.EncodeVarint(uint64(0))
+		if err != nil {
+			panic(fmt.Errorf("This error should not occur: %s", err))
+		}
+		return
+	}
+	err := buffer.EncodeVarint(uint64(1))
+	if err != nil {
+		panic(fmt.Errorf("This error should not occur: %s", err))
+	}
+	// If the value happen to be an empty byte array, it would appear as a nil during
+	// deserialization - see method 'unmarshalValueWithMarker'
+	err = buffer.EncodeRawBytes(value)
+	if err != nil {
+		panic(fmt.Errorf("This error should not occur: %s", err))
+	}
 }
 
 // Unmarshal deserializes StateDelta
@@ -321,30 +333,34 @@ func (chaincodeStateDelta *ChaincodeStateDelta) unmarshal(buffer *proto.Buffer) 
 		if err != nil {
 			return fmt.Errorf("Error unmarshaling state delta : %s", err)
 		}
-		value, err := buffer.DecodeRawBytes(false)
+		value, err := chaincodeStateDelta.unmarshalValueWithMarker(buffer)
 		if err != nil {
 			return fmt.Errorf("Error unmarshaling state delta : %s", err)
 		}
-
-		// protobuff does not differentiate between an empty []byte or a nil
-		// For now we assume user does not have a motivation to store []byte array
-		// as a value for a key and we treat an empty []byte represent that the value was nil
-		// during marshalling (i.e., the entry represent a delete of a key)
-		// If we need to differentiate, we need to write a flag during marshalling
-		//(which would require one bool per keyvalue entry)
-		if len(value) == 0 {
-			value = nil
-		}
-
-		previousValue, err := buffer.DecodeRawBytes(false)
+		previousValue, err := chaincodeStateDelta.unmarshalValueWithMarker(buffer)
 		if err != nil {
-			return fmt.Errorf("Error unmarhsaling state delta : %s", err)
+			return fmt.Errorf("Error unmarshaling state delta : %s", err)
 		}
-		if len(previousValue) == 0 {
-			previousValue = nil
-		}
-
 		chaincodeStateDelta.UpdatedKVs[key] = &UpdatedValue{value, previousValue}
 	}
 	return nil
+}
+
+func (chaincodeStateDelta *ChaincodeStateDelta) unmarshalValueWithMarker(buffer *proto.Buffer) ([]byte, error) {
+	valueMarker, err := buffer.DecodeVarint()
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling state delta : %s", err)
+	}
+	if valueMarker == 0 {
+		return nil, nil
+	}
+	value, err := buffer.DecodeRawBytes(false)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarhsaling state delta : %s", err)
+	}
+	// protobuff makes an empty []byte into a nil. So, assigning an empty byte array explicitly
+	if value == nil {
+		value = []byte{}
+	}
+	return value, nil
 }

--- a/core/ledger/statemgmt/state_delta_test.go
+++ b/core/ledger/statemgmt/state_delta_test.go
@@ -50,3 +50,29 @@ func TestStateDeltaCryptoHash(t *testing.T) {
 	stateDelta.Delete("chaincodeID2", "key1", nil)
 	testutil.AssertEquals(t, stateDelta.ComputeCryptoHash(), testutil.ComputeCryptoHash([]byte("chaincodeID1key1value1key2value2chaincodeID2key1key2value2")))
 }
+
+func TestStateDeltaEmptyArrayValue(t *testing.T) {
+	stateDelta := NewStateDelta()
+	stateDelta.Set("chaincode1", "key1", []byte("value1"), nil)
+	stateDelta.Set("chaincode2", "key2", []byte{}, nil)
+	stateDelta.Set("chaincode3", "key3", nil, nil)
+	stateDelta.Set("chaincode4", "", []byte("value4"), nil)
+
+	by := stateDelta.Marshal()
+	t.Logf("length of marshalled bytes = [%d]", len(by))
+	stateDelta1 := NewStateDelta()
+	stateDelta1.Unmarshal(by)
+
+	v := stateDelta1.Get("chaincode2", "key2")
+	if v.GetValue() == nil || len(v.GetValue()) > 0 {
+		t.Fatalf("An empty array expected. found = %#v", v)
+	}
+
+	v = stateDelta1.Get("chaincode3", "key3")
+	if v.GetValue() != nil {
+		t.Fatalf("Nil value expected. found = %#v", v)
+	}
+
+	v = stateDelta1.Get("chaincode4", "")
+	testutil.AssertEquals(t, v.GetValue(), []byte("value4"))
+}

--- a/core/ledger/statemgmt/trie/range_scan_iterator.go
+++ b/core/ledger/statemgmt/trie/range_scan_iterator.go
@@ -19,7 +19,6 @@ package trie
 import (
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
-	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/tecbot/gorocksdb"
 )
 
@@ -52,7 +51,7 @@ func (itr *RangeScanIterator) Next() bool {
 		trieKeyBytes := statemgmt.Copy(itr.dbItr.Key().Data())
 		trieNodeBytes := statemgmt.Copy(itr.dbItr.Value().Data())
 		value := unmarshalTrieNodeValue(trieNodeBytes)
-		if util.IsNil(value) {
+		if value == nil {
 			continue
 		}
 

--- a/core/ledger/statemgmt/trie/snapshot_iterator.go
+++ b/core/ledger/statemgmt/trie/snapshot_iterator.go
@@ -19,7 +19,6 @@ package trie
 import (
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
-	"github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/tecbot/gorocksdb"
 )
 
@@ -48,7 +47,7 @@ func (snapshotItr *StateSnapshotIterator) Next() bool {
 		trieKeyBytes := statemgmt.Copy(snapshotItr.dbItr.Key().Data())
 		trieNodeBytes := statemgmt.Copy(snapshotItr.dbItr.Value().Data())
 		value := unmarshalTrieNodeValue(trieNodeBytes)
-		if util.NotNil(value) {
+		if value != nil {
 			snapshotItr.currentKey = trieKeyEncoderImpl.decodeTrieKeyBytes(statemgmt.Copy(trieKeyBytes))
 			snapshotItr.currentValue = value
 			available = true

--- a/core/ledger/statemgmt/trie/state_trie.go
+++ b/core/ledger/statemgmt/trie/state_trie.go
@@ -19,9 +19,9 @@ package trie
 import (
 	"fmt"
 
-	"github.com/op/go-logging"
 	"github.com/hyperledger/fabric/core/db"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
+	"github.com/op/go-logging"
 	"github.com/tecbot/gorocksdb"
 )
 

--- a/core/ledger/statemgmt/trie/state_trie_test.go
+++ b/core/ledger/statemgmt/trie/state_trie_test.go
@@ -42,6 +42,7 @@ func TestStateTrie_ComputeHash_AllInMemory(t *testing.T) {
 	stateDelta.Set("chaincodeID1", "key2", []byte("value2"), nil)
 	stateDelta.Set("chaincodeID2", "key3", []byte("value3"), nil)
 	stateDelta.Set("chaincodeID2", "key4", []byte("value4"), nil)
+	stateTrieTestWrapper.PrepareWorkingSetAndComputeCryptoHash(stateDelta)
 	rootHash1 := stateTrieTestWrapper.PrepareWorkingSetAndComputeCryptoHash(stateDelta)
 
 	hash1 := expectedCryptoHashForTest(newTrieKey("chaincodeID1", "key1"), []byte("value1"))
@@ -55,7 +56,7 @@ func TestStateTrie_ComputeHash_AllInMemory(t *testing.T) {
 	testutil.AssertEquals(t, rootHash1, expectedRootHash1)
 	stateTrie.ClearWorkingSet(true)
 
-	// Test2 - Add one more key
+	//Test2 - Add one more key
 	t.Logf("-- Add one more key exiting key --- ")
 	stateDelta.Set("chaincodeID3", "key5", []byte("value5"), nil)
 	rootHash2 := stateTrieTestWrapper.PrepareWorkingSetAndComputeCryptoHash(stateDelta)
@@ -82,9 +83,19 @@ func TestStateTrie_GetSet_WithDB(t *testing.T) {
 	stateDelta.Set("chaincodeID1", "key2", []byte("value2"), nil)
 	stateDelta.Set("chaincodeID2", "key3", []byte("value3"), nil)
 	stateDelta.Set("chaincodeID2", "key4", []byte("value4"), nil)
+	stateDelta.Set("chaincodeID3", "key5", []byte{}, nil)
 	stateTrieTestWrapper.PrepareWorkingSetAndComputeCryptoHash(stateDelta)
 	stateTrieTestWrapper.PersistChangesAndResetInMemoryChanges()
 	testutil.AssertEquals(t, stateTrieTestWrapper.Get("chaincodeID1", "key1"), []byte("value1"))
+
+	emptyBytes := stateTrieTestWrapper.Get("chaincodeID3", "key5")
+	if emptyBytes == nil || len(emptyBytes) != 0 {
+		t.Fatalf("Expected an empty byte array. found = %#v", emptyBytes)
+	}
+	nilVal := stateTrieTestWrapper.Get("chaincodeID3", "non-existing-key")
+	if nilVal != nil {
+		t.Fatalf("Expected a nil. found = %#v", nilVal)
+	}
 }
 
 func TestStateTrie_ComputeHash_WithDB_Spread_Keys(t *testing.T) {

--- a/core/ledger/statemgmt/trie/trie_db_helper.go
+++ b/core/ledger/statemgmt/trie/trie_db_helper.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package trie
 
-import (
-	"github.com/hyperledger/fabric/core/db"
-	"github.com/hyperledger/fabric/core/ledger/util"
-)
+import "github.com/hyperledger/fabric/core/db"
 
 func fetchTrieNodeFromDB(key *trieKey) (*trieNode, error) {
 	stateTrieLogger.Debug("Enter fetchTrieNodeFromDB() for trieKey [%s]", key)
@@ -30,7 +27,7 @@ func fetchTrieNodeFromDB(key *trieKey) (*trieNode, error) {
 		return nil, err
 	}
 
-	if util.NilOrEmpty(trieNodeBytes) {
+	if trieNodeBytes == nil {
 		return nil, nil
 	}
 

--- a/core/ledger/statemgmt/trie/trie_db_helper.go
+++ b/core/ledger/statemgmt/trie/trie_db_helper.go
@@ -18,6 +18,7 @@ package trie
 
 import (
 	"github.com/hyperledger/fabric/core/db"
+	"github.com/hyperledger/fabric/core/ledger/util"
 )
 
 func fetchTrieNodeFromDB(key *trieKey) (*trieNode, error) {
@@ -29,7 +30,7 @@ func fetchTrieNodeFromDB(key *trieKey) (*trieNode, error) {
 		return nil, err
 	}
 
-	if trieNodeBytes == nil {
+	if util.NilOrEmpty(trieNodeBytes) {
 		return nil, nil
 	}
 

--- a/core/ledger/statemgmt/trie/trie_node.go
+++ b/core/ledger/statemgmt/trie/trie_node.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 
 	"github.com/golang/protobuf/proto"
-	ledgerUtil "github.com/hyperledger/fabric/core/ledger/util"
 	"github.com/hyperledger/fabric/core/util"
 )
 
@@ -128,21 +127,30 @@ func (trieNode *trieNode) containsValue() bool {
 	if trieNode.isRootNode() {
 		return false
 	}
-	return ledgerUtil.NotNil(trieNode.value)
+	return trieNode.value != nil
 }
 
 func (trieNode *trieNode) marshal() ([]byte, error) {
 	buffer := proto.NewBuffer([]byte{})
 
-	// write value
-	err := buffer.EncodeRawBytes(trieNode.value)
+	// write value marker explicitly because rocksdb apis convertes a nil into an empty array and protobuf does it other-way around
+	var valueMarker uint64 = 0
+	if trieNode.value != nil {
+		valueMarker = 1
+	}
+	err := buffer.EncodeVarint(valueMarker)
 	if err != nil {
 		return nil, err
 	}
-
-	numCryptoHashes := trieNode.getNumChildren()
-
+	if trieNode.value != nil {
+		// write value
+		err = buffer.EncodeRawBytes(trieNode.value)
+		if err != nil {
+			return nil, err
+		}
+	}
 	//write number of crypto-hashes
+	numCryptoHashes := trieNode.getNumChildren()
 	err = buffer.EncodeVarint(uint64(numCryptoHashes))
 	if err != nil {
 		return nil, err
@@ -164,23 +172,22 @@ func (trieNode *trieNode) marshal() ([]byte, error) {
 			return nil, err
 		}
 	}
-	return buffer.Bytes(), nil
+	serializedBytes := buffer.Bytes()
+	stateTrieLogger.Debug("Marshalled trieNode [%s]. Serialized bytes size = %d", trieNode.trieKey, len(serializedBytes))
+	return serializedBytes, nil
 }
 
 func unmarshalTrieNode(key *trieKey, serializedContent []byte) (*trieNode, error) {
+	stateTrieLogger.Debug("key = [%s], len(serializedContent) = %d", key, len(serializedContent))
 	trieNode := newTrieNode(key, nil, false)
 	buffer := proto.NewBuffer(serializedContent)
-	value, err := buffer.DecodeRawBytes(false)
-	if err != nil {
-		return nil, err
-	}
-	trieNode.value = value
+	trieNode.value = unmarshalTrieNodeValueFromBuffer(buffer)
 
 	numCryptoHashes, err := buffer.DecodeVarint()
+	stateTrieLogger.Debug("numCryptoHashes = [%d]", numCryptoHashes)
 	if err != nil {
 		return nil, err
 	}
-
 	for i := uint64(0); i < numCryptoHashes; i++ {
 		index, err := buffer.DecodeVarint()
 		if err != nil {
@@ -192,11 +199,22 @@ func unmarshalTrieNode(key *trieKey, serializedContent []byte) (*trieNode, error
 		}
 		trieNode.childrenCryptoHashes[int(index)] = cryptoHash
 	}
+	stateTrieLogger.Debug("unmarshalled trieNode = [%s]", trieNode)
 	return trieNode, nil
 }
 
 func unmarshalTrieNodeValue(serializedContent []byte) []byte {
-	buffer := proto.NewBuffer(serializedContent)
+	return unmarshalTrieNodeValueFromBuffer(proto.NewBuffer(serializedContent))
+}
+
+func unmarshalTrieNodeValueFromBuffer(buffer *proto.Buffer) []byte {
+	valueMarker, err := buffer.DecodeVarint()
+	if err != nil {
+		panic(fmt.Errorf("This error is not excpected: %s", err))
+	}
+	if valueMarker == 0 {
+		return nil
+	}
 	value, err := buffer.DecodeRawBytes(false)
 	if err != nil {
 		panic(fmt.Errorf("This error is not excpected: %s", err))

--- a/core/ledger/statemgmt/trie/trie_node_test.go
+++ b/core/ledger/statemgmt/trie/trie_node_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package trie
 
 import (
-	"github.com/hyperledger/fabric/core/ledger/testutil"
 	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/testutil"
 )
 
 func TestTrieNode_MarshalUnmarshal_NoValue_NoChildren(t *testing.T) {

--- a/core/ledger/testutil/test_util.go
+++ b/core/ledger/testutil/test_util.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/op/go-logging"
 	"github.com/hyperledger/fabric/core/util"
+	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 )
 

--- a/core/ledger/util/util.go
+++ b/core/ledger/util/util.go
@@ -23,16 +23,6 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//IsNilOrEmpty returns true if b is either nil or zero-length array
-func NilOrEmpty(b []byte) bool {
-	return b == nil || len(b) == 0
-}
-
-//NotNilOrEmpty returns true if b is a non-zero length array
-func NotNilOrEmpty(b []byte) bool {
-	return !NilOrEmpty(b)
-}
-
 // EncodeOrderPreservingVarUint64 returns a byte-representation for a uint64 number such that
 // all zero-bits starting bytes are trimmed in order to reduce the length of the array
 // For preserving the order in a default bytes-comparision, first byte contains the number of remaining bytes.

--- a/core/ledger/util/util.go
+++ b/core/ledger/util/util.go
@@ -23,14 +23,14 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// IsNil returns true if b is either nil or zero-length array
-func IsNil(b []byte) bool {
+//IsNilOrEmpty returns true if b is either nil or zero-length array
+func NilOrEmpty(b []byte) bool {
 	return b == nil || len(b) == 0
 }
 
-// NotNil returns true if b is a non-zero length array
-func NotNil(b []byte) bool {
-	return !IsNil(b)
+//NotNilOrEmpty returns true if b is a non-zero length array
+func NotNilOrEmpty(b []byte) bool {
+	return !NilOrEmpty(b)
 }
 
 // EncodeOrderPreservingVarUint64 returns a byte-representation for a uint64 number such that


### PR DESCRIPTION
This PR allows storing an empty array as a value of a key in the ledger. However, an attempt to store a 'nil' would result in an error - see issue# 936
Signed-off-by:manishsethi@in.ibm.com
