### PR TITLE
Include Stack Overflow link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
+<!-- For general purpose questions, use Stack Overflow http://stackoverflow.com/questions/tagged/hyperledger -->
+
 ## Description
-<!--- Describe your issue or user story in detail. -->
+<!-- Describe your issue or user story in detail -->
 
 ## Describe How to Reproduce
-<!--- If an issue, provide sufficient context and steps to reproduce the issue -->
+<!-- If an issue, provide sufficient context and steps to reproduce the issue -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

The PR adds the following comment to the top of the GitHub issue template.
"For general purpose questions, use Stack Overflow http://stackoverflow.com/questions/tagged/hyperledger"
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Encourages people to use Stack Overflow and the 'hyperledger' tag for general purpose questions instead of opening issues.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

No new tests are needed. This only changes the GitHub issues template.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
