### PR TITLE
Issue 1507 address lint issues membersrvc/ca/tca.go

### DIFF
--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -158,16 +158,15 @@ func (tca *TCA) initializePreKeyNonRootGroup(group *AffiliationGroup) error {
 
 func (tca *TCA) initializePreKeyGroup(group *AffiliationGroup) error {
 	if group.parentID == 0 {
-		//This group is root
+		// This group is root ("top level")
 		group.preKey = tca.rootPreKey
 		return nil
-	} else {
-		return tca.initializePreKeyNonRootGroup(group)
 	}
+	return tca.initializePreKeyNonRootGroup(group)
 }
 
 func (tca *TCA) initializePreKeyTree() error {
-	Trace.Println("Initializing PreKeys.")
+	Trace.Println("Initializing Pre-Keys")
 	groups, err := tca.eca.readAffiliationGroups()
 	if err != nil {
 		return err
@@ -180,7 +179,7 @@ func (tca *TCA) initializePreKeyTree() error {
 				return err
 			}
 		}
-		Trace.Println("Initializing PK group ", group.name)
+		Trace.Println("Initializing Pre-Key for group '", group.name, "'")
 		tca.preKeys[group.name] = group.preKey
 	}
 
@@ -194,7 +193,7 @@ func (tca *TCA) getPreKFrom(enrollmentCertificate *x509.Certificate) ([]byte, er
 	}
 	preK := tca.preKeys[affiliation]
 	if preK == nil {
-		return nil, errors.New("Could not be found a pre-k to the affiliation group " + affiliation + ".")
+		return nil, errors.New("Could not find a Pre-Key corresponding to affiliation group '" + affiliation + "'")
 	}
 	return preK, nil
 }
@@ -224,14 +223,14 @@ func (tca *TCA) startTCAA(srv *grpc.Server) {
 
 // ReadCACertificate reads the certificate of the TCA.
 func (tcap *TCAP) ReadCACertificate(ctx context.Context, in *pb.Empty) (*pb.Cert, error) {
-	Trace.Println("grpc TCAP:ReadCACertificate")
+	Trace.Println("gRPC TCAP:ReadCACertificate")
 
 	return &pb.Cert{tcap.tca.raw}, nil
 }
 
 // CreateCertificateSet requests the creation of a new transaction certificate set by the TCA.
 func (tcap *TCAP) CreateCertificateSet(ctx context.Context, in *pb.TCertCreateSetReq) (*pb.TCertCreateSetResp, error) {
-	Trace.Println("grpc TCAP:CreateCertificateSet")
+	Trace.Println("gRPC TCAP:CreateCertificateSet")
 
 	id := in.Id.Id
 	raw, err := tcap.tca.eca.readCertificate(id, x509.KeyUsageDigitalSignature)
@@ -255,7 +254,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, in *pb.TCertCreateSe
 	raw, _ = proto.Marshal(in)
 	hash.Write(raw)
 	if ecdsa.Verify(pub, hash.Sum(nil), r, s) == false {
-		return nil, errors.New("signature does not verify")
+		return nil, errors.New("Signature verification failed")
 	}
 
 	// Generate nonce for TCertIndex
@@ -333,24 +332,24 @@ func (tcap *TCAP) generateExtensions(tcertid *big.Int, tidx []byte, enrollmentCe
 	extensions := make([]pkix.Extension, len(attributes))
 
 	// Compute preK_1 to encrypt attributes and enrollment ID
-	preK_1, err := tcap.tca.getPreKFrom(enrollmentCert)
+	preK1, err := tcap.tca.getPreKFrom(enrollmentCert)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	mac := hmac.New(primitives.GetDefaultHash(), preK_1)
+	mac := hmac.New(primitives.GetDefaultHash(), preK1)
 	mac.Write(tcertid.Bytes())
-	preK_0 := mac.Sum(nil)
+	preK0 := mac.Sum(nil)
 
 	// Compute encrypted EnrollmentID
-	mac = hmac.New(primitives.GetDefaultHash(), preK_0)
+	mac = hmac.New(primitives.GetDefaultHash(), preK0)
 	mac.Write([]byte("enrollmentID"))
-	enrollmentIdKey := mac.Sum(nil)[:32]
+	enrollmentIDKey := mac.Sum(nil)[:32]
 
 	enrollmentID := []byte(enrollmentCert.Subject.CommonName)
 	enrollmentID = append(enrollmentID, Padding...)
 
-	encEnrollmentID, err := CBCEncrypt(enrollmentIdKey, enrollmentID)
+	encEnrollmentID, err := CBCEncrypt(enrollmentIDKey, enrollmentID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -364,14 +363,13 @@ func (tcap *TCAP) generateExtensions(tcertid *big.Int, tidx []byte, enrollmentCe
 	// Encrypt and append attributes to the extensions slice
 	for _, a := range attributes {
 		count++
-
 		value := []byte(a.AttributeValue)
 
 		//Save the position of the attribute extension on the header.
 		attributesHeader[a.AttributeName] = count
 
 		if viper.GetBool("tca.attribute-encryption.enabled") {
-			mac = hmac.New(primitives.GetDefaultHash(), preK_0)
+			mac = hmac.New(primitives.GetDefaultHash(), preK0)
 			mac.Write([]byte(a.AttributeName))
 			attributeKey := mac.Sum(nil)[:32]
 
@@ -407,26 +405,22 @@ func (tcap *TCAP) generateExtensions(tcertid *big.Int, tidx []byte, enrollmentCe
 }
 
 func buildAttributesHeader(attributesHeader map[string]int) []byte {
-	var header []byte
 	var headerString string
 	for k, v := range attributesHeader {
-		v_str := strconv.Itoa(v)
-		headerString = headerString + k + "->" + v_str + "#"
+		headerString = headerString + k + "->" + strconv.Itoa(v) + "#"
 	}
-	header = []byte(headerString)
-
-	return header
+	return []byte(headerString)
 }
 
 // ReadCertificate reads a transaction certificate from the TCA.
 func (tcap *TCAP) ReadCertificate(ctx context.Context, in *pb.TCertReadReq) (*pb.Cert, error) {
-	Trace.Println("grpc TCAP:ReadCertificate")
+	Trace.Println("gRPC TCAP:ReadCertificate")
 
 	req := in.Req.Id
 	id := in.Id.Id
 
 	if req != id && tcap.tca.eca.readRole(req)&(int(pb.Role_VALIDATOR)|int(pb.Role_AUDITOR)) == 0 {
-		return nil, errors.New("access denied")
+		return nil, errors.New("Access denied")
 	}
 
 	raw, err := tcap.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
@@ -449,7 +443,7 @@ func (tcap *TCAP) ReadCertificate(ctx context.Context, in *pb.TCertReadReq) (*pb
 	raw, _ = proto.Marshal(in)
 	hash.Write(raw)
 	if ecdsa.Verify(cert.PublicKey.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {
-		return nil, errors.New("signature does not verify")
+		return nil, errors.New("Signature verification failed")
 	}
 
 	if in.Ts.Seconds != 0 {
@@ -466,13 +460,13 @@ func (tcap *TCAP) ReadCertificate(ctx context.Context, in *pb.TCertReadReq) (*pb
 
 // ReadCertificateSet reads a transaction certificate set from the TCA.  Not yet implemented.
 func (tcap *TCAP) ReadCertificateSet(ctx context.Context, in *pb.TCertReadSetReq) (*pb.CertSet, error) {
-	Trace.Println("grpc TCAP:ReadCertificateSet")
+	Trace.Println("gRPC TCAP:ReadCertificateSet")
 
 	req := in.Req.Id
 	id := in.Id.Id
 
 	if req != id && tcap.tca.eca.readRole(req)&int(pb.Role_AUDITOR) == 0 {
-		return nil, errors.New("access denied")
+		return nil, errors.New("Access denied")
 	}
 
 	raw, err := tcap.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
@@ -495,7 +489,7 @@ func (tcap *TCAP) ReadCertificateSet(ctx context.Context, in *pb.TCertReadSetReq
 	raw, _ = proto.Marshal(in)
 	hash.Write(raw)
 	if ecdsa.Verify(cert.PublicKey.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {
-		return nil, errors.New("signature does not verify")
+		return nil, errors.New("Signature verification failed")
 	}
 
 	rows, err := tcap.tca.readCertificates(id, in.Ts.Seconds)
@@ -524,25 +518,25 @@ func (tcap *TCAP) ReadCertificateSet(ctx context.Context, in *pb.TCertReadSetReq
 
 // RevokeCertificate revokes a certificate from the TCA.  Not yet implemented.
 func (tcap *TCAP) RevokeCertificate(context.Context, *pb.TCertRevokeReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAP:RevokeCertificate")
+	Trace.Println("gRPC TCAP:RevokeCertificate")
 
-	return nil, errors.New("not yet implemented")
+	return nil, errors.New("TCAP:RevokeCertificate method not (yet) implemented")
 }
 
 // RevokeCertificateSet revokes a certificate set from the TCA.  Not yet implemented.
 func (tcap *TCAP) RevokeCertificateSet(context.Context, *pb.TCertRevokeSetReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAP:RevokeCertificateSet")
+	Trace.Println("gRPC TCAP:RevokeCertificateSet")
 
-	return nil, errors.New("not yet implemented")
+	return nil, errors.New("TCAP:RevokeCertificateSet method not (yet) implemented")
 }
 
 // ReadCertificateSets returns all certificates matching the filter criteria of the request.
 func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsReq) (*pb.CertSets, error) {
-	Trace.Println("grpc TCAA:ReadCertificateSets")
+	Trace.Println("gRPC TCAA:ReadCertificateSets")
 
 	req := in.Req.Id
 	if tcaa.tca.eca.readRole(req)&int(pb.Role_AUDITOR) == 0 {
-		return nil, errors.New("access denied")
+		return nil, errors.New("Access denied")
 	}
 
 	raw, err := tcaa.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
@@ -565,7 +559,7 @@ func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsR
 	raw, _ = proto.Marshal(in)
 	hash.Write(raw)
 	if ecdsa.Verify(cert.PublicKey.(*ecdsa.PublicKey), hash.Sum(nil), r, s) == false {
-		return nil, errors.New("signature does not verify")
+		return nil, errors.New("Signature verification failed")
 	}
 
 	users, err := tcaa.tca.eca.readUsers(int(in.Role))
@@ -635,21 +629,21 @@ func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsR
 
 // RevokeCertificate revokes a certificate from the TCA.  Not yet implemented.
 func (tcaa *TCAA) RevokeCertificate(context.Context, *pb.TCertRevokeReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:RevokeCertificate")
+	Trace.Println("gRPC TCAA:RevokeCertificate")
 
-	return nil, errors.New("not yet implemented")
+	return nil, errors.New("TCAA:RevokeCertificate method not (yet) implemented")
 }
 
 // RevokeCertificateSet revokes a certificate set from the TCA.  Not yet implemented.
 func (tcaa *TCAA) RevokeCertificateSet(context.Context, *pb.TCertRevokeSetReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:RevokeCertificateSet")
+	Trace.Println("gRPC TCAA:RevokeCertificateSet")
 
-	return nil, errors.New("not yet implemented")
+	return nil, errors.New("TCAA:RevokeCertificateSet method not (yet) implemented")
 }
 
 // PublishCRL requests the creation of a certificate revocation list from the TCA.  Not yet implemented.
 func (tcaa *TCAA) PublishCRL(context.Context, *pb.TCertCRLReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:CreateCRL")
+	Trace.Println("gRPC TCAA:CreateCRL")
 
-	return nil, errors.New("not yet implemented")
+	return nil, errors.New("TCAA:PublichCRL method not (yet) implemented")
 }


### PR DESCRIPTION
Address lint errors 
## Description
- Addressing each lint issue in tca.go (listed out in #[1286](https://github.com/hyperledger/fabric/issues/1286))

Minor, but while at it:
- More consistent error- and trace-messages
- Name functions/methods that are not (yet) implemented
- Consistent capitalization of messages + gRPC
- Reconcile the various references/aliases to Pre-Key (from PreK, pre-K, PreKeys, ...)
- Remove temporaries
## Motivation and Context

We are "joining forces" to improve on a few key code quality measures - and lint warnings/errors is one of these measures.

Fixes  #[1507](https://github.com/hyperledger/fabric/issues/1507)

```
ca/tca.go:164:9: if block ends with a return statement, so drop this else and outdent its block
ca/tca.go:336:2: don't use underscores in Go names; var preK_1 should be preK1
ca/tca.go:343:2: don't use underscores in Go names; var preK_0 should be preK0
ca/tca.go:348:2: var enrollmentIdKey should be enrollmentIDKey
ca/tca.go:413:3: don't use underscores in Go names; var v_str should be vStr
```
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

`golint + make all
`
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
