### PR TITLE
Let chaincode container networkmode configurable

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hyperledger/fabric/core/container/ccintf"
 	cutil "github.com/hyperledger/fabric/core/container/util"
 	"github.com/op/go-logging"
+	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
 
@@ -96,7 +97,7 @@ func (vm *DockerVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string,
 		dockerLogger.Error(fmt.Sprintf("start-could not recreate container %s", err))
 		return err
 	}
-	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: "host"})
+	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: viper.GetString("core.chaincode.containerNetworkmode")})
 	if err != nil {
 		dockerLogger.Error(fmt.Sprintf("start-could not start container %s", err))
 		return err

--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -97,7 +97,7 @@ func (vm *DockerVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string,
 		dockerLogger.Error(fmt.Sprintf("start-could not recreate container %s", err))
 		return err
 	}
-	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: viper.GetString("core.chaincode.containerNetworkmode")})
+	err = client.StartContainer(containerID, &docker.HostConfig{NetworkMode: viper.GetString("core.chaincode.containerNetworkMode")})
 	if err != nil {
 		dockerLogger.Error(fmt.Sprintf("start-could not start container %s", err))
 		return err

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -314,10 +314,14 @@ chaincode:
     #net - in net mode validator will run chaincode in a docker container
 
     mode: net
+
     # typically installpath should not be modified. Otherwise, user must ensure
     # the chaincode executable is placed in the path specifed by installpath in
     # the image
     installpath: /opt/gopath/bin/
+
+    # The NetworkMode in HostConfig when starting a chaincode container
+    containerNetworkmode: host
 
 ###############################################################################
 #

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -321,7 +321,7 @@ chaincode:
     installpath: /opt/gopath/bin/
 
     # The NetworkMode in HostConfig when starting a chaincode container
-    containerNetworkmode: host
+    containerNetworkMode: host
 
 ###############################################################################
 #

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -320,7 +320,10 @@ chaincode:
     # the image
     installpath: /opt/gopath/bin/
 
-    # The NetworkMode in HostConfig when starting a chaincode container
+    # The NetworkMode in HostConfig when starting a chaincode container. The 
+    # value could be anyone that is supported by Docker Engine, e.g., host,
+    # bridge, overlay. Use may change this one if he deployes chaincode outside
+    # the same host of the validator node.
     containerNetworkMode: host
 
 ###############################################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Let user can set the networkmode for the chaincode container
## Description

<!--- Describe your changes in detail. -->

Read from the viper variable when using networkmode; Add chaincode.containerNetworkmode in core.yaml file.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1582.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Ran `make checks`, No new tests are required because this PR does not add new functionality.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:Baohua Yang baohyang@cn.ibm.com
