### PR TITLE
Fix state transfer to fail on out of order

### DIFF
--- a/core/peer/statetransfer/statetransfer_test.go
+++ b/core/peer/statetransfer/statetransfer_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/hyperledger/fabric/protos"
 )
 
+var AllFailures = [...]mockResponse{Timeout, Corrupt, OutOfOrder}
+
 type testPartialStack struct {
 	*MockRemoteHashLedgerDirectory
 	*MockLedger
@@ -194,7 +196,7 @@ func TestCatchupWithoutDeltas(t *testing.T) {
 }
 
 func TestCatchupSyncBlocksErrors(t *testing.T) {
-	for _, failureType := range []mockResponse{Timeout, Corrupt} {
+	for _, failureType := range AllFailures {
 		mrls := createRemoteLedgers(1, 3)
 
 		// Test from blockheight of 1 with valid genesis block
@@ -219,7 +221,7 @@ func TestCatchupSyncBlocksErrors(t *testing.T) {
 func TestCatchupSyncBlocksAllErrors(t *testing.T) {
 	blockNumber := uint64(10)
 
-	for _, failureType := range []mockResponse{Timeout, Corrupt} {
+	for _, failureType := range AllFailures {
 		mrls := createRemoteLedgers(1, 3)
 
 		// Test from blockheight of 1 with valid genesis block
@@ -321,7 +323,7 @@ func TestCatchupMissingEarlyChain(t *testing.T) {
 }
 
 func TestCatchupSyncSnapshotError(t *testing.T) {
-	for _, failureType := range []mockResponse{Timeout, Corrupt} {
+	for _, failureType := range AllFailures {
 		mrls := createRemoteLedgers(1, 3)
 
 		// Test from blockheight of 5 (with missing blocks 0-3)
@@ -342,7 +344,7 @@ func TestCatchupSyncSnapshotError(t *testing.T) {
 }
 
 func TestCatchupSyncDeltasError(t *testing.T) {
-	for _, failureType := range []mockResponse{Timeout, Corrupt} {
+	for _, failureType := range AllFailures {
 		mrls := createRemoteLedgers(1, 3)
 
 		// Test from blockheight of 5 (with missing blocks 0-3)
@@ -489,7 +491,7 @@ func TestCatchupLaggingChains(t *testing.T) {
 }
 
 func TestCatchupLaggingChainsErrors(t *testing.T) {
-	for _, failureType := range []mockResponse{Timeout, Corrupt} {
+	for _, failureType := range AllFailures {
 		mrls := createRemoteLedgers(0, 3)
 
 		for peerID := range mrls.remoteLedgers {


### PR DESCRIPTION
## Description

Change the state transfer code to abort on incorrectly ordered messages, rather than tolerate them.
## Motivation and Context

When the underpinning mechanisms of state transfer (`SYNC_GET_BLOCKS` and `SYNC_GET_STATE_DELTAS`) were introduced, they had no notion of correlation ID.  Consequently, when the invoking code received messages, there was no guarantee that message was associated with any particular call from the caller.  Therefore, the code would check for inappropriately ordered messages, but could not treat them as errors.  Now thanks to issue #974 and PR #1495 (which should be merged before this one), state transfer can treat these bad messages as errors.

This fixes some outstanding TODOs in the code.  It can be seen as contributing to implementation of #1496, or as more general cleanup.

The bulk of the changes are to the tests, and only general golang knowledge is required for review.
## How Has This Been Tested?

A new failure type, `OutOfOrder` was introduced to the state transfer mock testing framework.  All existing state transfer tests that check for survival of failure were enhanced to also test for tolerance of an `OutOfOrder` failure.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
