### PR TITLE
Issue 1509 address lint issues membersrvc/ca/tlsca_test.go

### DIFF
--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -46,8 +46,8 @@ import (
 )
 
 var (
-	eca_s   *ECA
-	tlsca_s *TLSCA
+	ecaS   *ECA
+	tlscaS *TLSCA
 	srv     *grpc.Server
 )
 
@@ -67,8 +67,8 @@ func TestTLS(t *testing.T) {
 func startTLSCA(t *testing.T) {
 	LogInit(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, os.Stdout)
 
-	eca_s = NewECA()
-	tlsca_s = NewTLSCA(eca_s)
+	ecaS = NewECA()
+	tlscaS = NewTLSCA(ecaS)
 
 	var opts []grpc.ServerOption
 	creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.certfile"), viper.GetString("server.tls.keyfile"))
@@ -81,8 +81,8 @@ func startTLSCA(t *testing.T) {
 
 	srv = grpc.NewServer(opts...)
 
-	eca_s.Start(srv)
-	tlsca_s.Start(srv)
+	ecaS.Start(srv)
+	tlscaS.Start(srv)
 
 	sock, err := net.Listen("tcp", viper.GetString("server.port"))
 	if err != nil {


### PR DESCRIPTION
Address lint errors 
## Description
- Addressing each lint issue in tlsca.go (listed out in #[1286](https://github.com/hyperledger/fabric/issues/1286))
## Motivation and Context

We are "joining forces" to improve on a few key code quality measures - and lint warnings/errors is one of these measures.

Fixes  #[1509](https://github.com/hyperledger/fabric/issues/1509)
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

`golint + make all
`
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
