### PR TITLE
Remove debug message#issue1479

### DIFF
--- a/core/container/util/writer.go
+++ b/core/container/util/writer.go
@@ -69,7 +69,6 @@ func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 		newPath := fmt.Sprintf("src%s", path[rootDirLen:])
 		//newPath := path[len(rootDirectory):]
 
-		vmLogger.Debug("writing file %s to %s", path, newPath)
 		err = WriteFileToPackage(path, newPath, tw)
 		if err != nil {
 			return fmt.Errorf("Error writing file to package: %s", err)

--- a/core/container/util/writer.go
+++ b/core/container/util/writer.go
@@ -20,12 +20,13 @@ import (
 	"archive/tar"
 	"bufio"
 	"fmt"
-	"github.com/op/go-logging"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/op/go-logging"
 )
 
 var vmLogger = logging.MustGetLogger("container")


### PR DESCRIPTION
Removed debug statement from core/container/util/writer.go
## Description

Removed debug statement from core/container/util/writer.go
## Motivation and Context

The list of all files collected during deploy is too large. Have never need to use that for a long time. Reducing log file size and cut out a few seconds.

Fixes #1479
## How Has This Been Tested?

Ran tests before and after, with and without debug level.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
