### PR TITLE
Fixing Issue #1514: GetTCertificateHandlerFromDER does not recover the signing key

### DIFF
--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -382,6 +382,26 @@ func TestClientTCertHandlerSign(t *testing.T) {
 		t.Fatalf("Failed verifying signature: [%s]", err)
 	}
 
+	// Check that deployer can reload the cert handler from DER and sign
+	handlerDeployer2, err := deployer.GetTCertificateHandlerFromDER(handlerDeployer.GetCertificate())
+	if err != nil {
+		t.Fatalf("Failed getting tcert: [%s]", err)
+	}
+
+	msg = []byte("Hello World!!!")
+	signature, err = handlerDeployer2.Sign(msg)
+	if err != nil {
+		t.Fatalf("Failed getting tcert: [%s]", err)
+	}
+	if signature == nil || len(signature) == 0 {
+		t.Fatalf("Failed getting non-nil signature")
+	}
+
+	err = handlerDeployer2.Verify(signature, msg)
+	if err != nil {
+		t.Fatalf("Failed verifying signature: [%s]", err)
+	}
+
 	// Check that invoker (another party) can verify the signature
 	handlerInvoker, err := invoker.GetTCertificateHandlerFromDER(handlerDeployer.GetCertificate())
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This PR modifies the implementation of the method Client#GetTCertificateHandlerFromDER in order to recover the signing key associated to the TCert's verification key when this operation is well defined. Recovering the signing key is well defined when Alice tries to load a TCert that she has generated in the past. The signing key cannot be recovered if Alice tries to load a TCert generated by Bob.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1514
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

The PR introduces a new unit test.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
