### PR TITLE
Add search path for config file based on GOPATH

### DIFF
--- a/membersrvc/server.go
+++ b/membersrvc/server.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/hyperledger/fabric/core/crypto"
@@ -36,6 +37,12 @@ func main() {
 	viper.SetConfigName("membersrvc")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath("./")
+	// Path to look for the config file based on GOPATH
+	gopath := os.Getenv("GOPATH")
+	for _, p := range filepath.SplitList(gopath) {
+		cfgpath := filepath.Join(p, "src/github.com/hyperledger/fabric/membersrvc")
+		viper.AddConfigPath(cfgpath)
+	}
 	err := viper.ReadInConfig()
 	if err != nil {
 		panic(err)

--- a/membersrvc/server.go
+++ b/membersrvc/server.go
@@ -45,7 +45,7 @@ func main() {
 	}
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("Fatal error when reading %s config file: %s\n", "membersrvc", err))
 	}
 
 	var iotrace, ioinfo, iowarning, ioerror, iopanic io.Writer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Added to viper's config search path the membersrvc directory based on the value of $GOPATH to allow for membersrvc to run outside the source directory.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1489
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Testing is simple. Before the change running membersrvc from outside its directory fails:

```
$ cd $GOPATH/src/github.com/hyperledger/fabric
$ membersrvc/membersrvc
panic: open : no such file or directory

goroutine 1 [running]:
panic(0xaa2c00, 0xc82017cea0)
        /opt/go/src/runtime/panic.go:464 +0x3e6
main.main()
        /opt/gopath/src/github.com/hyperledger/fabric/membersrvc/server.go:41 +0x159
```

After the change, the config file is found and the program runs successfully:

```
$ membersrvc/membersrvc
2016/05/17 16:00:26 Log level not recognized '', defaulting to DEBUG: logger: invalid log level
2016/05/17 16:00:26 Working at security level [256]
INFO: 2016/05/17 16:00:26 CA Server (0.1)
INFO: 2016/05/17 16:00:26 Fresh start; creating databases, key pairs, and certificates.

```
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Arnaud J Le Hors lehors@us.ibm.com
