### PR TITLE
Repository name fix for Travis CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 before_script:
 
  - echo " CREATING BASE IMAGE "
- - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME
+ - cd $HOME/gopath/src/github.com/$USER_NAME/$REPO_NAME/scripts && chmod +x foldercopy.sh && ./foldercopy.sh $TR_PULL_REQUEST $USER_NAME $REPO_NAME
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - cd /$HOME/gopath/src/github.com/hyperledger/fabric
  - make unit-test

--- a/scripts/containerlogs.sh
+++ b/scripts/containerlogs.sh
@@ -19,5 +19,5 @@ echo "$file"
 cat $file | curl -sT - chunk.io
 
 done
-
+echo " >>>>> testsummary log file <<<< "
 cat testsummary.log | curl -sT - chunk.io

--- a/scripts/foldercopy.sh
+++ b/scripts/foldercopy.sh
@@ -1,9 +1,31 @@
 #!/bin/bash
+
 if [ "$1" = "false" ] && [ "$2" != "hyperledger" ]; then
+	
+	echo " Pull Request number is $1 "
+	echo " User Name is $2 "
+	echo " Repository Name is $3 "
+
 rm -rf $HOME/gopath/src/github.com/hyperledger/
-echo "Deleted hyperledger folder"
-cp -r $HOME/gopath/src/github.com/$2 $HOME/gopath/src/github.com/hyperledger
-echo "Copied User Directory into hyperledger"
+	
+	echo "creating fabric folder to copy files"
+
+mkdir -p $HOME/gopath/src/github.com/hyperledger/fabric
+
+	echo "hyperledger/fabric folder created"
+
+cp -r $HOME/gopath/src/github.com/$2/$3/* $HOME/gopath/src/github.com/hyperledger/fabric/
+
+	echo "Copied $2 files into hyperledger/fabric folder"
+
 elif [ "$2" != "hyperledger" ]; then
-mv $HOME/gopath/src/github.com/$2 $HOME/gopath/src/github.com/hyperledger
+
+mkdir -p $HOME/gopath/src/github.com/hyperledger/fabric
+
+	echo "hyperledger/fabric folder created"
+
+cp -r $HOME/gopath/src/github.com/$2/$3/* $HOME/gopath/src/github.com/hyperledger/fabric/
+	
+	echo "copied $2 user repo into hyperledger/fabric folder"
+
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR provides fix to support Travis CI build process for any repository name forked from hyperledger/fabric.
## Description

<!--- Describe your changes in detail. -->

Passing $REPO_NAME to foldercopy.sh script to copy files from user repository to hyperledger/fabric folder.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #
For Errored Travis Build Results with no such file or directory error message (Travis CI now supports any repository name) Previously it was hard coded to fabric.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Tested this PR with (rameshthoomu/hyperledger-fabric) repository name and worked as expected in Travis.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X ] Either no new documentation is required by this change, OR I added new documentation
- [ ] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Ramesh Babu Thoomu thoomu@us.ibm.com
