### PR TITLE
Adding deprecation warning messages for /devops endpoint

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -669,6 +669,7 @@ func (s *ServerOpenchainREST) GetTransactionByUUID(rw web.ResponseWriter, req *w
 // blockchain.
 func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST deploying chaincode...")
+	restLogger.Warning("/devops/deploy endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeSpec
@@ -812,6 +813,7 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 // Invoke executes a specified function within a target Chaincode.
 func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST invoking chaincode...")
+	restLogger.Warning("/devops/invoke endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec
@@ -948,6 +950,7 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 // Query performs the requested query on the target Chaincode.
 func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST querying chaincode...")
+	restLogger.Warning("/devops/query endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec


### PR DESCRIPTION
## Description

Adding three warning level messages that will appear in the peer logs whenever the deprecated /devops endpoint receives a REST request. Specifically, whenever the /devops/deploy, /devops/invoke, or /devops/query endpoints receive a request the below messages will be seen in the logs.

> [rest] Deploy -> WARN 017 /devops/deploy endpoint has been deprecated. Use /chaincode endpoint instead.
> [rest] Invoke -> WARN 01b /devops/invoke endpoint has been deprecated. Use /chaincode endpoint instead.
> [rest] Query -> WARN 01e /devops/query endpoint has been deprecated. Use /chaincode endpoint instead.
## Motivation and Context

This change is necessary to warn users of the REST API that the /devops endpoint is being deprecated and is now superceeded by the /chaincode endpoint. Users should transition to using the /chaincode endpoint as the /devops endpoint will eventually be removed.

Fixes #1101
## How Has This Been Tested?

I tested this change by sending requests to the /devops/deploy, /devops/invoke, and /devops/query endpoints and confirming that the correct warning messages are seen in the peer logs. This issue does not require new test cases as the code change simply adds new logging messages, not new functionality.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Adding a warning message whenever the deprecated /devops endpoint
receives a REST request.

Fixes #1101.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
