### PR TITLE
Persist qset correctly

### DIFF
--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -455,7 +455,7 @@ func (op *omniProto) DelState(key string) {
 }
 
 func (op *omniProto) StoreState(key string, value []byte) error {
-	if nil != op.ReadStateImpl {
+	if nil != op.StoreStateImpl {
 		return op.StoreStateImpl(key, value)
 	}
 	return fmt.Errorf("unimplemented")

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -671,11 +671,11 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 	if cert.digest != "" && cert.digest != preprep.RequestDigest {
 		logger.Warning("Pre-prepare found for same view/seqNo but different digest: received %s, stored %s", preprep.RequestDigest, cert.digest)
 		instance.sendViewChange()
-	} else {
-		cert.prePrepare = preprep
-		cert.digest = preprep.RequestDigest
-		instance.persistQSet()
+		return nil
 	}
+
+	cert.prePrepare = preprep
+	cert.digest = preprep.RequestDigest
 
 	// Store the request if, for whatever reason, haven't received it from an earlier broadcast.
 	if _, ok := instance.reqStore[preprep.RequestDigest]; !ok {
@@ -712,6 +712,7 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 		}
 
 		cert.sentPrepare = true
+		instance.persistQSet()
 		instance.recvPrepare(prep)
 		return instance.innerBroadcast(&Message{&Message_Prepare{prep}})
 	}

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1187,8 +1187,9 @@ func TestReplicaCrash3(t *testing.T) {
 	// Create new pbft instances to restore from persistence
 	for id := 0; id < 2; id++ {
 		pe := net.pbftEndpoints[id]
-		os.Setenv("CORE_PBFT_GENERAL_K", "2") // TODO, this is a hacky way to inject config before initialization rather than after, address this in a future changeset
-		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc)
+		config := loadConfig()
+		config.Set("general.K", "2")
+		pe.pbft = newPbftCore(uint64(id), config, pe.sc)
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.requestTimeout = 200 * time.Millisecond


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

We need to persist the qset after adding the request to the reqstore, not before.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1551 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

unit tests, behave
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
