### PR TITLE
forwarding port 31315 in vagrant

### DIFF
--- a/devenv/Vagrantfile
+++ b/devenv/Vagrantfile
@@ -35,6 +35,7 @@ Vagrant.configure('2') do |config|
   config.vm.network :forwarded_port, guest: 5000, host: 3000 # Openchain REST services
   config.vm.network :forwarded_port, guest: 30303, host: 30303 # Openchain gRPC services
   config.vm.network :forwarded_port, guest: 50051, host: 50051 # Membership service
+  config.vm.network :forwarded_port, guest: 31315, host: 31315 # GRPCCient gRPC services
 
   config.vm.synced_folder "..", "#{SRCMOUNT}"
   config.vm.synced_folder "..", "/opt/gopath/src/github.com/hyperledger/fabric"


### PR DESCRIPTION
Enabling forwarding port 31315 in vagrant
## Description

Added a port to be forwarded in vagrant.
## Motivation and Context

Need to be able to register listeners for the utxo chaincode.
## How Has This Been Tested?

Manually brought up the utxo chaincode and ran a new test against it from fabric-api from this not-yet-merged commit: https://github.com/hyperledger/fabric-api/commit/ad10ecea6b08cd7e730bc1bcca0c4c313e90e7d3.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:
