### PR TITLE
Replace magic number to http status code constant

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -602,11 +602,11 @@ func (s *ServerOpenchainREST) GetBlockchainInfo(rw web.ResponseWriter, req *web.
 	// Check for error
 	if err != nil {
 		// Failure
-		rw.WriteHeader(400)
+		rw.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
 	} else {
 		// Success
-		rw.WriteHeader(200)
+		rw.WriteHeader(http.StatusOK)
 		encoder.Encode(info)
 	}
 }
@@ -620,7 +620,7 @@ func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.R
 	// Check for proper Block id syntax
 	if err != nil {
 		// Failure
-		rw.WriteHeader(400)
+		rw.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(rw, "{\"Error\": \"Block id must be an integer (uint64).\"}")
 	} else {
 		// Retrieve Block from blockchain


### PR DESCRIPTION
## Description

There is several places use '400' and '200' which should be http status code. I change them to http status code constant.
## Motivation and Context

Unify and readable
## How Has This Been Tested?

unit test and bddtest done.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:Kai Chen 281165273@qq.com
