### PR TITLE
correctly parse docker output from z debian systems in behave functions

### DIFF
--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -49,9 +49,16 @@ def parseComposeOutput(context):
     containerNamePrefix = os.path.basename(os.getcwd()) + "_"
     containerNames = []
     for l in context.compose_error.splitlines():
-    	print(l.split())
-    	containerNames.append(l.split()[1])
+        tokens = l.split()
+        print(tokens)
+        if 1 < len(tokens):
+            thisContainer = tokens[1]
+            if containerNamePrefix not in thisContainer:
+               thisContainer = containerNamePrefix + thisContainer + "_1"
+            if thisContainer not in containerNames:
+               containerNames.append(thisContainer)
 
+    print("Containers started: ")
     print(containerNames)
     # Now get the Network Address for each name, and set the ContainerData onto the context.
     containerDataList = []
@@ -100,6 +107,9 @@ def buildUrl(context, ipAddress, path):
     if 'TLS' in context.tags:
         schema = "https"
     return "{0}://{1}:{2}{3}".format(schema, ipAddress, CORE_REST_PORT, path)
+
+def currentTime():
+    return time.strftime("%H:%M:%S")
 
 def getDockerComposeFileArgsFromYamlFile(compose_yaml):
     parts = compose_yaml.split()
@@ -240,7 +250,7 @@ def invokeChaincode(context, devopsFunc, functionName, containerName):
     }
     ipAddress = ipFromContainerNamePart(containerName, context.compose_containers)
     request_url = buildUrl(context, ipAddress, "/devops/{0}".format(devopsFunc))
-    print("POSTing path = {0}".format(request_url))
+    print("{0} POSTing path = {1}".format(currentTime(), request_url))
 
     resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeInvocationSpec), verify=False)
     assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
@@ -266,7 +276,7 @@ def step_impl(context, seconds, containerName):
     assert 'transactionID' in context, "transactionID not found in context"
     ipAddress = ipFromContainerNamePart(containerName, context.compose_containers)
     request_url = buildUrl(context, ipAddress, "/transactions/{0}".format(context.transactionID))
-    print("GETing path = {0}".format(request_url))
+    print("{0} GETing path = {1}".format(currentTime(), request_url))
 
     resp = requests.get(request_url, headers={'Accept': 'application/json'}, verify=False)
     assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
@@ -284,7 +294,7 @@ def multiRequest(context, seconds, containerDataList, pathBuilderFunc):
 
         # Loop unless failure or time exceeded
         while (datetime.now() < maxTime):
-            print("GETing path = {0}".format(request_url))
+            print("{0} GETing path = {1}".format(currentTime(), request_url))
             resp = requests.get(request_url, headers={'Accept': 'application/json'}, verify=False)
             respMap[container.containerName] = resp
         else:
@@ -306,7 +316,7 @@ def step_impl(context, seconds):
 
         # Loop unless failure or time exceeded
         while (datetime.now() < maxTime):
-            print("GETing path = {0}".format(request_url))
+            print("{0} GETing path = {1}".format(currentTime(), request_url))
             resp = requests.get(request_url, headers={'Accept': 'application/json'}, verify=False)
             if resp.status_code == 404:
                 # Pause then try again
@@ -357,7 +367,7 @@ def step_impl(context, seconds):
 
         # Loop unless failure or time exceeded
         while (datetime.now() < maxTime):
-            print("GETing path = {0}".format(request_url))
+            print("{0} GETing path = {1}".format(currentTime(), request_url))
             resp = requests.get(request_url, headers={'Accept': 'application/json'}, verify=False)
             if resp.status_code == 404:
                 # Pause then try again
@@ -395,7 +405,7 @@ def step_impl(context, chaincodeName, functionName):
     responses = []
     for container in context.compose_containers:
         request_url = buildUrl(context, container.ipAddress, "/devops/{0}".format(functionName))
-        print("POSTing path = {0}".format(request_url))
+        print("{0} POSTing path = {1}".format(currentTime(), request_url))
         resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeInvocationSpec), verify=False)
         assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
         responses.append(resp)
@@ -426,7 +436,7 @@ def step_impl(context, chaincodeName, functionName, value):
         chaincodeInvocationSpec['chaincodeSpec']["secureContext"] = context.peerToSecretMessage[container.composeService]['enrollId']
         print("Container {0} enrollID = {1}".format(container.containerName, container.getEnv("CORE_SECURITY_ENROLLID")))
         request_url = buildUrl(context, container.ipAddress, "/devops/{0}".format(functionName))
-        print("POSTing path = {0}".format(request_url))
+        print("{0} POSTing path = {1}".format(currentTime(), request_url))
         resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeInvocationSpec), timeout=30, verify=False)
         assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
         print("RESULT from {0} of chaincode from peer {1}".format(functionName, container.containerName))
@@ -473,7 +483,7 @@ def step_impl(context, userName, secret):
     # Login to each container specified
     for ipAddress in ipAddressList:
         request_url = buildUrl(context, ipAddress, "/registrar")
-        print("POSTing path = {0}".format(request_url))
+        print("{0} POSTing path = {1}".format(currentTime(), request_url))
 
         resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(secretMsg), verify=False)
         assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
@@ -527,7 +537,7 @@ def step_impl(context):
        assert context.compose_returncode == 0, "docker-compose failed to stop {0}".format(service)
        #remove from the containerDataList
        context.compose_containers = [containerData for  containerData in context.compose_containers if containerData.composeService != service]
-    print("After stopping, the container serive list is = {0}".format([containerData.composeService for  containerData in context.compose_containers]))
+    print("After stopping, the container service list is = {0}".format([containerData.composeService for  containerData in context.compose_containers]))
 
 @given(u'I start peers')
 def step_impl(context):


### PR DESCRIPTION
## Description
- Correctly parse docker-compose output to pull container names when stopping/restarting peers. 
- add timestamp when printing out REST calls
## Motivation and Context

on certain z systems running debian ( @gongsu832 ) , we get an indexError message when running testcase @issue1000.
This is because when behave uses docker-compose to stop and restart the peers as part of the test, docker will return an output string with a different format from what is returned in a Vagrant/Ubuntu system. Behave will fail as it cannot parse the container names correctly.
This fixes an interim problem while investigating #1466
## How Has This Been Tested?

`behave` tests run on vagrant and z systems
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Tuan Dang tdang@us.ibm.com
