### PR TITLE
Allow cc call cc for minimal security settings#issue1530

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -1,0 +1,540 @@
+# CA server parameters
+#
+server:
+        # current version of the CA
+        version: "0.1"
+
+        # limits the number of operating system threads used by the CA
+        gomaxprocs: 2
+
+        # path to the OBC state directory and CA state subdirectory
+        # rootpath: "."
+        # cadir: ".ca"
+
+        # port the CA services are listening on
+        port: ":50051"
+
+        # TLS certificate and key file paths
+        tls:
+
+security:
+    # Can be 256 or 384
+    # Must be the same as in core.yaml
+    level: 256
+
+# Enabling/disabling different logging levels of the CA.
+#
+logging:
+        trace: 0
+        info: 1
+        warning: 1
+        error: 1
+        panic: 1
+
+# Default users to be registered with the CA on first launch.  The role is a binary OR
+# of the different roles a user can have:
+#
+# - simple client such as a wallet: CLIENT
+# - non-validating peer: PEER
+# - validating client: VALIDATOR
+# - auditing client: AUDITOR
+#
+eca:
+        affiliation_groups:
+           banks_and_institutions:
+              banks:
+                  bank_a:
+                  bank_b:
+                  bank_c:              		
+              institutions:
+                  institution_a:
+        users:
+                # <EnrollmentID>: <role (1:client, 2: peer, 4: validator, 8: auditor)> <EnrollmentPWD> <Affiliation> <Affiliation_Role>
+                lukas: 1 NPKYL39uKbkj institution_a	00001
+                diego: 1 DRJ23pEQl16a institution_a	00002
+                jim: 1 6avZQLwcUe9b institution_a	00003
+
+                vp: 4 f3489fy98ghf
+
+pki:
+          validity-period:
+                 # Setting the update property will prevent the invocation of the update_validity_period system chaincode to update the validity period.
+                 update: false
+                 chaincodeHash: 6091c3abd07c18edd6ef48ae24cfe409522f7defb51e4103dfa61ca3012386380c1b179f904375e253f20f4b2c5c848299988e65d8b80cb3f6b3d848b6fb2230
+                 # TLS Settings for communications to update the validity period
+                 tls:
+                         enabled: false
+                         cert:
+                                file: testdata/server1.pem
+                         key:
+                                file: testdata/server1.key
+                         # The server name use to verify the hostname returned by TLS handshake
+                         server-host-override:
+                 devops-address: 0.0.0.0:40404
+
+###############################################################################
+#
+#    CLI section
+#
+###############################################################################
+cli:
+
+    # The address that the cli process will use for callbacks from chaincodes
+    address: 0.0.0.0:30304
+
+
+
+###############################################################################
+#
+#    REST section
+#
+###############################################################################
+rest:
+
+    # Enable/disable setting for the REST service. It is recommended to disable
+    # REST service on validators in production deployment and use non-validating
+    # nodes to host REST service
+    enabled: true
+
+    # The address that the REST service will listen on for incoming requests.
+    address: 0.0.0.0:5000
+
+
+###############################################################################
+#
+#    LOGGING section
+#
+###############################################################################
+logging:
+
+    # Valid logging levels are case-insensitive strings chosen from
+
+    #     CRITICAL | ERROR | WARNING | NOTICE | INFO | DEBUG
+
+    # Logging 'module' names are also strings, however valid module names are
+    # defined at runtime and are not checked for validity during option
+    # processing.
+
+    # Default logging levels are specified here for each of the peer
+    # commands. For commands that have subcommands, the defaults also apply to
+    # all subcommands of the command. These logging levels can be overridden
+    # on the command line using the --logging-level command-line option, or by
+    # setting the CORE_LOGGING_LEVEL environment variable.
+
+    # The logging level specification is of the form
+
+    #     [<module>[,<module>...]=]<level>[:[<module>[,<module>...]=]<level>...]
+
+    # A logging level by itself is taken as the overall default. Otherwise,
+    # overrides for individual or groups of modules can be specified using the
+    # <module>[,<module>...]=<level> syntax.
+
+    # Examples:
+    #   info                                       - Set default to INFO
+    #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
+    #   chaincode=info:main=debug:db=debug:warning - Same as above
+    peer:      debug
+    crypto:    info
+    status:    warning
+    stop:      warning
+    login:     warning
+    vm:        warning
+    chaincode: warning
+
+
+###############################################################################
+#
+#    Peer section
+#
+###############################################################################
+peer:
+
+    # Peer Version following version semantics as described here http://semver.org/
+    # The Peer supplies this version in communications with other Peers
+    version:  0.1.0
+
+    # The Peer id is used for identifying this Peer instance.
+    id: jdoe
+
+    # The privateKey to be used by this peer
+    # privateKey: 794ef087680e2494fa4918fd8fb80fb284b50b57d321a31423fe42b9ccf6216047cea0b66fe8365a8e3f2a8140c6866cc45852e63124668bee1daa9c97da0c2a
+
+    # The networkId allows for logical seperation of networks
+    # networkId: dev
+    # networkId: test
+    networkId: dev
+
+    Dockerfile:  |
+        from hyperledger/fabric-baseimage:latest
+        # Copy GOPATH src and install Peer
+        COPY src $GOPATH/src
+        RUN mkdir -p /var/hyperledger/db
+        WORKDIR $GOPATH/src/github.com/hyperledger/fabric/peer/
+        RUN CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/hyperledger/fabric/peer/core.yaml $GOPATH/bin
+
+
+    # The Address this Peer will listen on
+    listenAddress: 0.0.0.0:40404
+    # The Address this Peer will bind to for providing services
+    address: 0.0.0.0:40404
+    # Whether the Peer should programmatically determine the address to bind to.
+    # This case is useful for docker containers.
+    addressAutoDetect: false
+
+    # Peer port to accept connections on
+    port:    40404
+    # Setting for runtime.GOMAXPROCS(n). If n < 1, it does not change the current setting
+    gomaxprocs: -1
+    workers: 2
+
+    # Sync related configuration
+    sync:
+        blocks:
+            # Channel size for readonly SyncBlocks messages channel for receiving
+            # blocks from oppositie Peer Endpoints.
+            # NOTE: currently messages are not stored and forwarded, but rather
+            # lost if the channel write blocks.
+            channelSize: 10
+        state:
+            snapshot:
+                # Channel size for readonly syncStateSnapshot messages channel
+                # for receiving state deltas for snapshot from oppositie Peer Endpoints.
+                # NOTE: currently messages are not stored and forwarded, but
+                # rather lost if the channel write blocks.
+                channelSize: 50
+            deltas:
+                # Channel size for readonly syncStateDeltas messages channel for
+                # receiving state deltas for a syncBlockRange from oppositie
+                # Peer Endpoints.
+                # NOTE: currently messages are not stored and forwarded,
+                # but rather lost if the channel write blocks.
+                channelSize: 20
+
+    # Validator defines whether this peer is a validating peer or not, and if
+    # it is enabled, what consensus plugin to load
+    validator:
+        enabled: true
+
+        consensus:
+            # Consensus plugin to use. The value is the name of the plugin, e.g. pbft, noops ( this value is case-insensitive)
+            # if the given value is not recognized, we will default to noops
+            plugin: noops
+
+            # total number of consensus messages which will be buffered per connection before delivery is rejected
+            buffersize: 1000
+
+        events:
+            # The address that the Event service will be enabled on the validator
+            address: 0.0.0.0:31315
+
+            # total number of events that could be buffered without blocking the
+            # validator sends
+            buffersize: 100
+
+            # milliseconds timeout for producer to send an event.
+            # if < 0, if buffer full, unblocks immediately and not send
+            # if 0, if buffer full, will block and guarantee the event will be sent out
+            # if > 0, if buffer full, blocks till timeout
+            timeout: 10
+        # Setting the validity-period.verification to false will disable the verification
+        # of the validity period in the validator
+        validity-period:
+            verification: false
+
+    # TLS Settings for p2p communications
+    tls:
+        enabled:  false
+        cert:
+            file: testdata/server1.pem
+        key:
+            file: testdata/server1.key
+        # The server name use to verify the hostname returned by TLS handshake
+        serverhostoverride:
+
+    # PKI member services properties
+    pki:
+        eca:
+            paddr: localhost:50051
+        tca:
+            paddr: localhost:50051
+        tlsca:
+            paddr: localhost:50051
+        tls:
+            enabled: false
+            rootcert:
+                file: tlsca.cert
+            # The server name use to verify the hostname returned by TLS handshake
+            serverhostoverride:
+
+    # Peer discovery settings.  Controls how this peer discovers other peers
+    discovery:
+
+        # The root nodes are used for bootstrapping purposes, and generally
+        # supplied through ENV variables
+        rootnode:
+
+        # The duration of time between attempts to asks peers for their connected peers
+        period:  5s
+
+        ## leaving this in for example of sub map entry
+        # testNodes:
+        #    - node   : 1
+        #      ip     : 127.0.0.1
+        #      port   : 40404
+        #    - node   : 2
+        #      ip     : 127.0.0.1
+        #      port   : 40404
+
+        # Should the discovered nodes and their reputations
+        # be stored in DB and persisted between restarts
+        persist:    true
+
+        # if peer discovery is off
+        # the peer window will show
+        # only what retrieved by active
+        # peer [true/false]
+        enabled:    true
+
+        # number of workers that
+        # test the peers for being
+        # online [1..10]
+        workers: 8
+
+        # the period in seconds with which the discovery
+        # tries to reconnect to successful nodes
+        # 0 means the nodes are not reconnected
+        touchPeriod: 600
+
+        # the maximum nuber of nodes to reconnect to
+        # -1 for unlimited
+        touchMaxNodes: 100
+
+    # Path on the file system where peer will store data
+    fileSystemPath: /var/hyperledger/production
+
+
+    profile:
+        enabled:     false
+        listenAddress: 0.0.0.0:6060
+
+###############################################################################
+#
+#    VM section
+#
+###############################################################################
+vm:
+
+    # Endpoint of the vm management system.  For docker can be one of the following in general
+    # unix:///var/run/docker.sock
+    # http://localhost:2375
+    # https://localhost:2376
+    endpoint: unix:///var/run/docker.sock
+
+    # settings for docker vms
+    docker:
+        tls:
+            enabled: false
+            cert:
+                file: /path/to/server.pem
+            ca:
+                file: /path/to/ca.pem
+            key:
+                file: /path/to/server-key.pem
+
+###############################################################################
+#
+#    Chaincode section
+#
+###############################################################################
+chaincode:
+
+    # The id is used by the Chaincode stub to register the executing Chaincode
+    # ID with the Peerand is generally supplied through ENV variables
+    # the Path form of ID is provided when deploying the chaincode. The name is
+    # used for all other requests. The name is really a hashcode
+    # returned by the system in response to the deploy transaction. In
+    # development mode where user runs the chaincode, the name can be any string
+    id:
+        path:
+        name:
+
+    golang:
+
+        # This is the basis for the Golang Dockerfile.  Additional commands will
+        # be appended depedendent upon the chaincode specification.
+        Dockerfile:  |
+            from hyperledger/fabric-baseimage
+            #from utxo:0.1.0
+            COPY src $GOPATH/src
+            WORKDIR $GOPATH
+
+    car:
+
+        # This is the basis for the CAR Dockerfile.  Additional commands will
+        # be appended depedendent upon the chaincode specification.
+        Dockerfile:  |
+            FROM hyperledger/fabric-baseimage
+
+    # timeout in millisecs for starting up a container and waiting for Register
+    # to come through. 1sec should be plenty for chaincode unit tests
+    startuptimeout: 1000
+
+    #timeout in millisecs for deploying chaincode from a remote repository.
+    deploytimeout: 30000
+
+    #mode - options are "dev", "net"
+    #dev - in dev mode, user runs the chaincode after starting validator from
+    # command line on local machine
+    #net - in net mode validator will run chaincode in a docker container
+
+    mode: net
+    # typically installpath should not be modified. Otherwise, user must ensure
+    # the chaincode executable is placed in the path specifed by installpath in
+    # the image
+    installpath: /opt/gopath/bin/
+
+###############################################################################
+#
+#    Ledger section - ledger configuration encompases both the blockchain
+#    and the state
+#
+###############################################################################
+ledger:
+
+  blockchain:
+
+    # Define the genesis block
+    genesisBlock:
+
+      # Deploy chaincodes into the genesis block
+      chaincodes:
+
+        #sample_syscc:
+        #  path: github.com/hyperledger/fabric/core/system_chaincode/sample_syscc
+        #  type: GOLANG
+        #  constructor:
+        #    args:
+        #      - greetings
+        #      - hello world
+
+    # Setting the deploy-system-chaincode property to false will prevent the
+    # deploying of system chaincode at genesis time.
+    deploy-system-chaincode: false
+
+  state:
+
+    # Control the number state deltas that are maintained. This takes additional
+    # disk space, but allow the state to be rolled backwards and forwards
+    # without the need to replay transactions.
+    deltaHistorySize: 500
+
+    # The data structure in which the state will be stored. Different data
+    # structures may offer different performance characteristics. 
+    # Options are 'buckettree', 'trie' and 'raw'.
+    # ( Note:'raw' is experimental and incomplete. )
+    # If not set, the default data structure is the 'buckettree'.
+    # This CANNOT be changed after the DB has been created.
+    dataStructure:
+      # The name of the data structure is for storing the state
+      name: buckettree
+      # The data structure specific configurations
+      configs:
+        # configurations for 'bucketree'. These CANNOT be changed after the DB
+        # has been created. 'numBuckets' defines the number of bins that the
+        # state key-values are to be divided
+        numBuckets: 1000003
+        # 'maxGroupingAtEachLevel' defines the number of bins that are grouped
+        #together to construct next level of the merkle-tree (this is applied
+        # repeatedly for constructing the entire tree).
+        maxGroupingAtEachLevel: 5
+        # 'bucketCacheSize' defines the size (in MBs) of the cache that is used to keep
+        # the buckets (from root upto secondlast level) in memory. This cache helps
+        # in making state hash computation faster. A value less than or equals to zero
+        # leads to disabling this caching. This caching helps more if transactions
+        # perform significant writes.
+        bucketCacheSize: 100
+
+        # configurations for 'trie'
+        # 'tire' has no additional configurations exposed as yet
+
+
+###############################################################################
+#
+#    Security section - Applied to all entities (client, NVP, VP)
+#
+###############################################################################
+security:
+    # Enable security will force every entity on the network to enroll with obc-ca
+    # and maintain a valid set of certificates in order to communicate with
+    # other peers
+    enabled: false
+    # To enroll NVP or VP with membersrvc. These parameters are for 1 time use.
+    # They will not be valid on subsequent times without un-enroll first.
+    # The values come from off-line registration with obc-ca. For testing, make
+    # sure the values are in membersrvc/membersrvc.yaml file eca.users
+    enrollID: vp
+    enrollSecret: f3489fy98ghf
+    # To enable privacy of transactions (requires security to be enabled). This
+    # encrypts the transaction content during transit and at rest. The state
+    # data is also encrypted
+    privacy: false
+
+    # Can be 256 or 384. If you change here, you have to change also
+    # the same property in membersrvc.yaml to the same value
+    level: 256
+
+    # Can be SHA2 or SHA3. If you change here, you have to change also
+    # the same property in membersrvc.yaml to the same value
+    hashAlgorithm: SHA3
+
+    # TCerts related configuration
+    tcert:
+      batch:
+        # The size of the batch of TCerts
+        size:  200
+      attributes:
+        company: IBM
+        position: "Software Engineer"
+
+
+################################################################################
+#
+#   SECTION: STATETRANSFER
+#
+#   - This applies to recovery behavior when the replica has detected
+#     a state transfer is required
+#
+#   - This might happen:
+#     - During a view change in response to a faulty primary
+#     - After a network outage which has isolated the replica
+#     - If the current blockchain/state is determined to be corrupt
+#
+################################################################################
+statetransfer:
+
+    # Should a replica attempt to fix damaged blocks?
+    # In general, this should be set to true, setting to false will cause
+    # the replica to panic, and require a human's intervention to intervene
+    # and fix the corruption
+    recoverdamage: true
+
+    # The number of blocks to retrieve per sync request
+    blocksperrequest: 20
+
+    # The maximum number of state deltas to attempt to retrieve
+    # If more than this number of deltas is required to play the state up to date
+    # then instead the state will be flagged as invalid, and a full copy of the state
+    # will be retrieved instead
+    maxdeltas: 200
+
+    # Timeouts
+    timeout:
+
+        # How long may returning a single block take
+        singleblock: 2s
+
+        # How long may returning a single state delta take
+        singlestatedelta: 2s
+
+        # How long may transferring the complete state take
+        fullstate: 60s

--- a/core/chaincode/config.go
+++ b/core/chaincode/config.go
@@ -55,13 +55,12 @@ func SetupTestConfig() {
 	flag.Parse()
 
 	// Now set the configuration file
-	viper.SetEnvPrefix("HYPERLEDGER")
+	viper.SetEnvPrefix("CORE")
 	viper.AutomaticEnv()
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
-	viper.SetConfigName("core")          // name of config file (without extension)
+	viper.SetConfigName("chaincodetest")          // name of config file (without extension)
 	viper.AddConfigPath("./")            // path to look for the config file in
-	viper.AddConfigPath("./../../peer/") // path to look for the config file in
 	err := viper.ReadInConfig()          // Find and read the config file
 	if err != nil {                      // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s \n", err))
@@ -72,5 +71,4 @@ func SetupTestConfig() {
 	// Set the number of maxprocs
 	var numProcsDesired = viper.GetInt("peer.gomaxprocs")
 	chaincodeLogger.Debug("setting Number of procs to %d, was %d\n", numProcsDesired, runtime.GOMAXPROCS(2))
-
 }

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -18,6 +18,7 @@ package chaincode
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -26,10 +27,14 @@ import (
 	"testing"
 	"time"
 
+	"path/filepath"
+
 	"github.com/hyperledger/fabric/core/container"
+	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/system_chaincode"
 	"github.com/hyperledger/fabric/core/util"
+	"github.com/hyperledger/fabric/membersrvc/ca"
 	pb "github.com/hyperledger/fabric/protos"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
@@ -43,6 +48,91 @@ func getNowMillis() int64 {
 	return nanos / 1000000
 }
 
+//initialize memberservices and startup
+func initMemSrvc() (net.Listener, error) {
+	//start clean
+	finitMemSrvc(nil)
+
+	ca.LogInit(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, os.Stdout)
+
+	eca := ca.NewECA()
+	tca := ca.NewTCA(eca)
+	tlsca := ca.NewTLSCA(eca)
+
+	sockp, err := net.Listen("tcp", viper.GetString("server.port"))
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []grpc.ServerOption
+	server := grpc.NewServer(opts...)
+
+	eca.Start(server)
+	tca.Start(server)
+	tlsca.Start(server)
+
+	go server.Serve(sockp)
+
+	return sockp, nil
+}
+
+//cleanup memberservice debris
+func finitMemSrvc(lis net.Listener) {
+	closeListenerAndSleep(lis)
+	os.RemoveAll(filepath.Join(os.TempDir(), "ca"))
+}
+
+//initialize peer and start up. If security==enabled, login as vp
+func initPeer() (net.Listener, error) {
+	//start clean
+	finitPeer(nil)
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+
+	peerAddress := viper.GetString("peer.address")
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("Error starting peer listener %s", err)
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	// Install security object for peer
+	var secHelper crypto.Peer
+	if viper.GetBool("security.enabled") {
+		enrollID := viper.GetString("security.enrollID")
+		enrollSecret := viper.GetString("security.enrollSecret")
+		if err = crypto.RegisterValidator(enrollID, nil, enrollID, enrollSecret); nil != err {
+			return nil, err
+		}
+		secHelper, err = crypto.InitValidator(enrollID, nil)
+		if nil != err {
+			return nil, err
+		}
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, secHelper))
+
+	go grpcServer.Serve(lis)
+
+	return lis, nil
+}
+
+func finitPeer(lis net.Listener) {
+	closeListenerAndSleep(lis)
+	os.RemoveAll(filepath.Join(os.TempDir(), "hyperledger"))
+}
+
 // Build a chaincode.
 func getDeploymentSpec(context context.Context, spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
 	fmt.Printf("getting deployment spec for chaincode spec: %v\n", spec)
@@ -52,6 +142,64 @@ func getDeploymentSpec(context context.Context, spec *pb.ChaincodeSpec) (*pb.Cha
 	}
 	chaincodeDeploymentSpec := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec, CodePackage: codePackageBytes}
 	return chaincodeDeploymentSpec, nil
+}
+
+func createDeployTransaction(dspec *pb.ChaincodeDeploymentSpec, uuid string) (*pb.Transaction, error) {
+	var tx *pb.Transaction
+	var err error
+	var sec crypto.Client
+	if dspec.ChaincodeSpec.SecureContext != "" {
+		sec, err = crypto.InitClient(dspec.ChaincodeSpec.SecureContext, nil)
+		defer crypto.CloseClient(sec)
+
+		if nil != err {
+			return nil, err
+		}
+
+		tx, err = sec.NewChaincodeDeployTransaction(dspec, uuid)
+		if nil != err {
+			return nil, err
+		}
+	} else {
+		tx, err = pb.NewChaincodeDeployTransaction(dspec, uuid)
+		if err != nil {
+			return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
+		}
+	}
+	return tx, nil
+}
+
+func createTransaction(invokeTx bool, spec *pb.ChaincodeInvocationSpec, uuid string) (*pb.Transaction, error) {
+	var tx *pb.Transaction
+	var err error
+	var sec crypto.Client
+	if nil != sec {
+		sec, err = crypto.InitClient(spec.ChaincodeSpec.SecureContext, nil)
+		defer crypto.CloseClient(sec)
+		if nil != err {
+			return nil, err
+		}
+		if invokeTx {
+			tx, err = sec.NewChaincodeExecute(spec, uuid)
+		} else {
+			tx, err = sec.NewChaincodeQuery(spec, uuid)
+		}
+		if nil != err {
+			return nil, err
+		}
+	} else {
+		var t pb.Transaction_Type
+		if invokeTx {
+			t = pb.Transaction_CHAINCODE_INVOKE
+		} else {
+			t = pb.Transaction_CHAINCODE_QUERY
+		}
+		tx, err = pb.NewChaincodeExecute(spec, uuid, t)
+		if nil != err {
+			return nil, err
+		}
+	}
+	return tx, nil
 }
 
 // Deploy a chaincode - i.e., build and initialize.
@@ -65,7 +213,7 @@ func deploy(ctx context.Context, spec *pb.ChaincodeSpec) ([]byte, error) {
 	tid := chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name
 
 	// Now create the Transactions message and send to Peer.
-	transaction, err := pb.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, tid)
+	transaction, err := createDeployTransaction(chaincodeDeploymentSpec, tid)
 	if err != nil {
 		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
 	}
@@ -88,7 +236,7 @@ func deploy2(ctx context.Context, chaincodeDeploymentSpec *pb.ChaincodeDeploymen
 	tid := chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name
 
 	// Now create the Transactions message and send to Peer.
-	transaction, err := pb.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, tid)
+	transaction, err := createDeployTransaction(chaincodeDeploymentSpec, tid)
 	if err != nil {
 		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
 	}
@@ -111,7 +259,13 @@ func invoke(ctx context.Context, spec *pb.ChaincodeSpec, typ pb.Transaction_Type
 	// Now create the Transactions message and send to Peer.
 	uuid := util.GenerateUUID()
 
-	transaction, err := pb.NewChaincodeExecute(chaincodeInvocationSpec, uuid, typ)
+	var transaction *pb.Transaction
+	var err error
+	if typ == pb.Transaction_CHAINCODE_QUERY {
+		transaction, err = createTransaction(false, chaincodeInvocationSpec, uuid)
+	} else {
+		transaction, err = createTransaction(true, chaincodeInvocationSpec, uuid)
+	}
 	if err != nil {
 		return uuid, nil, fmt.Errorf("Error invoking chaincode: %s ", err)
 	}
@@ -134,8 +288,10 @@ func invoke(ctx context.Context, spec *pb.ChaincodeSpec, typ pb.Transaction_Type
 }
 
 func closeListenerAndSleep(l net.Listener) {
-	l.Close()
-	time.Sleep(2 * time.Second)
+	if l != nil {
+		l.Close()
+		time.Sleep(2 * time.Second)
+	}
 }
 
 // Test deploy of a transaction.
@@ -181,14 +337,14 @@ func TestExecuteDeployTransaction(t *testing.T) {
 	_, err = deploy(ctxt, spec)
 	chaincodeID := spec.ChaincodeID.Name
 	if err != nil {
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		t.Fail()
 		t.Logf("Error deploying <%s>: %s", chaincodeID, err)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -318,7 +474,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 		t.Logf("Invoke test passed")
 	}
 
-	GetChain(DefaultChain).Stop(ctxt,  &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 	closeListenerAndSleep(lis)
 }
@@ -416,7 +572,7 @@ func TestExecuteQuery(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -447,7 +603,7 @@ func TestExecuteQuery(t *testing.T) {
 	//end := getNowMillis()
 	//fmt.Fprintf(os.Stderr, "Ending: %d\n", end)
 	//fmt.Fprintf(os.Stderr, "Elapsed : %d millis\n", end-start)
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -498,7 +654,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 		errStr := err.Error()
 		t.Logf("Got error %s\n", errStr)
 		t.Logf("InvalidInvoke test passed")
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID:chaincodeID}})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 		closeListenerAndSleep(lis)
 		return
@@ -507,7 +663,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 	t.Fail()
 	t.Logf("Error invoking transaction %s", err)
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:&pb.ChaincodeSpec{ChaincodeID:chaincodeID}})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: &pb.ChaincodeSpec{ChaincodeID: chaincodeID}})
 
 	closeListenerAndSleep(lis)
 }
@@ -560,7 +716,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -579,7 +735,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 		t.Logf("This query should not have succeeded as it attempts to put state")
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 	closeListenerAndSleep(lis)
 }
 
@@ -632,7 +788,7 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -653,8 +809,8 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -673,8 +829,8 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -684,14 +840,14 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -745,7 +901,7 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -766,8 +922,8 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -785,8 +941,8 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	if err == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -794,50 +950,18 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 	if strings.Index(err.Error(), "Incorrect number of arguments. Expecting 3") < 0 {
 		t.Fail()
 		t.Logf("Unexpected error %s", err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
-// Test the execution of a chaincode query that queries another chaincode.
-func TestChaincodeQueryChaincode(t *testing.T) {
-	var opts []grpc.ServerOption
-	if viper.GetBool("peer.tls.enabled") {
-		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
-		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
-		}
-		opts = []grpc.ServerOption{grpc.Creds(creds)}
-	}
-	grpcServer := grpc.NewServer(opts...)
-	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
-
-	//use a different address than what we usually use for "peer"
-	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
-
-	lis, err := net.Listen("tcp", peerAddress)
-	if err != nil {
-		t.Fail()
-		t.Logf("Error starting peer listener %s", err)
-		return
-	}
-
-	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
-		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
-	}
-
-	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
-	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
-
-	go grpcServer.Serve(lis)
-
+func chaincodeQueryChaincode(user string) error {
 	var ctxt = context.Background()
 
 	// Deploy first chaincode
@@ -847,16 +971,13 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 
-	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec1 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID1, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}, SecureContext: user}
 
-	_, err = deploy(ctxt, spec1)
+	_, err := deploy(ctxt, spec1)
 	chaincodeID1 := spec1.ChaincodeID.Name
 	if err != nil {
-		t.Fail()
-		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		closeListenerAndSleep(lis)
-		return
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		return fmt.Errorf("Error initializing chaincode %s(%s)", chaincodeID1, err)
 	}
 
 	time.Sleep(time.Second)
@@ -868,83 +989,87 @@ func TestChaincodeQueryChaincode(t *testing.T) {
 	f = "init"
 	args = []string{"sum", "0"}
 
-	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}, SecureContext: user}
 
 	_, err = deploy(ctxt, spec2)
 	chaincodeID2 := spec2.ChaincodeID.Name
 	if err != nil {
-		t.Fail()
-		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-		closeListenerAndSleep(lis)
-		return
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+		return fmt.Errorf("Error initializing chaincode %s(%s)", chaincodeID2, err)
 	}
 
 	time.Sleep(time.Second)
 
 	// Invoke second chaincode, which will inturn query the first chaincode
-	t.Logf("Starting chaincode query chaincode in transaction mode")
 	f = "invoke"
 	args = []string{chaincodeID1, "sum"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}, SecureContext: user}
 	// Invoke chaincode
 	var retVal []byte
 	_, retVal, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_INVOKE)
 
 	if err != nil {
-		t.Fail()
-		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-		closeListenerAndSleep(lis)
-		return
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+		return fmt.Errorf("Error invoking <%s>: %s", chaincodeID2, err)
 	}
 
 	// Check the return value
 	result, err := strconv.Atoi(string(retVal))
 	if err != nil || result != 300 {
-		t.Fail()
-		t.Logf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-		closeListenerAndSleep(lis)
-		return
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+		return fmt.Errorf("Incorrect final state after transaction for <%s>: %s", chaincodeID1, err)
 	}
 
 	// Query second chaincode, which will inturn query the first chaincode
-	t.Logf("Starting chaincode query chaincode in query mode")
 	f = "query"
 	args = []string{chaincodeID1, "sum"}
 
-	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	spec2 = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID2, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}, SecureContext: user}
 	// Invoke chaincode
 	_, retVal, err = invoke(ctxt, spec2, pb.Transaction_CHAINCODE_QUERY)
 
 	if err != nil {
-		t.Fail()
-		t.Logf("Error querying <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-		closeListenerAndSleep(lis)
-		return
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+		return fmt.Errorf("Error querying <%s>: %s", chaincodeID2, err)
 	}
 
 	// Check the return value
 	result, err = strconv.Atoi(string(retVal))
 	if err != nil || result != 300 {
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+		return fmt.Errorf("Incorrect final value after query for <%s>: %s", chaincodeID1, err)
+	}
+
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
+
+	return nil
+}
+
+// Test the execution of a chaincode query that queries another chaincode without security enabled
+func TestChaincodeQueryChaincode(t *testing.T) {
+	var peerLis net.Listener
+	var err error
+	if peerLis, err = initPeer(); err != nil {
 		t.Fail()
-		t.Logf("Incorrect final value after query for <%s>: %s", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-		closeListenerAndSleep(lis)
+		t.Logf("Error registering user  %s", err)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
-	closeListenerAndSleep(lis)
+	if err = chaincodeQueryChaincode(""); err != nil {
+		finitPeer(peerLis)
+		t.Fail()
+		t.Logf("Error executing test %s", err)
+		return
+	}
+
+	finitPeer(peerLis)
 }
 
 // Test the execution of a chaincode that queries another chaincode with invalid parameter. Should receive error from
@@ -997,7 +1122,7 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID1, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1018,8 +1143,8 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	if err != nil {
 		t.Fail()
 		t.Logf("Error initializing chaincode %s(%s)", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1037,8 +1162,8 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	if err == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID2, err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
@@ -1046,14 +1171,14 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 	if strings.Index(err.Error(), "Nil amount for c") < 0 {
 		t.Fail()
 		t.Logf("Unexpected error %s", err)
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 		closeListenerAndSleep(lis)
 		return
 	}
 
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec1})
-	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec2})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
 	closeListenerAndSleep(lis)
 }
 
@@ -1098,7 +1223,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 	url := "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
 
 	args := []string{"greeting", "hello world"}
-	cds := &pb.ChaincodeDeploymentSpec{ExecEnv:1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Args: args}}}
+	cds := &pb.ChaincodeDeploymentSpec{ExecEnv: 1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Args: args}}}
 	_, err = deploy2(ctxt, cds)
 	chaincodeID := cds.ChaincodeSpec.ChaincodeID.Name
 	if err != nil {
@@ -1112,9 +1237,62 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 	GetChain(DefaultChain).Stop(ctxt, cds)
 	closeListenerAndSleep(lis)
 }
+
+// Test the execution of a chaincode query that queries another chaincode with security enabled
+// NOTE: this really needs to be a behave test. Remove when we have support in behave for multiple chaincodes
+func TestChaincodeQueryChaincodeWithSec(t *testing.T) {
+	viper.Set("security.enabled", "true")
+
+	//Initialize crypto
+	if err := crypto.Init(); err != nil {
+		panic(fmt.Errorf("Failed initializing the crypto layer [%s]", err))
+	}
+
+	//set paths for memberservice to pick up
+	viper.Set("peer.fileSystemPath", filepath.Join(os.TempDir(), "hyperledger", "production"))
+	viper.Set("server.rootpath", filepath.Join(os.TempDir(), "ca"))
+
+	var err error
+	var memSrvcLis net.Listener
+	if memSrvcLis, err = initMemSrvc(); err != nil {
+		t.Fail()
+		t.Logf("Error registering user  %s", err)
+		return
+	}
+
+	time.Sleep(2 * time.Second)
+
+	var peerLis net.Listener
+	if peerLis, err = initPeer(); err != nil {
+		finitMemSrvc(memSrvcLis)
+		t.Fail()
+		t.Logf("Error registering user  %s", err)
+		return
+	}
+
+	if err = crypto.RegisterClient("jim", nil, "jim", "6avZQLwcUe9b"); err != nil {
+		finitMemSrvc(memSrvcLis)
+		finitPeer(peerLis)
+		t.Fail()
+		t.Logf("Error registering user  %s", err)
+		return
+	}
+
+	//login as jim and test chaincode-chaincode interaction with security
+	if err = chaincodeQueryChaincode("jim"); err != nil {
+		finitMemSrvc(memSrvcLis)
+		finitPeer(peerLis)
+		t.Fail()
+		t.Logf("Error executing test %s", err)
+		return
+	}
+
+	//cleanup
+	finitMemSrvc(memSrvcLis)
+	finitPeer(peerLis)
+}
+
 func TestMain(m *testing.M) {
 	SetupTestConfig()
-	viper.Set("ledger.blockchain.deploy-system-chaincode", "false")
-	viper.Set("validator.validity-period.verification", "false")
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Chaincode - Chaincode interactions did not support security enablement options. This fix supports chaincode calling chaincode with security enabled but privacy disabled.  Further, the fix returns a "not supported" error if chaincode calls another with privacy enabled.

NOTE : Has undergone a preliminary code review from @adecaro. However, would like another code review... but want to make sure the PR will pass tests while waiting for it.
## Description

The called chaincode is passed the security context (the transaction wrapper with a security context). Both chaincode-query-chaincode and chaincode-invoke-chaincode call a "canCallChaincode" whose only purpose is to prevent interactions when privacy is enabled. This function should be a guideline to complete the fix in future to allow chaincode interactions with privacy enabled.

Rest of the changes are for unit test case to test the "with security" scenario, _pending support for multiple chaincodes in behave test framework_. Part of the changes was to refactor the TestChaincodeQueryChaincode test case to extract common code.

NOTE : resorted to creating a "chaincodetest.yaml" in the chaincode dir after having difficulties getting properties from peer and member services to work together - all other approaches (such as overriding specific properties) yielded interactions I could not figure out.
## Motivation and Context

Issue found in the field where chaincode-chaincode interaction does not work with security enabled.

Fixes #1530
## How Has This Been Tested?

Added a new unit test and ran make unit-test and behave. Also tested the unit test in isolation,
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
