### PR TITLE
Add correlation ID to peer statetransfer for blocks and state deltas

### DIFF
--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -52,6 +52,7 @@ var peerEndpointError error
 // Cached values of commonly used configuration constants.
 var syncStateSnapshotChannelSize int
 var syncStateDeltasChannelSize int
+var syncBlocksChannelSize int
 var validatorEnabled bool
 var tlsEnabled bool
 
@@ -116,6 +117,7 @@ func CacheConfiguration() (err error) {
 
 	syncStateSnapshotChannelSize = viper.GetInt("peer.sync.state.snapshot.channelSize")
 	syncStateDeltasChannelSize = viper.GetInt("peer.sync.state.deltas.channelSize")
+	syncBlocksChannelSize = viper.GetInt("peer.sync.blocks.channelSize")
 	validatorEnabled = viper.GetBool("peer.validator.enabled")
 	tlsEnabled = viper.GetBool("peer.tls.enabled")
 
@@ -173,6 +175,13 @@ func SyncStateDeltasChannelSize() int {
 		cacheConfiguration()
 	}
 	return syncStateDeltasChannelSize
+}
+
+func SyncBlocksChannelSize() int {
+	if !configurationCached {
+		cacheConfiguration()
+	}
+	return syncBlocksChannelSize
 }
 
 func ValidatorEnabled() bool {

--- a/core/peer/handler_sync_state.go
+++ b/core/peer/handler_sync_state.go
@@ -33,6 +33,10 @@ type syncHandler struct {
 	correlationID uint64
 }
 
+func (sh *syncHandler) shouldHandle(correlationID uint64) bool {
+	return correlationID == sh.correlationID
+}
+
 //-----------------------------------------------------------------------------
 //
 // Sync Blocks Handler
@@ -50,10 +54,6 @@ func (sbh *syncBlocksRequestHandler) reset() {
 	}
 	sbh.channel = make(chan *pb.SyncBlocks, SyncBlocksChannelSize())
 	sbh.correlationID++
-}
-
-func (sbh *syncBlocksRequestHandler) shouldHandle(syncBlocks *pb.SyncBlocks) bool {
-	return syncBlocks.Range.CorrelationId == sbh.correlationID
 }
 
 func newSyncBlocksRequestHandler() *syncBlocksRequestHandler {
@@ -79,10 +79,6 @@ func (srh *syncStateSnapshotRequestHandler) reset() {
 	}
 	srh.channel = make(chan *pb.SyncStateSnapshot, SyncStateSnapshotChannelSize())
 	srh.correlationID++
-}
-
-func (srh *syncStateSnapshotRequestHandler) shouldHandle(syncStateSnapshot *pb.SyncStateSnapshot) bool {
-	return syncStateSnapshot.Request.CorrelationId == srh.correlationID
 }
 
 func (srh *syncStateSnapshotRequestHandler) createRequest() *pb.SyncStateSnapshotRequest {

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -444,11 +444,12 @@ Synchronization protocol starts with discovery, described above in section 3.1.1
 
 The installed consensus plugin (e.g. pbft) dictates how synchronization protocol is being applied. Each message is designed for a specific situation:
 
-**SYNC_GET_BLOCKS** requests for a range of contiguous blocks expressed in the message `payload`, which is an object of `SyncBlockRange`.
+**SYNC_GET_BLOCKS** requests for a range of contiguous blocks expressed in the message `payload`, which is an object of `SyncBlockRange`.  The correlationId specified is included in the `SyncBlockRange` of any replies to this message.
 ```
 message SyncBlockRange {
-    uint64 start = 1;
-    uint64 end = 2;
+    uint64 correlationId = 1;
+    uint64 start = 2;
+    uint64 end = 3;
 }
 ```
 A receiving peer responds with a `SYNC_BLOCKS` message whose `payload` contains an object of `SyncBlocks`

--- a/protos/fabric.pb.go
+++ b/protos/fabric.pb.go
@@ -439,8 +439,9 @@ func (m *BlockState) GetBlock() *Block {
 // example, if start=3 and end=5, the order of blocks will be 3, 4, 5.
 // If start=5 and end=3, the order will be 5, 4, 3.
 type SyncBlockRange struct {
-	Start uint64 `protobuf:"varint,1,opt,name=start" json:"start,omitempty"`
-	End   uint64 `protobuf:"varint,2,opt,name=end" json:"end,omitempty"`
+	CorrelationId uint64 `protobuf:"varint,1,opt,name=correlationId" json:"correlationId,omitempty"`
+	Start         uint64 `protobuf:"varint,2,opt,name=start" json:"start,omitempty"`
+	End           uint64 `protobuf:"varint,3,opt,name=end" json:"end,omitempty"`
 }
 
 func (m *SyncBlockRange) Reset()         { *m = SyncBlockRange{} }

--- a/protos/fabric.proto
+++ b/protos/fabric.proto
@@ -201,8 +201,9 @@ message BlockState {
 // example, if start=3 and end=5, the order of blocks will be 3, 4, 5.
 // If start=5 and end=3, the order will be 5, 4, 3.
 message SyncBlockRange {
-    uint64 start = 1;
-    uint64 end = 2;
+    uint64 correlationId = 1;
+    uint64 start = 2;
+    uint64 end = 3;
 }
 // SyncBlocks is the payload of Message.SYNC_BLOCKS, where the range
 // indicates the blocks responded to the request SYNC_GET_BLOCKS


### PR DESCRIPTION
## Description

This changeset adds a correlation ID to `SyncBlockRange`, it also modifies the peer handler to populate this correlation ID field, and filter extraneous messages with the wrong correlation ID.
## Motivation and Context

Because of the peer's stream based approach, it is not possible to determine which `SYNC_GET_BLOCKS` request a `SYNC_BLOCKS` message corresponds to.  Therefore, if multiple request are issued to the same peer, the requester cannot differentiate between that peer sending garbage, and that peer merely having other traffic on the wire.  This requires that consumers of the state transfer rely on timeouts, rather than being able to detect errors.  In the case of a 'missed' block (do to, say an buffer overflow), the requesting peer must read all pending blocks or wait until a timeout in order to retry.  By including a correlation ID, this allows the caller to recognize that any out of order sequence number indicates an error, and the call should be aborted immediately.

This change applies to both block synchronization and state delta synchronization.

Fixes #974 
## How Has This Been Tested?

This has been tested using the existing state transfer behave test (@issue_680).  I'm unaware of any better way to test this function.  Maybe @jeffgarratt could weigh in here? (I'd also like Jeff's sign-off on the validity of these changes)
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Note, for the lint-ing, I have intentionally ignored the errors in the `config.go` as these are formulaic Get-ers to allow caching of Viper results.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
