### PR TITLE
Fix PBFT request custody bugs

### DIFF
--- a/consensus/obcpbft/complainer.go
+++ b/consensus/obcpbft/complainer.go
@@ -121,12 +121,14 @@ func (c *complainer) SuccessHash(hash string) {
 // The custody queue timeouts are reset.  Restart returns all requests
 // that are maintained in custody.
 func (c *complainer) Restart() map[string]*Request {
-	c.complaints.RemoveAll()
+	complaints := c.complaints.RemoveAll()
 	custody := c.custody.RemoveAll()
 	reqs := make(map[string]*Request)
-	for _, pair := range custody {
-		c.custody.Register(pair.ID, pair.Data)
-		reqs[pair.ID] = pair.Data.(*Request)
+	for _, custodian := range [][]custodian.CustodyPair{complaints, custody} {
+		for _, pair := range custodian {
+			c.custody.Register(pair.ID, pair.Data)
+			reqs[pair.ID] = pair.Data.(*Request)
+		}
 	}
 	return reqs
 }

--- a/consensus/obcpbft/complainer.go
+++ b/consensus/obcpbft/complainer.go
@@ -119,16 +119,20 @@ func (c *complainer) SuccessHash(hash string) {
 // Restart resets custody and complaint queues without calling into
 // the complaintHandler.  The complaint queue is drained completely.
 // The custody queue timeouts are reset.  Restart returns all requests
-// that are maintained in custody.
+// that are maintained in custody, or have been received from other replicas
 func (c *complainer) Restart() map[string]*Request {
-	complaints := c.complaints.RemoveAll()
-	custody := c.custody.RemoveAll()
 	reqs := make(map[string]*Request)
-	for _, custodian := range [][]custodian.CustodyPair{complaints, custody} {
-		for _, pair := range custodian {
-			c.custody.Register(pair.ID, pair.Data)
-			reqs[pair.ID] = pair.Data.(*Request)
-		}
+
+	complaints := c.complaints.RemoveAll()
+	for _, pair := range complaints {
+		reqs[pair.ID] = pair.Data.(*Request)
 	}
+
+	custody := c.custody.RemoveAll()
+	for _, pair := range custody {
+		c.custody.Register(pair.ID, pair.Data)
+		reqs[pair.ID] = pair.Data.(*Request)
+	}
+
 	return reqs
 }

--- a/consensus/obcpbft/custodian/custodian_test.go
+++ b/consensus/obcpbft/custodian/custodian_test.go
@@ -35,6 +35,7 @@ func TestCustody(t *testing.T) {
 		func(req string, data interface{}) {
 			notify <- info{req, data.(string)}
 		})
+	defer c.Stop()
 
 	c.Register("foo", "bar")
 	select {
@@ -53,6 +54,7 @@ func TestRemove(t *testing.T) {
 		func(id string, data interface{}) {
 			notify <- info{id, data.(string)}
 		})
+	defer c.Stop()
 
 	c.Register("foo", "1")
 	time.Sleep(10 * time.Millisecond)
@@ -80,6 +82,7 @@ func TestRemoveAll(t *testing.T) {
 		func(id string, data interface{}) {
 			notify <- info{id, data.(string)}
 		})
+	defer c.Stop()
 
 	c.Register("foo", "1")
 	time.Sleep(10 * time.Millisecond)
@@ -97,6 +100,7 @@ func TestElements(t *testing.T) {
 		func(id string, data interface{}) {
 			notify <- info{id, data.(string)}
 		})
+	defer c.Stop()
 
 	c.Register("foo", "1")
 	c.Register("baz", "3")
@@ -119,8 +123,8 @@ func TestElements(t *testing.T) {
 	}
 
 	l = c.RemoveAll()
-	if len(l) != 1 {
-		t.Fatal("expected 1 element")
+	if len(l) != 2 {
+		t.Fatal("expected 2 elements")
 	}
 	if l[0].ID != "bar" || l[0].Data.(string) != "2" {
 		t.Error("invalid element")
@@ -135,12 +139,13 @@ func TestReCustody(t *testing.T) {
 			c.Register(req, data)
 			notify <- true
 		})
+	defer c.Stop()
 
 	c.Register("foo", "bar")
 	select {
 	case <-notify:
 		reqs := c.Elements()
-		if len(reqs) != 1 || reqs[0].ID != "foo" || reqs[0].Data != "bar" {
+		if len(reqs) != 2 || reqs[0].ID != "foo" || reqs[0].Data != "bar" {
 			t.Error("invalid datasheet")
 		}
 	case <-time.After(200 * time.Millisecond):

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -81,12 +81,18 @@ func TestNetworkBatch(t *testing.T) {
 func TestBatchCustody(t *testing.T) {
 	validatorCount := 4
 	net := makeConsumerNetwork(validatorCount, func(id uint64, config *viper.Viper, stack consensus.Stack) pbftConsumer {
-		config.Set("general.batchsize", "2")
-		config.Set("general.timeout.batch", "500ms")
-		config.Set("general.timeout.request", "800ms")
-		config.Set("general.timeout.viewchange", "1600ms")
+		config.Set("general.batchsize", "1")
+		config.Set("general.timeout.batch", "250ms")
+		if id == 0 {
+			// Keep replica 0 from unnecessarilly advancing its view
+			config.Set("general.timeout.request", "1500ms")
+		} else {
+			config.Set("general.timeout.request", "250ms")
+		}
+		config.Set("general.timeout.viewchange", "800ms")
 		return newObcBatch(id, config, stack)
 	})
+	defer net.stop()
 	net.filterFn = func(src int, dst int, payload []byte) []byte {
 		logger.Info("msg from %d to %d", src, dst)
 		if src == 0 {
@@ -95,23 +101,44 @@ func TestBatchCustody(t *testing.T) {
 		return payload
 	}
 
-	go net.processContinually()
+	// Submit two requests to replica 2, because vp0 is byzantine, they will not be processed until complaints triggers a view change
+	// Once the complaints work, we should end up in view 1, with 2 blocks
 	r2 := net.endpoints[2].(*consumerEndpoint).consumer
 	r2.RecvMsg(createOcMsgWithChainTx(1), net.endpoints[1].getHandle())
 	r2.RecvMsg(createOcMsgWithChainTx(2), net.endpoints[1].getHandle())
-	time.Sleep(6 * time.Second)
-	net.stop()
 
-	for i, inst := range net.endpoints {
-		// Don't care about byzantine node 0
-		if i == 0 {
-			continue
-		}
-		inst := inst.(*consumerEndpoint)
-		_, err := inst.consumer.(*obcBatch).stack.GetBlock(1)
-		if err != nil {
-			t.Errorf("Expected replica %d to have one block", inst.id)
-			continue
+	//net.debug = true
+	net.debugMsg("Stage 1\n")
+	// Get the requests into the custody store, will return once vp2 complaints
+	net.process()
+	net.debugMsg("Stage 2\n")
+
+	// Let the complaint timer expire for vp1/vp3
+	time.Sleep(500 * time.Millisecond)
+
+	// Process the new view and execute the requests
+	net.process()
+	net.debugMsg("Stage 3\n")
+
+	// Let the complaint timer expire for the other request
+	time.Sleep(500 * time.Millisecond)
+
+	// Process the complaint, this time without view change
+	net.process()
+	net.debugMsg("Stage 4\n")
+
+	for i, ep := range net.endpoints {
+
+		b := ep.(*consumerEndpoint).consumer.(*obcBatch)
+
+		if _, err := b.stack.GetBlock(2); nil != err {
+			t.Errorf("Expected replica %d to have two blocks", i)
+		} else {
+			expectedView := uint64(1)
+			if b.pbft.view != expectedView {
+				t.Errorf("Expected replica %d to have two blocks and be in view %d", b.pbft.id, expectedView)
+			}
 		}
 	}
+
 }

--- a/consensus/obcpbft/obc-classic_test.go
+++ b/consensus/obcpbft/obc-classic_test.go
@@ -64,7 +64,7 @@ func TestClassicStateTransfer(t *testing.T) {
 		ce.consumer.(*obcClassic).pbft.L = 4
 	})
 	defer net.stop()
-	net.debug = true
+	// net.debug = true
 
 	filterMsg := true
 	net.filterFn = func(src int, dst int, msg []byte) []byte {
@@ -108,7 +108,7 @@ func TestClassicBackToBackStateTransfer(t *testing.T) {
 		ce.consumer.(*obcClassic).pbft.requestTimeout = time.Hour // We do not want any view changes
 	})
 	defer net.stop()
-	net.debug = true
+	// net.debug = true
 
 	filterMsg := true
 	net.filterFn = func(src int, dst int, msg []byte) []byte {

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -691,7 +691,7 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 		}
 
 		instance.reqStore[digest] = preprep.Request
-		logger.Debug("Replica %d storing request %s in oustanding request store", instance.id, digest)
+		logger.Debug("Replica %d storing request %s in outstanding request store", instance.id, digest)
 		instance.outstandingReqs[digest] = preprep.Request
 		instance.persistRequest(digest)
 	}
@@ -812,8 +812,10 @@ func (instance *pbftCore) recvCommit(commit *Commit) error {
 
 func (instance *pbftCore) executeOutstanding() {
 	if instance.currentExec != nil {
+		logger.Debug("Replica %d not attempting to executeOutstanding because a it is currently executing", instance.id)
 		return
 	}
+	logger.Debug("Replica %d attempting to executeOutstanding", instance.id)
 
 	for idx := range instance.certStore {
 		if instance.executeOne(idx) {
@@ -821,7 +823,7 @@ func (instance *pbftCore) executeOutstanding() {
 		}
 	}
 
-	logger.Debug("replica %d certstore %+v", instance.id, instance.certStore)
+	logger.Debug("Replica %d certstore %+v", instance.id, instance.certStore)
 
 	return
 }

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 const (
-	// An ugly thing, we need to create timers, then stop them before they expire, so use a large timeout
+	// UnreasonableTimeout is an ugly thing, we need to create timers, then stop them before they expire, so use a large timeout
 	UnreasonableTimeout = 100 * time.Hour
 )
 
@@ -611,9 +611,9 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 
 			instance.innerBroadcast(&Message{&Message_PrePrepare{preprep}})
 			return instance.maybeSendCommit(digest, instance.view, n)
-		} else {
-			logger.Debug("Replica %d is primary, not sending pre-prepare for request %s because it is out of sequence numbers", instance.id, digest)
 		}
+
+		logger.Debug("Replica %d is primary, not sending pre-prepare for request %s because it is out of sequence numbers", instance.id, digest)
 	} else {
 		logger.Debug("Replica %d is backup, not sending pre-prepare for request %s", instance.id, digest)
 	}


### PR DESCRIPTION
## Description

This changeset moves new view processing for batch onto the batch thread, clears the pbft core outstanding request map on view change (as it is maintained by custody now), retains complained requests until explicit removal, and uses the PBFT thread via function injection to initiate view change from complaints.
## Motivation and Context

After the failures in `TestBatchCustody` observed after the merging of PR #1277, it was clear that the `TestBatchCustody` needs to run faster, and more deterministically.  Additionally, to enhance this test, the terminal view for the test was added, which exposed other bugs in the code.
1. The batch thread was being used to invoke `op.pbft.sendViewChange()` which modifes the internal PBFT state, possibly causing data corruption, or even concurrent access panics.
2.  The `outstandingReqs` map in PBFT would complain that a request had not been executed, triggering unnecessary view changes.  This was wrong, because a batch request is a collection of requests, and although a particular batch is not executed does not mean that its component requests have not been.
3. The new primary was only processing the requests for which it was the original receiver, but was also discarding the complaints it had received in a previous view.  This required yet another round of complaints which slows recovery.
4. Once a request in custody's timer had expired, it was removed from custody, and a view change was initiated.  Once view change completed, the request was no longer available to be resubmitted.

All of these problems could be observed in the view being inappropriately advanced or replica 0 becoming out of sync.

Potentially fixes many bugs associated with PBFT batch, but because of the wide variety of potential failures, they will each need to be reviewed and will be linked to this PR later if associated.
## How Has This Been Tested?

These fixes are all targeted at the `TestBatchCustody` test.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
