### PR TITLE
Add PBFT event manager and convert core to use it

### DIFF
--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -1,20 +1,17 @@
 /*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+Copyright IBM Corp. 2016 All Rights Reserved.
 
-  http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package obcpbft

--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -1,0 +1,309 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package obcpbft
+
+import "time"
+
+// event is an interface which defines an event which is identified by eventType
+type event interface {
+	eventType() eventType // The type of the event
+}
+
+// eventReceiver is a consumer of events, processEvent will be called serially
+// as events arrive
+type eventReceiver interface {
+	// processEvent delivers an event to the eventReceiver, if it returns non-nil, the return is the next processed event
+	processEvent(e event) event
+}
+
+// ------------------------------------------------------------
+//
+// Threaded object
+//
+// ------------------------------------------------------------
+
+// threaded holds an exit channel to allow threads to break from a select
+type threaded struct {
+	exit chan struct{}
+}
+
+// halt tells the threaded object's thread to exit
+func (t *threaded) halt() {
+	select {
+	case <-t.exit:
+		logger.Warning("Attempted to halt a threaded object twice")
+	default:
+		close(t.exit)
+	}
+}
+
+// ------------------------------------------------------------
+//
+// Event Manager
+//
+// ------------------------------------------------------------
+
+// eventManager provides a serialized interface for submitting events to
+// an eventReceiver on the other side of the queue
+type eventManager interface {
+	queue() chan<- event // Get a write-only reference to the queue, to submit events
+	start()              // Starts the eventManager thread TODO, these thread management things should probably go away
+	halt()               // Stops the eventManager thread
+}
+
+// eventManagerImpl is an implementation of eventManger
+type eventManagerImpl struct {
+	threaded
+	receiver eventReceiver
+	events   chan event
+}
+
+// newEventManager creates an instance of eventManagerImpl
+func newEventManagerImpl(er eventReceiver) eventManager {
+	return &eventManagerImpl{
+		receiver: er,
+		events:   make(chan event),
+		threaded: threaded{make(chan struct{})},
+	}
+}
+
+// start creates the go routine necessary to deliver events
+func (em *eventManagerImpl) start() {
+	go em.eventLoop()
+}
+
+// queue returns a write only reference to the event queue
+func (em *eventManagerImpl) queue() chan<- event {
+	return em.events
+}
+
+// eventLoop is where the event thread loops, delivering events
+func (em *eventManagerImpl) eventLoop() {
+	for {
+		select {
+		case next := <-em.events:
+			// If an event returns something non-nil, then process it as a new event
+			for ; next != nil; next = em.receiver.processEvent(next) {
+			}
+		case <-em.exit:
+			logger.Debug("eventLoop told to exit")
+			return
+		}
+	}
+}
+
+// ------------------------------------------------------------
+//
+// Event Timer
+//
+// ------------------------------------------------------------
+
+// eventTimer is an interface for managing time driven events
+// the special contract eventTimer gives which a traditional golang
+// timer does not, is that if the event thread calls stop, or reset
+// then even if the timer has already fired, the event will not be
+// delivered to the event queue
+type eventTimer interface {
+	softReset(duration time.Duration, event event) // start a new countdown, only if one is not already started
+	reset(duration time.Duration, event event)     // start a new countdown, clear any pending events
+	stop()                                         // stop the countdown, clear any pending events
+	halt()                                         // Stops the eventTimer thread
+}
+
+// eventTimerFactory abstracts the creation of eventTimers, as they may
+// need to be mocked for testing
+type eventTimerFactory interface {
+	createTimer() eventTimer // Creates an eventTimer which is stopped
+}
+
+// eventTimerFactoryImpl implements the eventTimerFactory
+type eventTimerFactoryImpl struct {
+	manager eventManager // The eventManager to use in constructing the event timers
+}
+
+// newEventTimerFactoryImpl creates a new eventTimerFactory for the given eventManager
+func newEventTimerFactoryImpl(manager eventManager) eventTimerFactory {
+	return &eventTimerFactoryImpl{manager}
+}
+
+// createTimer creates a new timer which deliver events to the eventManager for this factory
+func (etf *eventTimerFactoryImpl) createTimer() eventTimer {
+	return newEventTimer(etf.manager)
+}
+
+// timerStart is used to deliver the start request to the eventTimer thread
+type timerStart struct {
+	hard     bool          // Whether to reset the timer if it is running
+	event    event         // What event to push onto the event queue
+	duration time.Duration // How long to wait before sending the event
+}
+
+// eventTimerImpl is an implementation of eventTimer
+type eventTimerImpl struct {
+	threaded                   // Gives us the exit chan
+	timerChan <-chan time.Time // When non-nil, counts down to preparing to do the event
+	startChan chan *timerStart // Channel to deliver the timer start events to the service go routine
+	stopChan  chan struct{}    // Channel to deliver the timer stop events to the service go routine
+	manager   eventManager     // The event manager to deliver the event to after timer expiration
+}
+
+// newEventTimer creates a new instance of eventTimerImpl
+func newEventTimer(manager eventManager) eventTimer {
+	et := &eventTimerImpl{
+		startChan: make(chan *timerStart),
+		stopChan:  make(chan struct{}),
+		threaded:  threaded{make(chan struct{})},
+		manager:   manager,
+	}
+	go et.loop()
+	return et
+}
+
+// softReset tells the timer to start a new countdown, only if it is not currently counting down
+// this will not clear any pending events
+func (et *eventTimerImpl) softReset(timeout time.Duration, event event) {
+	et.startChan <- &timerStart{
+		duration: timeout,
+		event:    event,
+		hard:     true,
+	}
+}
+
+// reset tells the timer to start counting down from a new timeout, this also clears any pending events
+func (et *eventTimerImpl) reset(timeout time.Duration, event event) {
+	et.startChan <- &timerStart{
+		duration: timeout,
+		event:    event,
+		hard:     false,
+	}
+}
+
+// stop tells the timer to stop, and not to deliver any pending events
+func (et *eventTimerImpl) stop() {
+	et.stopChan <- struct{}{}
+}
+
+// loop is where the timer thread lives, looping
+func (et *eventTimerImpl) loop() {
+	var eventDestChan chan<- event
+	var event event
+
+	for {
+		// A little state machine, relying on the fact that nil channels will block on read/write indefinitely
+
+		select {
+		case start := <-et.startChan:
+			if et.timerChan != nil {
+				if start.hard {
+					logger.Debug("Resetting a running timer")
+				} else {
+					continue
+				}
+			}
+			logger.Debug("Starting timer")
+			et.timerChan = time.After(start.duration)
+			if eventDestChan != nil {
+				logger.Debug("Timer cleared pending event")
+			}
+			event = start.event
+			eventDestChan = nil
+		case <-et.stopChan:
+			if et.timerChan == nil && eventDestChan == nil {
+				logger.Warning("Attempting to stop an unfired idle timer")
+			}
+			et.timerChan = nil
+			logger.Debug("Stopping timer for")
+			if eventDestChan != nil {
+				logger.Debug("Timer for cleared pending event")
+			}
+			eventDestChan = nil
+			event = nil
+		case <-et.timerChan:
+			logger.Debug("Event timer fired")
+			et.timerChan = nil
+			eventDestChan = et.manager.queue()
+		case eventDestChan <- event:
+			logger.Debug("Timer event delivered")
+			eventDestChan = nil
+		case <-et.exit:
+			logger.Debug("Halting timer")
+			return
+		}
+	}
+}
+
+// ------------------------------------------------------------
+//
+// Event Types
+//
+// ------------------------------------------------------------
+
+type eventType int
+
+const (
+	workEventID eventType = iota
+	viewChangeTimerEventID
+	execDoneEventID
+	stateUpdatedEventID
+	stateUpdatingEventID
+	messageEventID
+)
+
+// workEvent is a temporary type, to inject work
+type workEvent func()
+
+func (e workEvent) eventType() eventType {
+	return workEventID
+}
+
+// viewChangeTimerEvent is sent when the view change timer expires
+type viewChangeTimerEvent struct{}
+
+func (e viewChangeTimerEvent) eventType() eventType {
+	return viewChangeTimerEventID
+}
+
+// execDoneEvent is sent when an execution completes
+type execDoneEvent struct{}
+
+func (e execDoneEvent) eventType() eventType {
+	return execDoneEventID
+}
+
+// stateUpdatedEvent is sent when state transfer completes
+type stateUpdatedEvent checkpointMessage
+
+func (e stateUpdatedEvent) eventType() eventType {
+	return stateUpdatedEventID
+}
+
+// stateUpdatingEvent is sent when state transfer is initiated
+type stateUpdatingEvent checkpointMessage
+
+func (e stateUpdatingEvent) eventType() eventType {
+	return stateUpdatingEventID
+}
+
+// messageEvent is sent when a consensus messages is received to be sent to pbft
+type messageEvent pbftMessage
+
+func (e messageEvent) eventType() eventType {
+	return messageEventID
+}

--- a/consensus/obcpbft/events_test.go
+++ b/consensus/obcpbft/events_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import (
+	"testing"
+	"time"
+)
+
+// mockEventID is equivalent to MIN_INT to prevent collisions
+const mockEventID eventType = eventType(^0)
+
+type mockEvent struct{}
+
+func (mev *mockEvent) eventType() eventType {
+	return mockEventID
+}
+
+type mockReceiver struct {
+	processEventImpl func(event event) event
+}
+
+func (mr *mockReceiver) processEvent(event event) event {
+	if mr.processEventImpl != nil {
+		return mr.processEventImpl(event)
+	}
+	return nil
+}
+
+func newMockManager(processEvent func(event event) event) eventManager {
+	return newEventManagerImpl(&mockReceiver{
+		processEventImpl: processEvent,
+	})
+}
+
+// Starts an event timer, waits for the event to be delivered
+func TestEventTimerStart(t *testing.T) {
+	events := make(chan event)
+	mr := newMockManager(func(event event) event {
+		events <- event
+		return nil
+	})
+	mr.start()
+	defer mr.halt()
+	timer := newEventTimer(mr)
+	defer timer.halt()
+	me := &mockEvent{}
+	timer.reset(time.Millisecond, me)
+
+	select {
+	case e := <-events:
+		if e != me {
+			t.Fatalf("Received wrong output from event timer")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for event to fire")
+	}
+}
+
+// Starts an event timer, resets it twice, expects second output
+func TestEventTimerHardReset(t *testing.T) {
+	events := make(chan event)
+	mr := newMockManager(func(event event) event {
+		events <- event
+		return nil
+	})
+	timer := newEventTimer(mr)
+	defer timer.halt()
+	me1 := &mockEvent{}
+	me2 := &mockEvent{}
+	timer.reset(time.Millisecond, me1)
+	timer.reset(time.Millisecond, me2)
+
+	mr.start()
+	defer mr.halt()
+
+	select {
+	case e := <-events:
+		if e != me2 {
+			t.Fatalf("Received wrong output from event timer")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for event to fire")
+	}
+}
+
+// Starts an event timer, soft resets it twice, expects first output
+func TestEventTimerSoftReset(t *testing.T) {
+	events := make(chan event)
+	mr := newMockManager(func(event event) event {
+		events <- event
+		return nil
+	})
+	timer := newEventTimer(mr)
+	defer timer.halt()
+	me1 := &mockEvent{}
+	me2 := &mockEvent{}
+	timer.softReset(time.Millisecond, me1)
+	timer.softReset(time.Millisecond, me2)
+
+	mr.start()
+	defer mr.halt()
+
+	select {
+	case e := <-events:
+		if e != me1 {
+			t.Fatalf("Received wrong output from event timer")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for event to fire")
+	}
+}
+
+// Starts an event timer, then stops it before delivery is possible, should not receive event
+func TestEventTimerStop(t *testing.T) {
+	events := make(chan event)
+	mr := newMockManager(func(event event) event {
+		events <- event
+		return nil
+	})
+	timer := newEventTimer(mr)
+	defer timer.halt()
+	me := &mockEvent{}
+	timer.reset(time.Millisecond, me)
+	time.Sleep(100 * time.Millisecond) // Allow the timer to fire
+	timer.stop()
+
+	mr.start()
+	defer mr.halt()
+
+	select {
+	case <-events:
+		t.Fatalf("Received event output from event timer")
+	case <-time.After(100 * time.Millisecond):
+		// All good
+	}
+}
+
+// Replies to an event with a different event, should process both
+func TestEventManagerLoop(t *testing.T) {
+	success := make(chan struct{})
+	m2 := &mockEvent{}
+	mr := newMockManager(func(event event) event {
+		if event != m2 {
+			return m2
+		}
+		success <- struct{}{}
+		return nil
+	})
+	mr.start()
+	defer mr.halt()
+
+	mr.queue() <- &mockEvent{}
+
+	select {
+	case <-success:
+		// All good
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Did not succeed processing second event")
+	}
+}

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -52,7 +52,7 @@ func (ce *consumerEndpoint) isBusy() bool {
 	}
 
 	select {
-	case <-ce.consumer.getPBFTCore().idleChan:
+	case ce.consumer.getPBFTCore().manager.queue() <- nil:
 		ce.net.debugMsg("Reporting busy because pbft not idle\n")
 	default:
 		return true

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -83,7 +83,6 @@ func TestNetworkBatch(t *testing.T) {
 
 func TestBatchCustody(t *testing.T) {
 	t.Skip("test is racy")
-
 	validatorCount := 4
 	net := makeConsumerNetwork(validatorCount, func(id uint64, config *viper.Viper, stack consensus.Stack) pbftConsumer {
 		config.Set("general.batchsize", "1")

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -117,13 +117,13 @@ type pbftCore struct {
 	hChkpts        map[uint64]uint64 // highest checkpoint sequence number observed for each replica
 
 	currentExec        *uint64             // currently executing request
-	newViewTimer       *time.Timer         // timeout triggering a view change
 	timerActive        bool                // is the timer running?
+	newViewTimer       eventTimer          // timeout triggering a view change
+	manager            eventManager        // TODO, remove eventually, the event manager which sends events to pbft
 	requestTimeout     time.Duration       // progress timeout for requests
 	newViewTimeout     time.Duration       // progress timeout for new views
 	lastNewViewTimeout time.Duration       // last timeout we used during this view change
 	outstandingReqs    map[string]*Request // track whether we are waiting for requests to execute
-	newViewTimerReason string              // what triggered the timer
 
 	missingReqs map[string]bool // for all the assigned, non-checkpointed requests we might be missing during view-change
 
@@ -192,6 +192,13 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack) *pbftCore 
 	instance.idleChan = make(chan struct{})
 	instance.injectChan = make(chan func())
 
+	// TODO Ultimately, the timer factory will be passed in, and the existence of the manager
+	// will be hidden from pbftCore, but in the interest of a small PR, leaving it here for now
+	instance.manager = newEventManagerImpl(instance)
+	etf := newEventTimerFactoryImpl(instance.manager)
+	instance.newViewTimer = etf.createTimer()
+	instance.manager.start()
+
 	instance.N = config.GetInt("general.N")
 	instance.f = config.GetInt("general.f")
 	if instance.f*3+1 > instance.N {
@@ -249,67 +256,60 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack) *pbftCore 
 	instance.outstandingReqs = make(map[string]*Request)
 	instance.missingReqs = make(map[string]bool)
 
-	instance.stopTimer()
 	instance.restoreState()
-
-	go instance.main()
 
 	return instance
 }
 
 // close tears down resources opened by newPbftCore
 func (instance *pbftCore) close() {
-	select { // Prevent closing multiple times
-	case <-instance.closed:
-	default:
-		close(instance.closed)
-	}
-	instance.stopTimer()
+	instance.manager.halt()
+	instance.newViewTimer.halt()
 }
 
 // allow the view-change protocol to kick-off when the timer expires
-func (instance *pbftCore) main() {
+func (instance *pbftCore) processEvent(e event) event {
 
-	for {
-		logger.Debug("Replica %d service thread looping", instance.id)
+	logger.Debug("Replica %d processing event", instance.id)
 
-		select {
-		case <-instance.closed:
-			close(instance.idleChan)
-			return
-		case <-instance.newViewTimer.C:
-			logger.Info("Replica %d view change timer expired, sending view change", instance.id)
-			instance.sendViewChange()
-		case msg := <-instance.incomingChan:
-			logger.Debug("Replica %d received incoming message from %v", instance.id, msg.sender)
-			instance.recvMsg(msg.msg, msg.sender)
-		case update := <-instance.stateUpdatingChan:
-			instance.skipInProgress = true
-			instance.lastExec = update.seqNo
-			instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
-		case update := <-instance.stateUpdatedChan:
-			seqNo := update.seqNo
-			logger.Info("Replica %d application caught up via state transfer, lastExec now %d", instance.id, seqNo)
-			// XXX create checkpoint
-			instance.lastExec = seqNo
-			instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
-			instance.skipInProgress = false
-			instance.executeOutstanding()
-		case <-instance.execCompleteChan:
-			instance.execDoneSync()
-		case work := <-instance.injectChan:
-			work() // Used to allow the caller to steal use of the main thread
-		case instance.idleChan <- struct{}{}:
-			// Used to detect when this thread is idle for testing
-		}
+	switch e.eventType() {
+	case viewChangeTimerEventID:
+		logger.Info("Replica %d view change timer expired, sending view change", instance.id)
+		instance.timerActive = false
+		instance.sendViewChange()
+	case messageEventID:
+		msg := e.(messageEvent)
+		logger.Debug("Replica %d received incoming message from %v", instance.id, msg.sender)
+		instance.recvMsg(msg.msg, msg.sender)
+	case stateUpdatingEventID:
+		update := e.(stateUpdatingEvent)
+		instance.skipInProgress = true
+		instance.lastExec = update.seqNo
+		instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
+	case stateUpdatedEventID:
+		update := e.(stateUpdatedEvent)
+		seqNo := update.seqNo
+		logger.Info("Replica %d application caught up via state transfer, lastExec now %d", instance.id, seqNo)
+		// XXX create checkpoint
+		instance.lastExec = seqNo
+		instance.moveWatermarks(instance.lastExec) // The watermark movement handles moving this to a checkpoint boundary
+		instance.skipInProgress = false
+		instance.executeOutstanding()
+	case execDoneEventID:
+		instance.execDoneSync()
+	case workEventID:
+		e.(workEvent)() // Used to allow the caller to steal use of the main thread, to be removed
+	default:
+		logger.Error("Replica %d received an unknown message type", instance.id)
 	}
+
+	return nil
 }
 
 // Allows the caller to inject work onto the main thread
 // This is useful when the caller wants to safely manipulate PBFT state
 func (instance *pbftCore) inject(work func()) {
-	instance.injectChan <- work
-	<-instance.idleChan
+	instance.manager.queue() <- workEvent(work)
 }
 
 // =============================================================================
@@ -442,7 +442,7 @@ func (instance *pbftCore) committed(digest string, v uint64, n uint64) bool {
 func (instance *pbftCore) request(msgPayload []byte, senderID uint64) error {
 	msg := &Message{&Message_Request{&Request{Payload: msgPayload,
 		ReplicaId: senderID}}}
-	instance.incomingChan <- &pbftMessage{
+	instance.manager.queue() <- messageEvent{
 		sender: senderID,
 		msg:    msg,
 	}
@@ -457,7 +457,7 @@ func (instance *pbftCore) receive(msgPayload []byte, senderID uint64) error {
 		return fmt.Errorf("Error unpacking payload from message: %s", err)
 	}
 
-	instance.incomingChan <- &pbftMessage{
+	instance.manager.queue() <- messageEvent{
 		msg:    msg,
 		sender: senderID,
 	}
@@ -468,7 +468,7 @@ func (instance *pbftCore) receive(msgPayload []byte, senderID uint64) error {
 // stateUpdate is an event telling us that the application fast-forwarded its state
 func (instance *pbftCore) stateUpdated(seqNo uint64, id []byte) {
 	logger.Debug("Replica %d queueing message that it has caught up via state transfer", instance.id)
-	instance.stateUpdatedChan <- &checkpointMessage{
+	instance.manager.queue() <- stateUpdatedEvent{
 		seqNo: seqNo,
 		id:    id,
 	}
@@ -477,7 +477,7 @@ func (instance *pbftCore) stateUpdated(seqNo uint64, id []byte) {
 // stateUpdate is an event telling us that the application fast-forwarded its state
 func (instance *pbftCore) stateUpdating(seqNo uint64, id []byte) {
 	logger.Debug("Replica %d queueing message that state transfer has been initiated", instance.id)
-	instance.stateUpdatingChan <- &checkpointMessage{
+	instance.manager.queue() <- stateUpdatingEvent{
 		seqNo: seqNo,
 		id:    id,
 	}
@@ -485,7 +485,7 @@ func (instance *pbftCore) stateUpdating(seqNo uint64, id []byte) {
 
 // TODO, this should not return an error
 func (instance *pbftCore) recvMsgSync(msg *Message, senderID uint64) (err error) {
-	instance.incomingChan <- &pbftMessage{
+	instance.manager.queue() <- messageEvent{
 		msg:    msg,
 		sender: senderID,
 	}
@@ -573,8 +573,8 @@ func (instance *pbftCore) recvRequest(req *Request) error {
 	instance.reqStore[digest] = req
 	instance.outstandingReqs[digest] = req
 	instance.persistRequest(digest)
-	if !instance.timerActive && instance.activeView {
-		instance.startTimer(instance.requestTimeout, fmt.Sprintf("new request %s", digest))
+	if instance.activeView {
+		instance.softStartTimer(instance.requestTimeout, fmt.Sprintf("new request %s", digest))
 	}
 
 	if instance.primary(instance.view) == instance.id && instance.activeView { // if we're primary of current view
@@ -696,9 +696,7 @@ func (instance *pbftCore) recvPrePrepare(preprep *PrePrepare) error {
 		instance.persistRequest(digest)
 	}
 
-	if !instance.timerActive {
-		instance.startTimer(instance.requestTimeout, fmt.Sprintf("new pre-prepare for %s", preprep.RequestDigest))
-	}
+	instance.softStartTimer(instance.requestTimeout, fmt.Sprintf("new pre-prepare for %s", preprep.RequestDigest))
 
 	if instance.primary(instance.view) != instance.id && instance.prePrepared(preprep.RequestDigest, preprep.View, preprep.SequenceNumber) && !cert.sentPrepare {
 		logger.Debug("Backup %d broadcasting prepare for view=%d/seqNo=%d",
@@ -895,7 +893,7 @@ func (instance *pbftCore) Checkpoint(seqNo uint64, id []byte) {
 
 // execDone is an event telling us that the last execution has completed
 func (instance *pbftCore) execDone() {
-	instance.execCompleteChan <- struct{}{}
+	instance.manager.queue() <- execDoneEvent{}
 }
 
 func (instance *pbftCore) execDoneSync() {
@@ -1181,9 +1179,6 @@ func (instance *pbftCore) innerBroadcast(msg *Message) error {
 }
 
 func (instance *pbftCore) startTimerIfOutstandingRequests() {
-	if instance.timerActive {
-		return
-	}
 
 	if len(instance.outstandingReqs) > 0 {
 		reqs := func() []string {
@@ -1193,20 +1188,24 @@ func (instance *pbftCore) startTimerIfOutstandingRequests() {
 			}
 			return r
 		}()
-		instance.startTimer(instance.requestTimeout, fmt.Sprintf("outstanding requests %v", reqs))
+		instance.softStartTimer(instance.requestTimeout, fmt.Sprintf("outstanding requests %v", reqs))
 	}
 }
 
-func (instance *pbftCore) startTimer(timeout time.Duration, reason string) {
-	instance.newViewTimer = time.NewTimer(timeout) // Create a new timer, if it has already fired, it will still read on the channel
-	logger.Debug("Replica %d starting new view timer for %s: %s", instance.id, timeout, reason)
-	instance.newViewTimerReason = reason
+func (instance *pbftCore) softStartTimer(timeout time.Duration, reason string) {
+	logger.Debug("Replica %d soft starting new view timer for %s: %s", instance.id, timeout, reason)
 	instance.timerActive = true
+	instance.newViewTimer.softReset(timeout, viewChangeTimerEvent{})
+}
+
+func (instance *pbftCore) startTimer(timeout time.Duration, reason string) {
+	logger.Debug("Replica %d starting new view timer for %s: %s", instance.id, timeout, reason)
+	instance.timerActive = true
+	instance.newViewTimer.reset(timeout, viewChangeTimerEvent{})
 }
 
 func (instance *pbftCore) stopTimer() {
-	instance.newViewTimer = time.NewTimer(UnreasonableTimeout) // Create a new timer, then stop it, if it has already fired, it will still read on the channel
-	instance.newViewTimer.Stop()
 	logger.Debug("Replica %d stopping a running new view timer", instance.id)
 	instance.timerActive = false
+	instance.newViewTimer.stop()
 }

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -47,7 +47,7 @@ func (pe *pbftEndpoint) isBusy() bool {
 	// channel, the send blocks until the thread has picked up the new work, still
 	// this will be removed pending the transition to an externally driven state machine
 	select {
-	case <-pe.pbft.idleChan:
+	case pe.pbft.manager.queue() <- nil:
 	default:
 		pe.net.debugMsg("TEST: Returning as busy no reply on idleChan\n")
 		return true


### PR DESCRIPTION
## Description

This changeset is the first in a series designed to unify the execution path of pbft core, and its plugins.  This adds a new `eventManager` which serializes events and delivers them to a consumer, in this case, `pbft-core.go`.  It also adds a new `eventTimer` which integrates with the `eventManager` so that timers which are cancelled by the event thread will never be delivered as events to the consumer.

Please note, that as this is intended to be a reviewable series of patches, not all work has been completed, and there are some TODOs in the code, this is intentional.

I'd especially appreciate review from @corecode 
## Motivation and Context

The current PBFT code utilizes one go routine in its core, and one go routine in its plugins.  This causes race conditions and makes development much more difficult.  In order to be able to merge the two threads, we need a common event framework so that both plugin and core can share the same event processing thread.
## How Has This Been Tested?

The new event code contains several new unit tests.  The integration with the existing pbft core code has been checked via unit tests locally, and should be covered by CI.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
