### PR TITLE
Issue 1510 address lint issues in membersrvc/ca/validity_period_test.go

### DIFF
--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -98,17 +98,17 @@ func TestValidityPeriod(t *testing.T) {
 
 	// 6. Compare the values
 	if validityPeriodA != validityPeriodFromLedgerA {
-		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriod_A, validityPeriodFromLedger_A)
+		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriodA, validityPeriodFromLedgerA)
 		t.Fail()
 	}
 
 	if validityPeriodB != validityPeriodFromLedgerB {
-		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriod_B, validityPeriodFromLedger_B)
+		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriodB, validityPeriodFromLedgerB)
 		t.Fail()
 	}
 
 	if validityPeriodB-validityPeriodA != updateInterval {
-		t.Logf("Validity period difference must be equal to the update interval. Expected: %s, Actual: %s", updateInterval, validityPeriod_B-validityPeriod_A)
+		t.Logf("Validity period difference must be equal to the update interval. Expected: %s, Actual: %s", updateInterval, validityPeriodB-validityPeriodA)
 		t.Fail()
 	}
 

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -83,38 +83,38 @@ func TestValidityPeriod(t *testing.T) {
 	time.Sleep(time.Second * 240)
 
 	// 2. Obtain the validity period by querying and directly from the ledger
-	validityPeriod_A := queryValidityPeriod(t)
-	validityPeriodFromLedger_A := getValidityPeriodFromLedger(t)
+	validityPeriodA := queryValidityPeriod(t)
+	validityPeriodFromLedgerA := getValidityPeriodFromLedger(t)
 
 	// 3. Wait for the validity period to be updated...
 	time.Sleep(time.Second * 40)
 
 	// ... and read the values again
-	validityPeriod_B := queryValidityPeriod(t)
-	validityPeriodFromLedger_B := getValidityPeriodFromLedger(t)
+	validityPeriodB := queryValidityPeriod(t)
+	validityPeriodFromLedgerB := getValidityPeriodFromLedger(t)
 
 	// 5. Stop TCA and Openchain
 	stopServices(t)
 
 	// 6. Compare the values
-	if validityPeriod_A != validityPeriodFromLedger_A {
+	if validityPeriodA != validityPeriodFromLedgerA {
 		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriod_A, validityPeriodFromLedger_A)
 		t.Fail()
 	}
 
-	if validityPeriod_B != validityPeriodFromLedger_B {
+	if validityPeriodB != validityPeriodFromLedgerB {
 		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriod_B, validityPeriodFromLedger_B)
 		t.Fail()
 	}
 
-	if validityPeriod_B-validityPeriod_A != updateInterval {
+	if validityPeriodB-validityPeriodA != updateInterval {
 		t.Logf("Validity period difference must be equal to the update interval. Expected: %s, Actual: %s", updateInterval, validityPeriod_B-validityPeriod_A)
 		t.Fail()
 	}
 
 	// 7. since the validity period is used as time in the validators convert both validity periods to Unix time and compare them
-	vpA := time.Unix(validityPeriodFromLedger_A, 0)
-	vpB := time.Unix(validityPeriodFromLedger_B, 0)
+	vpA := time.Unix(validityPeriodFromLedgerA, 0)
+	vpB := time.Unix(validityPeriodFromLedgerB, 0)
 
 	nextVP := vpA.Add(time.Second * 37)
 	if !vpB.Equal(nextVP) {
@@ -204,13 +204,13 @@ func getValidityPeriodFromLedger(t *testing.T) int64 {
 		t.Fail()
 	}
 
-	vp_bytes, err := ledger.GetState(cid, "system.validity.period", true)
+	vpBytes, err := ledger.GetState(cid, "system.validity.period", true)
 	if err != nil {
 		t.Logf("Failed reading validity period from the ledger: %s", err)
 		t.Fail()
 	}
 
-	i, err := strconv.ParseInt(string(vp_bytes[:]), 10, 64)
+	i, err := strconv.ParseInt(string(vpBytes[:]), 10, 64)
 	if err != nil {
 		t.Logf("Failed to parse validity period: %s", err)
 		t.Fail()


### PR DESCRIPTION
Address lint errors 
## Description
- Addressing each lint issue in validity_period_test.go (listed out in #[1286](https://github.com/hyperledger/fabric/issues/1286))
## Motivation and Context

We are "joining forces" to improve on a few key code quality measures - and lint warnings/errors is one of these measures.

Fixes  #[1510](https://github.com/hyperledger/fabric/issues/1510)

```
ca/validity_period_test.go:86:2: don't use underscores in Go names; var validityPeriod_A should be validityPeriodA
ca/validity_period_test.go:87:2: don't use underscores in Go names; var validityPeriodFromLedger_A should be validityPeriodFromLedgerA
ca/validity_period_test.go:93:2: don't use underscores in Go names; var validityPeriod_B should be validityPeriodB
ca/validity_period_test.go:94:2: don't use underscores in Go names; var validityPeriodFromLedger_B should be validityPeriodFromLedgerB
ca/validity_period_test.go:207:2: don't use underscores in Go names; var vp_bytes should be vpBytes
```
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

`golint + make all
`
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
