### PR TITLE
resubmit raced custody requests, fix other custody bugs

### DIFF
--- a/consensus/obcpbft/complainer.go
+++ b/consensus/obcpbft/complainer.go
@@ -116,6 +116,12 @@ func (c *complainer) SuccessHash(hash string) {
 	c.complaints.Remove(hash)
 }
 
+// InCustody returns true if a request is currently in custody
+func (c *complainer) InCustody(req *Request) bool {
+	hash := hashReq(req)
+	return c.custody.InCustody(hash)
+}
+
 // Restart resets custody and complaint queues without calling into
 // the complaintHandler.  The complaint queue is drained completely.
 // The custody queue timeouts are reset.  Restart returns all requests

--- a/consensus/obcpbft/complainer.go
+++ b/consensus/obcpbft/complainer.go
@@ -25,6 +25,12 @@ import (
 	"github.com/hyperledger/fabric/consensus/obcpbft/custodian"
 )
 
+// CustodyPair is a tuple of enqueued id and data object
+type CustodyPair struct {
+	Hash    string
+	Request *Request
+}
+
 // complaintHandler represents a receiver of complaints
 type complaintHandler interface {
 	// Complain is called by the complainer to signal that custody
@@ -122,22 +128,28 @@ func (c *complainer) InCustody(req *Request) bool {
 	return c.custody.InCustody(hash)
 }
 
+// CustodyElements returns all requests currently in custody.
+func (c *complainer) CustodyElements() []CustodyPair {
+	var ret []CustodyPair
+	for _, pair := range c.custody.Elements() {
+		ret = append(ret, CustodyPair{pair.ID, pair.Data.(*Request)})
+	}
+	return ret
+}
+
 // Restart resets custody and complaint queues without calling into
 // the complaintHandler.  The complaint queue is drained completely.
 // The custody queue timeouts are reset.  Restart returns all requests
-// that are maintained in custody, or have been received from other replicas
-func (c *complainer) Restart() map[string]*Request {
-	reqs := make(map[string]*Request)
+// that were in the complaint queue.
+func (c *complainer) Restart() []CustodyPair {
+	var reqs []CustodyPair
 
-	complaints := c.complaints.RemoveAll()
-	for _, pair := range complaints {
-		reqs[pair.ID] = pair.Data.(*Request)
+	for _, pair := range c.custody.RemoveAll() {
+		c.custody.Register(pair.ID, pair.Data)
 	}
 
-	custody := c.custody.RemoveAll()
-	for _, pair := range custody {
-		c.custody.Register(pair.ID, pair.Data)
-		reqs[pair.ID] = pair.Data.(*Request)
+	for _, pair := range c.complaints.RemoveAll() {
+		reqs = append(reqs, CustodyPair{pair.ID, pair.Data.(*Request)})
 	}
 
 	return reqs

--- a/consensus/obcpbft/custodian/custodian.go
+++ b/consensus/obcpbft/custodian/custodian.go
@@ -117,6 +117,14 @@ func (c *Custodian) Remove(id string) bool {
 	return ok
 }
 
+// InCustody returns true if an object is in custody
+func (c *Custodian) InCustody(id string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, ok := c.requests[id]
+	return ok
+}
+
 // Elements returns all objects that are currently under custody.
 func (c *Custodian) Elements() []CustodyPair {
 	c.lock.Lock()

--- a/consensus/obcpbft/custodian/custodian.go
+++ b/consensus/obcpbft/custodian/custodian.go
@@ -41,8 +41,6 @@ type custody struct {
 
 // Custodian provides a timeout service for objects.  The timeout is
 // the same for all enqueued objects.  Order is retained.
-// When a timeout expires, the object is re-registered automatically
-// so that the timeout fires once every timeout duration until removed
 type Custodian struct {
 	lock     sync.Mutex
 	timeout  time.Duration
@@ -75,6 +73,7 @@ func New(timeout time.Duration, notifyCb CustodyNotify) *Custodian {
 	c.timer = time.NewTimer(time.Hour)
 	c.timer.Stop()
 	c.stopCh = make(chan struct{})
+	go c.notifyRoutine()
 	return c
 }
 
@@ -168,56 +167,35 @@ func (c *Custodian) resetTimer() {
 		diff = 0
 	}
 	c.timer.Reset(diff)
-	logger.Debug("Resetting timer to %v for req %s", diff, next.id)
-	go c.notifyRoutine()
 }
 
 func (c *Custodian) notifyRoutine() {
-	select {
-	case <-c.timer.C:
-		logger.Debug("Custodian timer expired")
-		break
-	case <-c.stopCh:
-		c.stopCh = nil
-		return
-	}
-	c.lock.Lock()
+	for {
+		select {
+		case <-c.timer.C:
+			break
+		case <-c.stopCh:
+			c.stopCh = nil
+			return
+		}
 
-	var expired *CustodyPair
+		var obj *custody
 
-	if len(c.seq) == 0 {
-		return
-	}
-
-	obj := c.seq[0]
-
-	if obj.deadline.After(time.Now()) {
-		// Timers are always in order in seq
-		logger.Debug("Timer expired, but first timer in the future")
-		return
-	}
-
-	delete(c.requests, obj.id)
-	c.seq = c.seq[1:]
-
-	if !obj.canceled {
-		logger.Debug("Found %s was not expired", obj.id)
-		expired = &CustodyPair{obj.id, obj.data}
-	} else {
+		c.lock.Lock()
+		if len(c.seq) > 0 {
+			obj = c.seq[0]
+			if obj.deadline.After(time.Now()) {
+				obj = nil
+			} else {
+				delete(c.requests, obj.id)
+				c.seq = c.seq[1:]
+			}
+		}
 		c.resetTimer()
-		logger.Debug("Found %s was already expired", obj.id)
-	}
+		c.lock.Unlock()
 
-	c.lock.Unlock()
-
-	if expired != nil {
-		logger.Debug("Determined timer expiration was for %s", expired.ID)
-
-		// re-Register the expired request so that it remains in the store until manually removed
-		c.Register(expired.ID, expired.Data)
-
-		c.notifyCb(expired.ID, expired.Data)
-	} else {
-		logger.Debug("Timer expired, but first timer had already been canceled")
+		if obj != nil && !obj.canceled {
+			c.notifyCb(obj.id, obj.data)
+		}
 	}
 }

--- a/consensus/obcpbft/custodian/custodian_test.go
+++ b/consensus/obcpbft/custodian/custodian_test.go
@@ -38,6 +38,12 @@ func TestCustody(t *testing.T) {
 	defer c.Stop()
 
 	c.Register("foo", "bar")
+	if !c.InCustody("foo") {
+		t.Error("should have request in custody")
+	}
+	if c.InCustody("bar") {
+		t.Error("should not have request in custody")
+	}
 	select {
 	case req := <-notify:
 		if req.id != "foo" || req.data != "bar" {
@@ -45,6 +51,9 @@ func TestCustody(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Error("did not receive notification")
+	}
+	if c.InCustody("foo") {
+		t.Error("should not have request in custody")
 	}
 }
 

--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -112,7 +112,9 @@ type omniProto struct {
 	VerifyImpl                 func(peerID *pb.PeerID, signature []byte, message []byte) error
 	GetBlockImpl               func(id uint64) (block *pb.Block, err error)
 	GetCurrentStateHashImpl    func() (stateHash []byte, err error)
-	GetBlockchainSizeImpl      func() (uint64, error)
+	GetBlockchainSizeImpl      func() uint64
+	GetBlockHeadMetadataImpl   func() ([]byte, error)
+	GetBlockchainInfoBlobImpl  func() []byte
 	HashBlockImpl              func(block *pb.Block) ([]byte, error)
 	VerifyBlockchainImpl       func(start, finish uint64) (uint64, error)
 	PutBlockImpl               func(blockNumber uint64, block *pb.Block) error
@@ -152,6 +154,7 @@ type omniProto struct {
 
 	// Orderer methods
 	ValidateImpl func(seqNo uint64, id []byte) (commit bool, correctedID []byte, peerIDs []*pb.PeerID)
+	SkipToImpl   func(seqNo uint64, id []byte, peers []*pb.PeerID)
 }
 
 func (op *omniProto) GetNetworkInfo() (self *pb.PeerEndpoint, network []*pb.PeerEndpoint, err error) {
@@ -210,9 +213,23 @@ func (op *omniProto) GetCurrentStateHash() (stateHash []byte, err error) {
 
 	panic("Unimplemented")
 }
-func (op *omniProto) GetBlockchainSize() (uint64, error) {
+func (op *omniProto) GetBlockchainSize() uint64 {
 	if nil != op.GetBlockchainSizeImpl {
 		return op.GetBlockchainSizeImpl()
+	}
+
+	panic("Unimplemented")
+}
+func (op *omniProto) GetBlockHeadMetadata() ([]byte, error) {
+	if nil != op.GetBlockHeadMetadataImpl {
+		return op.GetBlockHeadMetadataImpl()
+	}
+
+	return nil, nil
+}
+func (op *omniProto) GetBlockchainInfoBlob() []byte {
+	if nil != op.GetBlockchainInfoBlobImpl {
+		return op.GetBlockchainInfoBlobImpl()
 	}
 
 	panic("Unimplemented")
@@ -416,6 +433,15 @@ func (op *omniProto) Validate(seqNo uint64, id []byte) (commit bool, correctedID
 
 	panic("Unimplemented")
 
+}
+
+func (op *omniProto) SkipTo(seqNo uint64, meta []byte, id []*pb.PeerID) {
+	if nil != op.SkipToImpl {
+		op.SkipToImpl(seqNo, meta, id)
+		return
+	}
+
+	panic("Unimplemented")
 }
 
 func (op *omniProto) deliver(msg []byte, target *pb.PeerID) {

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -326,15 +326,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 
 		logger.Info("New consensus request received: %s", hash)
 
-		if (op.pbft.primary(op.pbft.view) == op.pbft.id) && op.pbft.activeView { // primary
-			err := op.leaderProcReq(req)
-			if err != nil {
-				return err
-			}
-		} else { // backup
-			batchMsg := &BatchMessage{&BatchMessage_Request{req}}
-			op.broadcastMsg(batchMsg)
-		}
+		op.submitToLeader(req)
 		return nil
 	}
 

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -329,7 +329,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 		req := op.txToReq(ocMsg.Payload)
 		hash := op.complainer.Custody(req)
 
-		logger.Info("New consensus request received: %s", hash)
+		logger.Info("Batch replica %d received new consensus request: %s", op.pbft.id, hash)
 
 		op.submitToLeader(req)
 		return nil

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -274,7 +274,7 @@ func (op *obcBatch) leaderProcReq(req *Request) error {
 		return nil
 	}
 
-	hash := op.complainer.Custody(req)
+	hash := hashReq(req)
 
 	logger.Debug("Batch primary %d queueing new request %s", op.pbft.id, hash)
 	op.batchStore = append(op.batchStore, req)

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -163,6 +163,12 @@ func TestBatchStaleCustody(t *testing.T) {
 			}
 			return nil
 		},
+		BroadcastImpl: func(msg *pb.Message, pt pb.PeerEndpoint_Type) error {
+			// we need this mock because occasionally the
+			// custody timer for req3 goes off, and a
+			// complaint is sent.
+			return nil
+		},
 		BeginTxBatchImpl: func(id interface{}) error {
 			return nil
 		},

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package obcpbft
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/hyperledger/fabric/consensus"
+	pb "github.com/hyperledger/fabric/protos"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/spf13/viper"
 )
 
@@ -141,4 +144,50 @@ func TestBatchCustody(t *testing.T) {
 		}
 	}
 
+}
+
+func TestBatchStaleCustody(t *testing.T) {
+	config := loadConfig()
+	config.Set("general.batchsize", "1")
+	config.Set("general.timeout.batch", "250ms")
+	config.Set("general.timeout.request", "250ms")
+	config.Set("general.timeout.viewchange", "800ms")
+
+	var reqs []*Request
+	stack := &omniProto{
+		UnicastImpl: func(msg *pb.Message, p *pb.PeerID) error {
+			m := &Message{}
+			proto.Unmarshal(msg.Payload, m)
+			if r := m.GetRequest(); r != nil {
+				reqs = append(reqs, r)
+			}
+			return nil
+		},
+		BeginTxBatchImpl: func(id interface{}) error {
+			return nil
+		},
+		ExecTxsImpl: func(id interface{}, txs []*pb.Transaction) ([]byte, error) {
+			return nil, nil
+		},
+		CommitTxBatchImpl: func(id interface{}, meta []byte) (*pb.Block, error) {
+			return nil, nil
+		},
+	}
+	op := newObcBatch(1, config, stack)
+	defer op.Close()
+
+	req1 := createOcMsgWithChainTx(1)
+	op.RecvMsg(req1, &pb.PeerID{})
+	op.RecvMsg(createOcMsgWithChainTx(2), &pb.PeerID{})
+	<-op.idleChannel()
+	op.pbft.currentExec = new(uint64) // so that pbft.execDone doesn't get unhappy
+	*op.pbft.currentExec = 1
+	rblock2raw, _ := proto.Marshal(&RequestBlock{[]*Request{reqs[1]}})
+	op.executeImpl(1, rblock2raw)
+	time.Sleep(500 * time.Millisecond)
+	<-op.idleChannel()
+
+	if len(reqs) != 3 || !reflect.DeepEqual(reqs[2].Payload, req1.Payload) {
+		t.Error("expected resubmitted request")
+	}
 }

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -90,7 +90,7 @@ func TestBatchCustody(t *testing.T) {
 			// Keep replica 0 from unnecessarilly advancing its view
 			config.Set("general.timeout.request", "1500ms")
 		} else {
-			config.Set("general.timeout.request", "250ms")
+			config.Set("general.timeout.request", "1000ms")
 		}
 		config.Set("general.timeout.viewchange", "800ms")
 		return newObcBatch(id, config, stack)

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -788,12 +788,10 @@ func (op *obcSieve) executeFlush(flush *Flush) {
 		op.rollback()
 	}
 
-	reqs := op.complainer.Restart()
-	if op.pbft.primary(op.pbft.view) == op.id {
-		for hash, req := range reqs {
-			logger.Info("Replica %d queueing request under custody: %s", op.id, hash)
-			op.queuedTx = append(op.queuedTx, req)
-		}
+	op.complainer.Restart()
+	for _, pair := range op.complainer.CustodyElements() {
+		logger.Info("Replica %d resubmitting request under custody: %s", op.id, pair.Hash)
+		op.submitToLeader(pair.Request)
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

If one of our requests turned stale without having been committed (because a newer request of us raced it), we need to repackage and resubmit the request.

During implementation of this patch, other bugs were uncovered and have been fixed in separate commits in this PR.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1484.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

unit tests keep failing erratically (all over the place) locally, hoping for CI to work better.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:
