### PR TITLE
Reject queries when out of date

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -67,8 +67,13 @@ type Executor interface {
 	CommitTxBatch(id interface{}, metadata []byte) (*pb.Block, error)
 	RollbackTxBatch(id interface{}) error
 	PreviewCommitTxBatch(id interface{}, metadata []byte) ([]byte, error)
+}
 
-	SkipTo(tag uint64, id []byte, peers []*pb.PeerID)
+// LedgerManager is used to manipulate the state of the ledger
+type LedgerManager interface {
+	SkipTo(tag uint64, id []byte, peers []*pb.PeerID) // SkipTo tells state transfer to bring the ledger to a particular state, it should generally be preceeded/proceeded by Invalidate/Validate
+	InvalidateState()                                 // Invalidate informs the ledger that it is out of date and should reject queries
+	ValidateState()                                   // Validate informs the ledger that it is back up to date and should resume replying to queries
 }
 
 // StatePersistor is used to store consensus state which should survive a process crash
@@ -84,6 +89,7 @@ type Stack interface {
 	NetworkStack
 	SecurityUtils
 	Executor
+	LedgerManager
 	ReadOnlyLedger
 	StatePersistor
 }

--- a/consensus/obcpbft/fuzz_test.go
+++ b/consensus/obcpbft/fuzz_test.go
@@ -47,6 +47,8 @@ func newFuzzMock() *omniProto {
 		},
 		viewChangeImpl: func(curView uint64) {
 		},
+		validateStateImpl:   func() {},
+		invalidateStateImpl: func() {},
 	}
 }
 

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -76,6 +76,9 @@ type completeStack struct {
 
 const MaxStateTransferTime int = 200
 
+func (cs *completeStack) ValidateState()   {}
+func (cs *completeStack) InvalidateState() {}
+
 func (cs *completeStack) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
 	select {
 	// This guarantees the first SkipTo call is the one that's queued, whereas a mutex can be raced for

--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -134,18 +134,22 @@ type omniProto struct {
 	ReadStateSetImpl           func(prefix string) (map[string][]byte, error)
 	StoreStateImpl             func(key string, value []byte) error
 	DelStateImpl               func(key string)
+	ValidateStateImpl          func()
+	InvalidateStateImpl        func()
 
 	// Inner Stack methods
-	broadcastImpl    func(msgPayload []byte)
-	unicastImpl      func(msgPayload []byte, receiverID uint64) (err error)
-	executeImpl      func(seqNo uint64, txRaw []byte)
-	getStateImpl     func() []byte
-	skipToImpl       func(seqNo uint64, snapshotID []byte, peers []uint64)
-	validateImpl     func(txRaw []byte) error
-	viewChangeImpl   func(curView uint64)
-	signImpl         func(msg []byte) ([]byte, error)
-	verifyImpl       func(senderID uint64, signature []byte, message []byte) error
-	getLastSeqNoImpl func() (uint64, error)
+	broadcastImpl       func(msgPayload []byte)
+	unicastImpl         func(msgPayload []byte, receiverID uint64) (err error)
+	executeImpl         func(seqNo uint64, txRaw []byte)
+	getStateImpl        func() []byte
+	skipToImpl          func(seqNo uint64, snapshotID []byte, peers []uint64)
+	validateImpl        func(txRaw []byte) error
+	viewChangeImpl      func(curView uint64)
+	signImpl            func(msg []byte) ([]byte, error)
+	verifyImpl          func(senderID uint64, signature []byte, message []byte) error
+	getLastSeqNoImpl    func() (uint64, error)
+	validateStateImpl   func()
+	invalidateStateImpl func()
 
 	// Closable Consenter methods
 	RecvMsgImpl func(ocMsg *pb.Message, senderHandle *pb.PeerID) error
@@ -485,6 +489,38 @@ func (op *omniProto) StoreState(key string, value []byte) error {
 		return op.StoreStateImpl(key, value)
 	}
 	return fmt.Errorf("unimplemented")
+}
+
+func (op *omniProto) ValidateState() {
+	if nil != op.ValidateStateImpl {
+		op.ValidateStateImpl()
+		return
+	}
+	panic("unimplemented")
+}
+
+func (op *omniProto) InvalidateState() {
+	if nil != op.InvalidateStateImpl {
+		op.InvalidateStateImpl()
+		return
+	}
+	panic("unimplemented")
+}
+
+func (op *omniProto) validateState() {
+	if nil != op.validateStateImpl {
+		op.validateStateImpl()
+		return
+	}
+	panic("unimplemented")
+}
+
+func (op *omniProto) invalidateState() {
+	if nil != op.invalidateStateImpl {
+		op.invalidateStateImpl()
+		return
+	}
+	panic("unimplemented")
 }
 
 /*

--- a/consensus/obcpbft/obc-pbft.go
+++ b/consensus/obcpbft/obc-pbft.go
@@ -134,6 +134,14 @@ func (op *obcGeneric) skipTo(seqNo uint64, id []byte, replicas []uint64) {
 	op.stack.SkipTo(seqNo, id, getValidatorHandles(replicas))
 }
 
+func (op *obcGeneric) invalidateState() {
+	op.stack.InvalidateState()
+}
+
+func (op *obcGeneric) validateState() {
+	op.stack.ValidateState()
+}
+
 func (op *obcGeneric) getState() []byte {
 	return op.stack.GetBlockchainInfoBlob()
 }

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -819,6 +819,7 @@ func (op *obcSieve) sync(seqNo uint64, id []byte, peers []uint64) {
 	if op.currentReq != "" {
 		op.rollback()
 	}
+	op.stack.InvalidateState()
 	op.obcGeneric.skipTo(seqNo, id, peers)
 }
 

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -66,6 +66,9 @@ type innerStack interface {
 	sign(msg []byte) ([]byte, error)
 	verify(senderID uint64, signature []byte, message []byte) error
 
+	invalidateState()
+	validateState()
+
 	consensus.StatePersistor
 }
 
@@ -294,6 +297,7 @@ func (instance *pbftCore) processEvent(e event) event {
 		instance.lastExec = seqNo
 		instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
 		instance.skipInProgress = false
+		instance.consumer.validateState()
 		instance.executeOutstanding()
 	case execDoneEventID:
 		instance.execDoneSync()
@@ -996,6 +1000,7 @@ func (instance *pbftCore) weakCheckpointSetOutOfRange(chkpt *Checkpoint) bool {
 				instance.moveWatermarks(m)
 				instance.outstandingReqs = make(map[string]*Request)
 				instance.skipInProgress = true
+				instance.consumer.invalidateState()
 				instance.stopTimer()
 
 				// TODO, reprocess the already gathered checkpoints, this will make recovery faster, though it is presently correct

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -102,6 +102,9 @@ func (sc *simpleConsumer) verify(senderID uint64, signature []byte, message []by
 func (sc *simpleConsumer) viewChange(curView uint64) {
 }
 
+func (sc *simpleConsumer) invalidateState() {}
+func (sc *simpleConsumer) validateState()   {}
+
 func (sc *simpleConsumer) skipTo(seqNo uint64, id []byte, replicas []uint64) {
 	sc.skipOccurred = true
 	sc.executions = seqNo

--- a/docs/FAQ/usage_FAQ.md
+++ b/docs/FAQ/usage_FAQ.md
@@ -13,3 +13,11 @@ No. You can still transact on a chain network by owning a non-validating node (N
 Although transactions initiated by NV-nodes will eventually be forwarded to their validating peers for consensus processing, NV-nodes establish their own connections to the membership service module and can therefore package transactions independently. This allows NV-node owners to independently register and manage certificates, a powerful feature that empowers NV-node owners to create custom-built applications for their clients while managing their client certificates.
 
 In addition, NV-nodes retain full copies of the ledger, enabling local queries of the ledger data. 
+
+&nbsp;
+##### What does the error string "state may be inconsistent, cannot query" as a query result mean?
+Sometimes, a validating peer will be out of sync with the rest of the network.  Although determining this condition is not always possible, validating peers make a best effort determination to detect it, and internally mark themselves as out of date.
+
+When under this condition, rather than reply with out of date or potentially incorrect data, the peer will reply to chaincode queries with the error string "state may be inconsistent, cannot query".
+
+In the future, more sophisticated reporting mechanisms may be introduced such as returning the stale value and a flag that the value is stale.


### PR DESCRIPTION
## Description

This changeset adds a flag to `helper.go` which tracks whether consensus believes the state to be valid or not.  When consensus believes state is no longer valid, it calls `InvalidateState()`, once it believe the replica has caught up, it calls `ValidateState()`.  When the peer receives a query, it first checks whether the helper believes the state is valid or not, and it not, rejects the query because the state may be inconsistent.

Note, presently, the state is assumed to be good at startup, and is only invalidated by consensus at a later time.  We may wish to flip this assumption at some point in the future, but for now it is still an improvement.

Note also that this change intentionally does nothing to change the processing of transaction submission.  Even though a peer is out of date, it does not mean that it cannot submit new transactions to the network.
## Motivation and Context

Before this change, clients would receive old state with no indication that there was a problem, even if the peer knew it was thousands of blocks out of date.  After discussions with @binhn and @jeffgarratt it was concluded that queries should be rejected in this scenario.

This is intended to partially address issue #1091.
## How Has This Been Tested?

This has been tested locally with behave test issue_680 and with a new behave test tagged as issue_1091.

For the new test, it gets a peer (vp3) into an inconsistent state, then queries, and verifies that an error is returned.  The test for issue_680 covers that once state transfer has completed that the 'invalid' flag is unset, and queries are replied to properly once more.

Relying on CI to execute the other tests.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
