### PR TITLE
Busywork "benchmarks" updates to include SHA3 micro benchmarks

### DIFF
--- a/tools/busywork/benchmarks/Makefile
+++ b/tools/busywork/benchmarks/Makefile
@@ -1,48 +1,75 @@
-# Makefile for crypto benchmarks, still in a nascent state...
+# Makefile for benchmarks, still in a nascent state...
+#
+# Targets:
+#
+# crypto-ubench : Go language cryptographic microbenchmarks
 
 GOARCH = $(shell go env GOARCH)
+
+.PHONY: crypto-ubench
 
 # These values were chosen because they take about 10 seconds to run on a
 # modern server. You can define TIMES on the make command line to define how
 # many times each run is made. The default is 1 run; If TIMES > 1 then the
-# results are averaged.
+# results are averaged. Define ENV to define an environment or wrapper-command.
 
 # Go's 'amd64' architecture has a hand-written assembler implementation of
 # P256, SHA256 and SHA512
 ifeq ($(GOARCH),amd64)
+
 P256_SIGNS    = 100000
 P256_VERIFIES = 50000
+
 SHA256x8  = 20000000
 SHA256x1K = 2000000
 SHA256x8K = 200000
+
 SHA512x8  = 20000000
 SHA512x1K = 3000000
 SHA512x8K = 400000
+
 else
+
 P256_SIGNS    = 4000
 P256_VERIFIES = 1500
+
 SHA256x8  = 5000000
 SHA256x1K = 300000
 SHA256x8K = 50000
+
 SHA512x8  = 5000000
 SHA512x1K = 300000
 SHA512x8K = 50000
+
 endif
 
 P384_SIGNS    = 300
 P384_VERIFIES = 300
 
+SHA3_256x8  = 5000000
+SHA3_256x1K = 2000000
+SHA3_256x8K = 300000
 
-.PHONY: all
-all:
+SHA3_512x8  = 6000000
+SHA3_512x1K = 1000000
+SHA3_512x8K = 150000
+
+crypto-ubench:
+
 	@go build -a
-	@benchmarks P256Sign   $(P256_SIGNS)    $(TIMES)
-	@benchmarks P256Verify $(P256_VERIFIES) $(TIMES)
-	@benchmarks P384Sign   $(P384_SIGNS)    $(TIMES)
-	@benchmarks P384Verify $(P384_VERIFIES) $(TIMES)
-	@benchmarks SHA256x8   $(SHA256x8)      $(TIMES)
-	@benchmarks SHA256x1K  $(SHA256x1K)     $(TIMES)
-	@benchmarks SHA256x8K  $(SHA256x8K)     $(TIMES)
-	@benchmarks SHA512x8   $(SHA512x8)      $(TIMES)
-	@benchmarks SHA512x1K  $(SHA512x1K)     $(TIMES)
-	@benchmarks SHA512x8K  $(SHA512x8K)     $(TIMES)
+	@$(ENV) benchmarks P256Sign    $(P256_SIGNS)    $(TIMES)
+	@$(ENV) benchmarks P256Verify  $(P256_VERIFIES) $(TIMES)
+	@$(ENV) benchmarks P384Sign    $(P384_SIGNS)    $(TIMES)
+	@$(ENV) benchmarks P384Verify  $(P384_VERIFIES) $(TIMES)
+	@$(ENV) benchmarks SHA256x8    $(SHA256x8)      $(TIMES)
+	@$(ENV) benchmarks SHA256x1K   $(SHA256x1K)     $(TIMES)
+	@$(ENV) benchmarks SHA256x8K   $(SHA256x8K)     $(TIMES)
+	@$(ENV) benchmarks SHA512x8    $(SHA512x8)      $(TIMES)
+	@$(ENV) benchmarks SHA512x1K   $(SHA512x1K)     $(TIMES)
+	@$(ENV) benchmarks SHA512x8K   $(SHA512x8K)     $(TIMES)
+	@$(ENV) benchmarks SHA3_256x8  $(SHA3_256x8)    $(TIMES)
+	@$(ENV) benchmarks SHA3_256x1K $(SHA3_256x1K)   $(TIMES)
+	@$(ENV) benchmarks SHA3_256x8K $(SHA3_256x8K)   $(TIMES)
+	@$(ENV) benchmarks SHA3_512x8  $(SHA3_512x8)    $(TIMES)
+	@$(ENV) benchmarks SHA3_512x1K $(SHA3_512x1K)   $(TIMES)
+	@$(ENV) benchmarks SHA3_512x8K $(SHA3_512x8K)   $(TIMES)

--- a/tools/busywork/benchmarks/README.md
+++ b/tools/busywork/benchmarks/README.md
@@ -1,8 +1,19 @@
 # Benchmarks
 
-This directory contains the beginnings of a set of microbenchmarks for the
-cryptographic primitives used by the Hyperledger fabric. Simply execute
+This directory contains benchmarks, and a Makefile to run the benchmarks.
 
-    make
+### crypto-ubench
+
+This target runs a set of microbenchmarks for the Go cryptographic primitives
+used by the Hyperledger fabric. Simply execute
+
+    make crypto-ubench
 	
-to run the microbenchmarks.
+to run the microbenchmarks. You can define `TIMES` on the make command line to
+define how many times each run is made. The default is 1 run; If `TIMES` > 1
+then the results are averaged. Define `ENV` to define an environment or
+wrapper-command. For example
+
+    make crypto-ubench ENV=time TIMES=3
+
+runs each benchmark 3 times and also reports the elapsed time.

--- a/tools/busywork/benchmarks/benchmarks.go
+++ b/tools/busywork/benchmarks/benchmarks.go
@@ -38,6 +38,12 @@ import (
 //    SHA512x8
 //    SHA512x1K
 //    SHA512x8K
+//    SHA3_256x8
+//    SHA3_256x1K
+//    SHA3_256x8K
+//    SHA3_512x8
+//    SHA3_512x1K
+//    SHA3_512x8K
 //
 // and <n> is the number of iterations
 func main() {
@@ -83,6 +89,18 @@ func main() {
 			thisRate, what = SHA512x1K(n)
 		case "SHA512x8K":
 			thisRate, what = SHA512x8K(n)
+		case "SHA3_256x8":
+			thisRate, what = SHA3_256x8(n)
+		case "SHA3_256x1K":
+			thisRate, what = SHA3_256x1K(n)
+		case "SHA3_256x8K":
+			thisRate, what = SHA3_256x8K(n)
+		case "SHA3_512x8":
+			thisRate, what = SHA3_512x8(n)
+		case "SHA3_512x1K":
+			thisRate, what = SHA3_512x1K(n)
+		case "SHA3_512x8K":
+			thisRate, what = SHA3_512x8K(n)
 		default:
 			fmt.Printf("Unrecognized operation : %s\n", operation)
 			os.Exit(1)

--- a/tools/busywork/benchmarks/goBenchmarks.go
+++ b/tools/busywork/benchmarks/goBenchmarks.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"golang.org/x/crypto/sha3"
 )
 
 // P256Sign returns the number of signs per second
@@ -87,6 +89,8 @@ var shaBuf = make([]byte, 8192)
 
 var sha256Object = sha256.New()
 var sha512Object = sha512.New()
+var sha3_256Object = sha3.New256()
+var sha3_512Object = sha3.New512()
 
 func sha256Bench(size int, n int) int {
 	sum := make([]byte, sha256Object.Size())
@@ -102,7 +106,7 @@ func sha256Bench(size int, n int) int {
 	return int(float64(size*n) / time.Since(start).Seconds())
 }
 
-// SHA256x8 benchmarks SHA256 on 8-byte buffers
+// SHA256x8 benchmarks SHA256 on 8-byte buffershash
 func SHA256x8(n int) (int, string) {
 	return sha256Bench(8, n), "bytes"
 }
@@ -144,4 +148,62 @@ func SHA512x1K(n int) (int, string) {
 // SHA512x8K benchmarks SHA512 on 8192-byte buffers
 func SHA512x8K(n int) (int, string) {
 	return sha512Bench(8192, n), "bytes"
+}
+
+func sha3_256Bench(size int, n int) int {
+	sum := make([]byte, sha3_256Object.Size())
+
+	start := time.Now()
+
+	for i := 0; i < n; i++ {
+		sha3_256Object.Reset()
+		sha3_256Object.Write(shaBuf[:size])
+		sha3_256Object.Sum(sum[:0])
+	}
+
+	return int(float64(size*n) / time.Since(start).Seconds())
+}
+
+// SHA3_256x8 benchmarks SHA3_256 on 8-byte buffersha3_sh
+func SHA3_256x8(n int) (int, string) {
+	return sha3_256Bench(8, n), "bytes"
+}
+
+// SHA3_256x1K benchmarks SHA3_256 on 1024-byte buffers
+func SHA3_256x1K(n int) (int, string) {
+	return sha3_256Bench(1024, n), "bytes"
+}
+
+// SHA3_256x8K benchmarks SHA3_256 on 8192-byte buffers
+func SHA3_256x8K(n int) (int, string) {
+	return sha3_256Bench(8192, n), "bytes"
+}
+
+func sha3_512Bench(size int, n int) int {
+	sum := make([]byte, sha3_512Object.Size())
+
+	start := time.Now()
+
+	for i := 0; i < n; i++ {
+		sha3_512Object.Reset()
+		sha3_512Object.Write(shaBuf[:size])
+		sha3_512Object.Sum(sum[:0])
+	}
+
+	return int(float64(size*n) / time.Since(start).Seconds())
+}
+
+// SHA3_512x8 benchmarks SHA3_512 on 8-byte buffers
+func SHA3_512x8(n int) (int, string) {
+	return sha3_512Bench(8, n), "bytes"
+}
+
+// SHA3_512x1K benchmarks SHA3_512 on 1024-byte buffers
+func SHA3_512x1K(n int) (int, string) {
+	return sha3_512Bench(1024, n), "bytes"
+}
+
+// SHA3_512x8K benchmarks SHA3_512 on 8192-byte buffers
+func SHA3_512x8K(n int) (int, string) {
+	return sha3_512Bench(8192, n), "bytes"
 }

--- a/tools/busywork/benchmarks/goBenchmarks.go
+++ b/tools/busywork/benchmarks/goBenchmarks.go
@@ -106,7 +106,7 @@ func sha256Bench(size int, n int) int {
 	return int(float64(size*n) / time.Since(start).Seconds())
 }
 
-// SHA256x8 benchmarks SHA256 on 8-byte buffershash
+// SHA256x8 benchmarks SHA256 on 8-byte buffers
 func SHA256x8(n int) (int, string) {
 	return sha256Bench(8, n), "bytes"
 }
@@ -164,7 +164,7 @@ func sha3_256Bench(size int, n int) int {
 	return int(float64(size*n) / time.Since(start).Seconds())
 }
 
-// SHA3_256x8 benchmarks SHA3_256 on 8-byte buffersha3_sh
+// SHA3_256x8 benchmarks SHA3_256 on 8-byte buffers
 func SHA3_256x8(n int) (int, string) {
 	return sha3_256Bench(8, n), "bytes"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Added support for SHA3 micro benchmarks. Added a few more lines of documentation in the README.md and Makefile.

This change set only changes files in the `fabric/tools/busywork/benchmarks` directory.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

People are interested in SHA3 performance.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Tested on X86 and POWER.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [ x] Either no new documentation is required by this change, OR I added new documentation
- [ x] Either no new tests are required by this change, OR I added new tests
- [ x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
