### PR TITLE
Linux on Z build support

### DIFF
--- a/devenv/setupRHELonZ.sh
+++ b/devenv/setupRHELonZ.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Development on Z is done on the native OS, not in Vagrant. This script can be 
+# used to set things up in RHEL on Z, similar to devenv/setup.sh which does the 
+# same for Vagrant. 
+# See https://github.com/hyperledger/fabric/blob/master/docs/dev-setup/install.md
+#
 # To get started:
 #       sudo su
 #       yum install git

--- a/devenv/setupRHELonZ.sh
+++ b/devenv/setupRHELonZ.sh
@@ -81,8 +81,9 @@ rm -rf /tmp/rocksdb
 
 ################
 # PIP
-wget http://dl.fedoraproject.org/pub/epel/7/x86_64/p/python-pip-7.1.0-1.el7.noarch.rpm
-rpm -ivh python-pip-7.1.0-1.el7.noarch.rpm
+yum install python-setuptools
+curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+python get-pip.py
 pip install --upgrade pip
 pip install behave nose docker-compose
 

--- a/devenv/setupRHELonZ.sh
+++ b/devenv/setupRHELonZ.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# To get started:
+#       sudo su
+#       yum install git
+#       mkdir -p $HOME/git/src/github.com/hyperledger
+#       cd $HOME/git/src/github.com/hyperledger
+#       git clone https://github.com/vpaprots/fabric.git
+#       source fabric/devenv/setupRHELonZ.sh
+#       ~/build.sh
+
+if [ xroot != x$(whoami) ]
+then
+   echo "You must run as root (Hint: sudo su)"
+   exit
+fi
+
+if [ -n -d $HOME/git/src/github.com/hyperledger/fabric ]
+then
+    echo "Script fabric code is under $HOME/git/src/github.com/hyperledger/fabric "
+    exit
+fi
+
+#TODO: should really just open a few ports..
+iptables -I INPUT 1 -j ACCEPT
+sysctl vm.overcommit_memory=1
+
+##################
+# Install Docker
+cd /tmp
+wget ftp://ftp.unicamp.br/pub/linuxpatch/s390x/redhat/rhel7.2/docker-1.10.1-rhel7.2-20160408.tar.gz
+tar -xvzf docker-1.10.1-rhel7.2-20160408.tar.gz
+cp docker-1.10.1-rhel7.2-20160408/docker /bin
+rm -rf docker docker-1.10.1-rhel7.2-20160408.tar.gz
+
+#TODO: Install on boot
+nohup docker daemon -g /data/docker -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock&
+
+###################################
+# Crosscompile and install GOLANG
+cd $HOME
+git clone http://github.com/linux-on-ibm-z/go.git
+cd go
+git checkout release-branch.go1.6
+
+cat > crosscompile.sh <<HEREDOC
+cd /tmp/home/go/src	
+yum install -y git wget tar gcc bzip2
+export GOROOT_BOOTSTRAP=/usr/local/go
+GOOS=linux GOARCH=s390x ./bootstrap.bash
+HEREDOC
+
+docker run --privileged --rm -ti -v $HOME:/tmp/home brunswickheads/openchain-peer /bin/bash /tmp/home/go/crosscompile.sh
+
+export GOROOT_BOOTSTRAP=$HOME/go-linux-s390x-bootstrap
+cd $HOME/go/src
+./all.bash
+export PATH=$HOME/go/bin:$PATH
+
+rm -rf $HOME/go-linux-s390x-bootstrap 
+
+################
+#ROCKSDB BUILD
+
+cd /tmp
+yum install -y gcc-c++ snappy snappy-devel zlib zlib-devel bzip2 bzip2-devel
+git clone https://github.com/facebook/rocksdb.git
+cd  rocksdb
+git checkout tags/v4.1
+echo There were some bugs in 4.1 for x/p, dev stream has the fix, living dangereously, fixing in place
+sed -i -e "s/-march=native/-march=zEC12/" build_tools/build_detect_platform
+sed -i -e "s/-momit-leaf-frame-pointer/-DDUMBDUMMY/" Makefile
+make shared_lib && INSTALL_PATH=/usr make install-shared && ldconfig
+cd /tmp
+rm -rf /tmp/rocksdb
+
+################
+# PIP
+wget http://dl.fedoraproject.org/pub/epel/7/x86_64/p/python-pip-7.1.0-1.el7.noarch.rpm
+rpm -ivh python-pip-7.1.0-1.el7.noarch.rpm
+pip install --upgrade pip
+pip install behave nose docker-compose
+
+# updater-server, update-engine, and update-service-common dependencies (for running locally)
+pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3
+cat >> ~/.bashrc <<HEREDOC
+      export PATH=$HOME/go/bin:$PATH
+      export GOROOT=$HOME/go
+      export GOPATH=$HOME/git
+HEREDOC
+
+source ~/.bashrc
+
+# Build the actual hyperledger peer
+cd $GOPATH/src/github.com/hyperledger/fabric
+make clean peer

--- a/devenv/setupRHELonZ.sh
+++ b/devenv/setupRHELonZ.sh
@@ -12,7 +12,7 @@
 #       cd $HOME/git/src/github.com/hyperledger
 #       git clone https://github.com/vpaprots/fabric.git
 #       source fabric/devenv/setupRHELonZ.sh
-#       ~/build.sh
+#       make peer unit-test behave
 
 if [ xroot != x$(whoami) ]
 then

--- a/docs/dev-setup/devenv.md
+++ b/docs/dev-setup/devenv.md
@@ -1,7 +1,7 @@
 ## Setting up the development environment
 
 ### Overview
-The current development environment utilizes Vagrant running an Ubuntu image, which in turn launches Docker containers. Conceptually, the Host launches a VM, which in turn launches Docker containers.
+The current supported development environment utilizes Vagrant running an Ubuntu image, which in turn launches Docker containers. Conceptually, the Host launches a VM, which in turn launches Docker containers.
 
 **Host -> VM -> Docker**
 
@@ -16,7 +16,7 @@ This model allows developers to leverage their favorite OS/editors and execute t
 * [VirtualBox](https://www.virtualbox.org/) - 5.0 or later
 * BIOS Enabled Virtualization - Varies based on hardware
 
-- Note: The BIOS Enabled Virtualization may be within the CPU or Security settings of the BIOS
+Note: The BIOS Enabled Virtualization may be within the CPU or Security settings of the BIOS
 
 ### Steps
 
@@ -65,3 +65,64 @@ Once complete, you should now be able to SSH into your new VM with the following
 Once inside the VM, you can find the peer project under $GOPATH/src/github.com/hyperledger/fabric (as well as /hyperledger).
 
 **NOTE:** any time you *git clone* any of the projects in your Host's fabric directory (under $GOPATH/src/github.com/hyperledger/fabric), the update will be instantly available within the VM fabric directory.
+
+## Building outside of Vagrant
+It is possible to build the project outside of Vagrant (e.g. when one already runs Linux and wants to develop natively). Generally speaking, one has to match the vagrant [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh).
+
+### Prerequisites
+* [Git client](https://git-scm.com/downloads)
+* [Go](https://golang.org/) - 1.6 or later
+* [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1 and its dependencies
+* [Docker](https://docs.docker.com/engine/installation/)
+* [Pip](https://pip.pypa.io/en/stable/installing/)
+* Set the maximum number of open files to 10000 or greater for your OS
+
+### Docker
+Make sure that the Docker daemon initialization includes the options
+```
+-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
+```
+
+Typically, docker runs as a `service` task, with configuration file at `/etc/default/docker`.
+
+Be aware that the Docker bridge (the `CORE_VM_ENDPOINT`) may not come
+up at the IP address currently assumed by the test environment
+(`172.17.0.1`). Use `ifconfig` or `ip addr` to find the docker bridge.
+
+### Building RocksDB
+```
+apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+cd /tmp
+git clone https://github.com/facebook/rocksdb.git
+cd rocksdb
+git checkout v4.1
+PORTABLE=1 make shared_lib
+INSTALL_PATH=/usr/local make install-shared
+```
+
+### `pip`, `behave` and `docker-compose`
+```
+pip install --upgrade pip
+pip install behave nose docker-compose
+pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3
+```
+
+### Building on Z
+To make building on Z easier and faster, [this script](https://github.com/hyperledger/fabric/tree/master/devenv/setupRHELonZ.sh) is provided (which is similar to the [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh) provided for vagrant). This script has been tested only on RHEL 7.2 and has some assumptions one might want to re-visit (firewall settings, development as root user, etc.). It is however sufficient for development in a personally-assigned VM instance.
+
+To get started, from a freshly installed OS:
+```
+sudo su
+yum install git
+mkdir -p $HOME/git/src/github.com/hyperledger
+cd $HOME/git/src/github.com/hyperledger
+git clone https://github.com/vpaprots/fabric.git
+source fabric/devenv/setupRHELonZ.sh
+```
+From there, follow instructions at [Installation](install.md):
+
+```
+cd $GOPATH/src/github.com/hyperledger/fabric
+make peer unit-test behave
+```
+

--- a/docs/dev-setup/devenv.md
+++ b/docs/dev-setup/devenv.md
@@ -1,7 +1,7 @@
 ## Setting up the development environment
 
 ### Overview
-The current supported development environment utilizes Vagrant running an Ubuntu image, which in turn launches Docker containers. Conceptually, the Host launches a VM, which in turn launches Docker containers.
+The current development environment utilizes Vagrant running an Ubuntu image, which in turn launches Docker containers. Conceptually, the Host launches a VM, which in turn launches Docker containers.
 
 **Host -> VM -> Docker**
 
@@ -16,7 +16,7 @@ This model allows developers to leverage their favorite OS/editors and execute t
 * [VirtualBox](https://www.virtualbox.org/) - 5.0 or later
 * BIOS Enabled Virtualization - Varies based on hardware
 
-Note: The BIOS Enabled Virtualization may be within the CPU or Security settings of the BIOS
+- Note: The BIOS Enabled Virtualization may be within the CPU or Security settings of the BIOS
 
 ### Steps
 
@@ -65,64 +65,3 @@ Once complete, you should now be able to SSH into your new VM with the following
 Once inside the VM, you can find the peer project under $GOPATH/src/github.com/hyperledger/fabric (as well as /hyperledger).
 
 **NOTE:** any time you *git clone* any of the projects in your Host's fabric directory (under $GOPATH/src/github.com/hyperledger/fabric), the update will be instantly available within the VM fabric directory.
-
-## Building outside of Vagrant
-It is possible to build the project outside of Vagrant (e.g. when one already runs Linux and wants to develop natively). Generally speaking, one has to match the vagrant [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh).
-
-### Prerequisites
-* [Git client](https://git-scm.com/downloads)
-* [Go](https://golang.org/) - 1.6 or later
-* [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1 and its dependencies
-* [Docker](https://docs.docker.com/engine/installation/)
-* [Pip](https://pip.pypa.io/en/stable/installing/)
-* Set the maximum number of open files to 10000 or greater for your OS
-
-### Docker
-Make sure that the Docker daemon initialization includes the options
-```
--H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
-```
-
-Typically, docker runs as a `service` task, with configuration file at `/etc/default/docker`.
-
-Be aware that the Docker bridge (the `CORE_VM_ENDPOINT`) may not come
-up at the IP address currently assumed by the test environment
-(`172.17.0.1`). Use `ifconfig` or `ip addr` to find the docker bridge.
-
-### Building RocksDB
-```
-apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-cd /tmp
-git clone https://github.com/facebook/rocksdb.git
-cd rocksdb
-git checkout v4.1
-PORTABLE=1 make shared_lib
-INSTALL_PATH=/usr/local make install-shared
-```
-
-### `pip`, `behave` and `docker-compose`
-```
-pip install --upgrade pip
-pip install behave nose docker-compose
-pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3
-```
-
-### Building on Z
-To make building on Z easier and faster, [this script](https://github.com/hyperledger/fabric/tree/master/devenv/setupRHELonZ.sh) is provided (which is similar to the [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh) provided for vagrant). This script has been tested only on RHEL 7.2 and has some assumptions one might want to re-visit (firewall settings, development as root user, etc.). It is however sufficient for development in a personally-assigned VM instance.
-
-To get started, from a freshly installed OS:
-```
-sudo su
-yum install git
-mkdir -p $HOME/git/src/github.com/hyperledger
-cd $HOME/git/src/github.com/hyperledger
-git clone https://github.com/vpaprots/fabric.git
-source fabric/devenv/setupRHELonZ.sh
-```
-From there, follow instructions at [Installation](install.md):
-
-```
-cd $GOPATH/src/github.com/hyperledger/fabric
-make peer unit-test behave
-```
-

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -2,7 +2,6 @@
 Install the blockchain fabric by completing the following tasks:
 
 * [Building the fabric core](#building-the-fabric-core-)
-* [Building outside of Vagrant](#building-outside-of-vagrant-)
 * [Code contributions](#code-contributions-)
 * [Writing Chaincode](#writing-chaincode-)
 * [Setting Up a Network](#setting-up-a-network-)
@@ -106,36 +105,6 @@ Note, in order to run behave directly, you must run 'make images' first to build
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Obcca
 ```
-
-## Building outside of Vagrant <a name="vagrant"></a>
-While not recommended, it is possible to build the project outside of Vagrant (e.g., for using an editor with built-in Go toolking). In such cases:
-
-- Follow all steps required to setup and run a Vagrant image:
-  - Make sure you you have [Go 1.6](https://golang.org/) installed
-  - Set the maximum number of open files to 10000 or greater for your OS
-  - Install [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1 and its dependencies
-```
-apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
-cd /tmp
-git clone https://github.com/facebook/rocksdb.git
-cd rocksdb
-git checkout v4.1
-PORTABLE=1 make shared_lib
-INSTALL_PATH=/usr/local make install-shared
-```
-- Execute the following commands:
-```
-cd $GOPATH/src/github.com/hyperledger/fabric
-make
-```
-- Make sure that the Docker daemon initialization includes the options
-```
--H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
-```
-- Be aware that the Docker bridge (the `CORE_VM_ENDPOINT`) may not come
-up at the IP address currently assumed by the test environment
-(`172.17.0.1`). Use `ifconfig` or `ip addr` to find the docker bridge.
-
 
 ## Code contributions <a name="contrib"></a>
 We welcome contributions to the Hyperledger Project in many forms. There's always plenty to do! Full details of how to contribute to this project are documented in the [CONTRIBUTING.md](../../CONTRIBUTING.md) file.

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -2,6 +2,7 @@
 Install the blockchain fabric by completing the following tasks:
 
 * [Building the fabric core](#building-the-fabric-core-)
+* [Building outside of Vagrant](#building-outside-of-vagrant-)
 * [Code contributions](#code-contributions-)
 * [Writing Chaincode](#writing-chaincode-)
 * [Setting Up a Network](#setting-up-a-network-)
@@ -104,6 +105,66 @@ Note, in order to run behave directly, you must run 'make images' first to build
 ```
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 go test github.com/hyperledger/fabric/core/container -run=BuildImage_Obcca
+```
+
+## Building outside of Vagrant
+It is possible to build the project outside of Vagrant (e.g. when one already runs Linux and wants to develop natively). Generally speaking, one has to match the vagrant [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh).
+
+### Prerequisites
+* [Git client](https://git-scm.com/downloads)
+* [Go](https://golang.org/) - 1.6 or later
+* [RocksDB](https://github.com/facebook/rocksdb/blob/master/INSTALL.md) version 4.1 and its dependencies
+* [Docker](https://docs.docker.com/engine/installation/)
+* [Pip](https://pip.pypa.io/en/stable/installing/)
+* Set the maximum number of open files to 10000 or greater for your OS
+
+### Docker
+Make sure that the Docker daemon initialization includes the options
+```
+-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
+```
+
+Typically, docker runs as a `service` task, with configuration file at `/etc/default/docker`.
+
+Be aware that the Docker bridge (the `CORE_VM_ENDPOINT`) may not come
+up at the IP address currently assumed by the test environment
+(`172.17.0.1`). Use `ifconfig` or `ip addr` to find the docker bridge.
+
+### Building RocksDB
+```
+apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+cd /tmp
+git clone https://github.com/facebook/rocksdb.git
+cd rocksdb
+git checkout v4.1
+PORTABLE=1 make shared_lib
+INSTALL_PATH=/usr/local make install-shared
+```
+
+### `pip`, `behave` and `docker-compose`
+```
+pip install --upgrade pip
+pip install behave nose docker-compose
+pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3
+```
+
+### Building on Z
+To make building on Z easier and faster, [this script](https://github.com/hyperledger/fabric/tree/master/devenv/setupRHELonZ.sh) is provided (which is similar to the [setup file](https://github.com/hyperledger/fabric/blob/master/devenv/setup.sh) provided for vagrant). This script has been tested only on RHEL 7.2 and has some assumptions one might want to re-visit (firewall settings, development as root user, etc.). It is however sufficient for development in a personally-assigned VM instance.
+
+To get started, from a freshly installed OS:
+```
+sudo su
+yum install git
+mkdir -p $HOME/git/src/github.com/hyperledger
+cd $HOME/git/src/github.com/hyperledger
+git clone https://github.com/vpaprots/fabric.git
+source fabric/devenv/setupRHELonZ.sh
+```
+From there, follow instructions at [Installation](install.md):
+
+```
+cd $GOPATH/src/github.com/hyperledger/fabric
+make peer unit-test behave
 ```
 
 ## Code contributions <a name="contrib"></a>

--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -5,6 +5,7 @@ DOCKER_TAG ?= $(ARCH)-$(VERSION)
 VAGRANTIMAGE=packer_virtualbox-iso_virtualbox.box
 
 DOCKER_BASE_x86_64=ubuntu:trusty
+DOCKER_BASE_s390x=s390x/ubuntu:xenial
 
 DOCKER_BASE=$(DOCKER_BASE_$(ARCH))
 

--- a/images/base/scripts/common/setup.sh
+++ b/images/base/scripts/common/setup.sh
@@ -129,7 +129,7 @@ git checkout tags/v4.1
 if [ x$MACHINE = xs390x ]
 then
     echo There were some bugs in 4.1 for x/p, dev stream has the fix, living dangereously, fixing in place
-    sed -i -e "s/-march=native/-march=zEC12/" build_tools/build_detect_platform
+    sed -i -e "s/-march=native/-march=z196/" build_tools/build_detect_platform
     sed -i -e "s/-momit-leaf-frame-pointer/-DDUMBDUMMY/" Makefile
 fi
 

--- a/images/base/scripts/common/setup.sh
+++ b/images/base/scripts/common/setup.sh
@@ -18,23 +18,37 @@ apt-get install --yes git
 
 # Set Go environment variables needed by other scripts
 export GOPATH="/opt/gopath"
-export GOROOT="/opt/go"
-PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 #install golang
 #apt-get install --yes golang
 mkdir -p $GOPATH
+MACHINE=`uname -m`
+if [ x$MACHINE = xs390x ]
+then
+   apt-get install --yes golang
+   export GOROOT="/usr/lib/go-1.6"
+elif [ x$MACHINE = xppc64 ]
+then
+   echo "TODO: Add PPC support"
+   exit
+elif [ x$MACHINE = xx86_64 ]
+then
+   export GOROOT="/opt/go"
+   
+   #ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
+   ARCH=amd64
+   GO_VER=1.6
+   
+   cd /tmp
+   wget --quiet --no-check-certificate https://storage.googleapis.com/golang/go$GO_VER.linux-${ARCH}.tar.gz
+   tar -xvf go$GO_VER.linux-${ARCH}.tar.gz
+   mv go $GOROOT
+   chmod 775 $GOROOT
+   rm go$GO_VER.linux-${ARCH}.tar.gz
+fi
 
-#ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
-ARCH=amd64
-GO_VER=1.6
+PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
-cd /tmp
-wget --quiet --no-check-certificate https://storage.googleapis.com/golang/go$GO_VER.linux-${ARCH}.tar.gz
-tar -xvf go$GO_VER.linux-${ARCH}.tar.gz
-mv go $GOROOT
-chmod 775 $GOROOT
-rm go$GO_VER.linux-${ARCH}.tar.gz
 cat <<EOF >/etc/profile.d/goroot.sh
 export GOROOT=$GOROOT
 export GOPATH=$GOPATH
@@ -52,16 +66,21 @@ EOF
 #./configure && make && sudo make install
 #cd /tmp && rm -rf node-v$ver
 
-NODE_VER=0.12.7
-NODE_PACKAGE=node-v$NODE_VER-linux-x64.tar.gz
-TEMP_DIR=/tmp
-SRC_PATH=$TEMP_DIR/$NODE_PACKAGE
-
 cd $TEMP_DIR
-# First remove any prior packages downloaded in case of failure
-rm -f node*.tar.gz
-wget --quiet https://nodejs.org/dist/v$NODE_VER/$NODE_PACKAGE
-cd /usr/local && sudo tar --strip-components 1 -xzf $SRC_PATH
+if [ x$MACHINE = xs390x ]
+then
+    apt-get install --yes nodejs
+else
+    NODE_VER=0.12.7
+    NODE_PACKAGE=node-v$NODE_VER-linux-x64.tar.gz
+    TEMP_DIR=/tmp
+    SRC_PATH=$TEMP_DIR/$NODE_PACKAGE
+
+    # First remove any prior packages downloaded in case of failure
+    rm -f node*.tar.gz
+    wget --quiet https://nodejs.org/dist/v$NODE_VER/$NODE_PACKAGE
+    cd /usr/local && sudo tar --strip-components 1 -xzf $SRC_PATH
+fi
 
 # Install GRPC
 
@@ -90,9 +109,14 @@ apt-get install -y build-essential libtool
 #./configure
 ./configure --prefix=/usr
 
-make
-make check
-make install
+if [ x$MACHINE = xs390x ]
+then
+    echo FIXME: protobufs wont compile on 390, missing atomic call
+else
+    make
+    make check
+    make install
+fi
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 cd ~/
 
@@ -102,6 +126,13 @@ cd /tmp
 git clone https://github.com/facebook/rocksdb.git
 cd rocksdb
 git checkout tags/v4.1
+if [ x$MACHINE = xs390x ]
+then
+    echo There were some bugs in 4.1 for x/p, dev stream has the fix, living dangereously, fixing in place
+    sed -i -e "s/-march=native/-march=zEC12/" build_tools/build_detect_platform
+    sed -i -e "s/-momit-leaf-frame-pointer/-DDUMBDUMMY/" Makefile
+fi
+
 PORTABLE=1 make shared_lib
 INSTALL_PATH=/usr/local make install-shared
 ldconfig


### PR DESCRIPTION
S390X build support
## Description

Two parts:
- Top level makefile can be now run on z (docker tags sensitive to s390x)
- development on z is done on native OS, not in vagrant. Added a script to set it up RHEL on Z, make it ready for development, similar to devenv/setup.sh which does the same for vagrant
## Motivation and Context

With the eventual move to Jenkins, we want to dispatch to a z machine to test as well as x86. For that to happen, builds on s390x must happen out of the box, as similar to x86 as possible
## How Has This Been Tested?

Ran unit tests and behave tests, all pass
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:Volodymyr Paprotski vpaprots@ca.ibm.com
