### PR TITLE
Fix Issue 866 and more

### DIFF
--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -205,12 +205,14 @@ func TestGopathExecuteDeployTransaction(t *testing.T) {
 }
 
 // Test deploy of a transaction with a chaincode over HTTP.
+/*
 func TestHTTPExecuteDeployTransaction(t *testing.T) {
 	// The chaincode used here cannot be from the hyperledger repo
 	// itself or it won't be downloaded because it will be found
 	// in GOPATH, which would defeat the test
 	executeDeployTransaction(t, "http://github.com/lehors/fabric/examples/chaincode/go/chaincode_example01")
 }
+*/
 
 // Check the correctness of the final state after transaction execution.
 func checkFinalState(uuid string, chaincodeID string) error {

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -190,9 +190,17 @@ func executeDeployTransaction(t *testing.T, url string) {
 	closeListenerAndSleep(lis)
 }
 
-
 // Test deploy of a transaction
 func TestExecuteDeployTransaction(t *testing.T) {
+	executeDeployTransaction(t, "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01")
+}
+
+// Test deploy of a transaction with a GOPATH with multiple elements
+func TestGopathExecuteDeployTransaction(t *testing.T) {
+	// add a trailing slash to GOPATH
+	// and a couple of elements - it doesn't matter what they are
+	os.Setenv("GOPATH", os.Getenv("GOPATH") + string(os.PathSeparator) + string(os.PathListSeparator) + "/tmp/foo" + string(os.PathListSeparator) + "/tmp/bar")
+	fmt.Printf("set GOPATH to: \"%s\"\n", os.Getenv("GOPATH"))
 	executeDeployTransaction(t, "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01")
 }
 

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -206,6 +206,9 @@ func TestGopathExecuteDeployTransaction(t *testing.T) {
 
 // Test deploy of a transaction with a chaincode over HTTP.
 func TestHTTPExecuteDeployTransaction(t *testing.T) {
+	// The chaincode used here cannot be from the hyperledger repo
+	// itself or it won't be downloaded because it will be found
+	// in GOPATH, which would defeat the test
 	executeDeployTransaction(t, "http://github.com/lehors/fabric/examples/chaincode/go/chaincode_example01")
 }
 

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -138,8 +138,7 @@ func closeListenerAndSleep(l net.Listener) {
 	time.Sleep(2 * time.Second)
 }
 
-// Test deploy of a transaction.
-func TestExecuteDeployTransaction(t *testing.T) {
+func executeDeployTransaction(t *testing.T, url string) {
 	var opts []grpc.ServerOption
 	if viper.GetBool("peer.tls.enabled") {
 		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
@@ -174,7 +173,6 @@ func TestExecuteDeployTransaction(t *testing.T) {
 
 	var ctxt = context.Background()
 
-	url := "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01"
 	f := "init"
 	args := []string{"a", "100", "b", "200"}
 	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Path: url}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
@@ -190,6 +188,17 @@ func TestExecuteDeployTransaction(t *testing.T) {
 
 	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec:spec})
 	closeListenerAndSleep(lis)
+}
+
+
+// Test deploy of a transaction
+func TestExecuteDeployTransaction(t *testing.T) {
+	executeDeployTransaction(t, "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example01")
+}
+
+// Test deploy of a transaction with a chaincode over HTTP.
+func TestHTTPExecuteDeployTransaction(t *testing.T) {
+	executeDeployTransaction(t, "http://github.com/lehors/fabric/examples/chaincode/go/chaincode_example01")
 }
 
 // Check the correctness of the final state after transaction execution.

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -180,23 +180,13 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 
 func getCodeFromFS(path string) (codegopath string, err error) {
 	logger.Debug("getCodeFromFS %s", path)
-	env := os.Environ()
-	var gopath string
-	for _, v := range env {
-		if strings.Index(v, "GOPATH=") == 0 {
-			p := strings.SplitAfter(v, "GOPATH=")
-			gopath = p[1]
-			// Only take the first element of GOPATH
-			gopath = filepath.SplitList(gopath)[0]
-			break
-		}
-	}
-
+	gopath := os.Getenv("GOPATH")
 	if gopath == "" {
+		err = fmt.Errorf("GOPATH not defined")
 		return
 	}
-
-	codegopath = gopath
+	// Only take the first element of GOPATH
+	codegopath = filepath.SplitList(gopath)[0]
 
 	return
 }

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -105,7 +105,18 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	err = nil
 	logger.Debug("getCodeFromHTTP %s", path)
 
-	origgopath := os.Getenv("GOPATH")
+	// The following could be done with os.Getenv("GOPATH") but we need to change it later so this prepares for that next step
+	env := os.Environ()
+	var origgopath string
+	var gopathenvIndex int
+	for i, v := range env {
+		if strings.Index(v, "GOPATH=") == 0 {
+			p := strings.SplitAfter(v, "GOPATH=")
+			origgopath = p[1]
+			gopathenvIndex = i
+			break
+		}
+	}
 	if origgopath == "" {
 		err = fmt.Errorf("GOPATH not defined")
 		return
@@ -135,13 +146,7 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	//     . more secure
 	//     . as we are not downloading OBC, private, password-protected OBC repo's become non-issue
 
-	env := os.Environ()
-	for i, v := range env {
-		if strings.Index(v, "GOPATH=") == 0 {
-			env[i] = "GOPATH=" + codegopath + string(os.PathListSeparator) + origgopath
-			break
-		}
-	}
+	env[gopathenvIndex] = "GOPATH=" + codegopath + string(os.PathListSeparator) + origgopath
 
 	// Use a 'go get' command to pull the chaincode from the given repo
 	logger.Debug("go get %s", path)

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -157,7 +157,6 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 		done <- cmd.Wait()
 	}()
 
-	fmt.Printf("chaincode.deploytimeout: %s\n", viper.GetInt("chaincode.deploytimeout"))
 	select {
 	case <-time.After(time.Duration(viper.GetInt("chaincode.deploytimeout")) * time.Millisecond):
 		// If pulling repos takes too long, we should give up
@@ -170,7 +169,7 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	case err = <-done:
 		// If we're here, the 'go get' command must have finished
 		if err != nil {
-			err = fmt.Errorf("'go get' failed with error\n\"%s\"\n", err, string(errBuf.Bytes()))
+			err = fmt.Errorf("'go get' failed with error: \"%s\"\n%s", err, string(errBuf.Bytes()))
 		}
 	}
 	return

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -156,6 +156,7 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 		done <- cmd.Wait()
 	}()
 
+	fmt.Printf("chaincode.deploytimeout: %s\n", viper.GetInt("chaincode.deploytimeout"))
 	select {
 	case <-time.After(time.Duration(viper.GetInt("chaincode.deploytimeout")) * time.Millisecond):
 		// If pulling repos takes too long, we should give up

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -43,10 +43,10 @@ var logger = logging.MustGetLogger("golang/hash")
 //Directory entries are traversed recursively. In the end a single
 //hash value is returned for the entire directory structure
 func hashFilesInDir(rootDir string, dir string, hash []byte, tw *tar.Writer) ([]byte, error) {
-	subdir := filepath.Join(rootDir, dir)
-	logger.Debug("hashFiles %s", subdir)
+	currentDir := filepath.Join(rootDir, dir)
+	logger.Debug("hashFiles %s", currentDir)
 	//ReadDir returns sorted list of files in dir
-	fis, err := ioutil.ReadDir(subdir)
+	fis, err := ioutil.ReadDir(currentDir)
 	if err != nil {
 		return hash, fmt.Errorf("ReadDir failed %s\n", err)
 	}

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -22,14 +22,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
-	"github.com/op/go-logging"
-	"github.com/spf13/viper"
 
 	cutil "github.com/hyperledger/fabric/core/container/util"
 	"github.com/hyperledger/fabric/core/util"
@@ -37,6 +37,7 @@ import (
 )
 
 var logger = logging.MustGetLogger("golang/hash")
+
 //hashFilesInDir computes h=hash(h,file bytes) for each file in a directory
 //Directory entries are traversed recursively. In the end a single
 //hash value is returned for the entire directory structure
@@ -132,7 +133,7 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	//     . more secure
 	//     . as we are not downloading OBC, private, password-protected OBC repo's become non-issue
 
-	os.Setenv("GOPATH", codegopath + ":" + origgopath)
+	os.Setenv("GOPATH", codegopath+":"+origgopath)
 	// Get a copy of that new env for the go get command
 	env := os.Environ()
 	// and reset GOPATH to its original value
@@ -166,7 +167,7 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	case err = <-done:
 		// If we're here, the 'go get' command must have finished
 		if err != nil {
-			 err = fmt.Errorf("'go get' failed with error\n\"%s\"\n", err, string(errBuf.Bytes()))
+			err = fmt.Errorf("'go get' failed with error\n\"%s\"\n", err, string(errBuf.Bytes()))
 		}
 	}
 	return

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -135,11 +135,13 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 	//     . more secure
 	//     . as we are not downloading OBC, private, password-protected OBC repo's become non-issue
 
-	os.Setenv("GOPATH", codegopath+":"+origgopath)
-	// Get a copy of that new env for the go get command
 	env := os.Environ()
-	// and reset GOPATH to its original value
-	os.Setenv("GOPATH", origgopath)
+	for i, v := range env {
+		if strings.Index(v, "GOPATH=") == 0 {
+			env[i] = "GOPATH=" + codegopath + string(os.PathListSeparator) + origgopath
+			break
+		}
+	}
 
 	// Use a 'go get' command to pull the chaincode from the given repo
 	logger.Debug("go get %s", path)

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -182,7 +182,7 @@ func getCodeFromFS(path string) (codegopath string, err error) {
 		return
 	}
 	// Only take the first element of GOPATH
-	gopath = filepath.SplitList(gopath)[0]
+	codegopath = filepath.SplitList(gopath)[0]
 
 	return
 }

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -22,14 +22,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/op/go-logging"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
 
 	cutil "github.com/hyperledger/fabric/core/container/util"
 	"github.com/hyperledger/fabric/core/util"

--- a/core/chaincode/platforms/golang/hash.go
+++ b/core/chaincode/platforms/golang/hash.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 	"github.com/op/go-logging"
@@ -108,6 +109,8 @@ func getCodeFromHTTP(path string) (codegopath string, err error) {
 		if strings.Index(v, "GOPATH=") == 0 {
 			p := strings.SplitAfter(v, "GOPATH=")
 			origgopath = p[1]
+			// Only take the first element of GOPATH
+			origgopath = filepath.SplitList(origgopath)[0]
 			newgopath = origgopath + "/_usercode_"
 			gopathenvIndex = i
 			break
@@ -183,6 +186,8 @@ func getCodeFromFS(path string) (codegopath string, err error) {
 		if strings.Index(v, "GOPATH=") == 0 {
 			p := strings.SplitAfter(v, "GOPATH=")
 			gopath = p[1]
+			// Only take the first element of GOPATH
+			gopath = filepath.SplitList(gopath)[0]
 			break
 		}
 	}

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -19,10 +19,11 @@ package golang
 import (
 	"archive/tar"
 	"fmt"
-	pb "github.com/hyperledger/fabric/protos"
 	"net/url"
 	"os"
 	"path/filepath"
+
+	pb "github.com/hyperledger/fabric/protos"
 )
 
 type Platform struct {

--- a/core/chaincode/platforms/golang/platform.go
+++ b/core/chaincode/platforms/golang/platform.go
@@ -50,7 +50,10 @@ func (self *Platform) ValidateSpec(spec *pb.ChaincodeSpec) error {
 	//which we do later anyway. But we *can* - and *should* - test for existence of local paths.
 	//Treat empty scheme as a local filesystem path
 	if url.Scheme == "" {
-		pathToCheck := filepath.Join(os.Getenv("GOPATH"), "src", spec.ChaincodeID.Path)
+		gopath := os.Getenv("GOPATH")
+		// Only take the first element of GOPATH
+		gopath = filepath.SplitList(gopath)[0]
+		pathToCheck := filepath.Join(gopath, "src", spec.ChaincodeID.Path)
 		exists, err := pathExists(pathToCheck)
 		if err != nil {
 			return fmt.Errorf("Error validating chaincode path: %s", err)

--- a/core/container/util/writer.go
+++ b/core/container/util/writer.go
@@ -36,10 +36,8 @@ func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 	gopath := os.Getenv("GOPATH")
 	// Only take the first element of GOPATH
 	gopath = filepath.SplitList(gopath)[0]
-	if strings.LastIndex(gopath, "/") == len(gopath)-1 {
-		gopath = gopath[:len(gopath)]
-	}
-	rootDirectory := fmt.Sprintf("%s%s%s", gopath, string(os.PathSeparator), "src")
+
+	rootDirectory := filepath.Join(gopath, "src")
 	vmLogger.Info("rootDirectory = %s", rootDirectory)
 
 	//append "/" if necessary

--- a/core/container/util/writer.go
+++ b/core/container/util/writer.go
@@ -34,10 +34,12 @@ var vmLogger = logging.MustGetLogger("container")
 //WriteGopathSrc tars up files under gopath src
 func WriteGopathSrc(tw *tar.Writer, excludeDir string) error {
 	gopath := os.Getenv("GOPATH")
+	// Only take the first element of GOPATH
+	gopath = filepath.SplitList(gopath)[0]
 	if strings.LastIndex(gopath, "/") == len(gopath)-1 {
 		gopath = gopath[:len(gopath)]
 	}
-	rootDirectory := fmt.Sprintf("%s%s%s", os.Getenv("GOPATH"), string(os.PathSeparator), "src")
+	rootDirectory := fmt.Sprintf("%s%s%s", gopath, string(os.PathSeparator), "src")
 	vmLogger.Info("rootDirectory = %s", rootDirectory)
 
 	//append "/" if necessary

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -71,6 +71,8 @@ With security enabled, modify the command to include the -u parameter passing th
 
 `./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'`
 
+**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
+
 ### Verify Results
 
 To verify that the block containing the latest transaction has been added to the blockchain, use the `/chain` REST endpoint from the command line. Target the IP address of either a validating or a non-validating node. In the example below, 172.17.0.2 is the IP address of a validating or a non-validating node and 5000 is the REST interface port defined in [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml).

--- a/docs/dev-setup/devnet-setup.md
+++ b/docs/dev-setup/devnet-setup.md
@@ -87,6 +87,8 @@ CORE_PEER_ADDRESS=172.17.0.2:30303 ./peer chaincode deploy -u jim -p github.com/
 
 You can watch for the message "Received build request for chaincode spec" on the output screen of all validating peers.
 
+**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
+
 On successful completion, the above command will print the "name" assigned to the deployed chaincode. This "name" is used as the value of the "-n" parameter in invoke and query commands described below. For example the value of "name" could be
 
     bb540edfc1ee2ac0f5e2ec6000677f4cd1c6728046d5e32dede7fea11a42f86a6943b76a8f9154f4792032551ed320871ff7b7076047e4184292e01e3421889c

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -85,6 +85,8 @@ To run a specific test use the `-run RE` flag where RE is a regular expression t
 
     go test -v -run=TestGetFoo
 
+**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
+
 #### 3.2 Node.js Unit Tests
 
 You must also run the Node.js unit tests to insure that the Node.js client SDK is not broken by your changes. To run the Node.js unit tests, follow the instructions [here](https://github.com/hyperledger/fabric/tree/master/sdk/node#unit-tests).

--- a/docs/dev-setup/install.md
+++ b/docs/dev-setup/install.md
@@ -72,6 +72,8 @@ The `node start` command will initiate a peer process, with which one can intera
       help        Help about any command
 ```
 
+**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
+
 #### 3. Test
 New code must be accompanied by test cases both in unit and Behave tests.
 
@@ -84,8 +86,6 @@ Use the following sequence to run all unit tests
 To run a specific test use the `-run RE` flag where RE is a regular expression that matches the test case name. To run tests with verbose output use the `-v` flag. For example, to run the `TestGetFoo` test case, change to the directory containing the `foo_test.go` and call/excecute
 
     go test -v -run=TestGetFoo
-
-**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
 
 #### 3.2 Node.js Unit Tests
 

--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -3137,6 +3137,8 @@ With security enabled, the command must be modified to pass an enrollment id of 
 ./peer chaincode deploy -u jim -p github.com/hyperledger/fabric/example/chaincode/go/chaincode_example02 -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
 ```
 
+**Note:** If your GOPATH environment variable contains more than one element, the chaincode must be found in the first one or deployment will fail.
+
 #### 6.3.1.4 chaincode invoke
 
 The CLI `invoke` command executes a specified function within the target chaincode. An example is below.

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -306,7 +306,7 @@ chaincode:
     startuptimeout: 1000
 
     #timeout in millisecs for deploying chaincode from a remote repository.
-    deploytimeout: 60000
+    deploytimeout: 30000
 
     #mode - options are "dev", "net"
     #dev - in dev mode, user runs the chaincode after starting validator from

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -306,7 +306,7 @@ chaincode:
     startuptimeout: 1000
 
     #timeout in millisecs for deploying chaincode from a remote repository.
-    deploytimeout: 30000
+    deploytimeout: 60000
 
     #mode - options are "dev", "net"
     #dev - in dev mode, user runs the chaincode after starting validator from


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This PR cleans up the way GOPATH is handled when deploying a chaincode so that when GOPATH contains multiple elements, double slashes, trailing spaces, etc, deployment can still succeed.
In case where GOPATH contains several elements only the first one is searched for the chaincode. So the chaincode must be found in the first element of GOPATH for deployment to succeed. The documentation has been updated to warn about this limitation.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #866 as well as several edge cases that can be met when GOPATH contains unusual values.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Two new unit tests were added:
- one that sets GOPATH to contain multiple elements and a trailing slash
- one to test deployment of a chaincode retrieved over HTTP

**05/25/16 Note: The second one depends on an external source so it will be submitted as part of a separate PR.**
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Arnaud J Le Hors lehors@us.ibm.com
