### PR TITLE
Move batch to pbft event manager

### DIFF
--- a/consensus/obcpbft/deduplicator.go
+++ b/consensus/obcpbft/deduplicator.go
@@ -1,20 +1,17 @@
 /*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+Copyright IBM Corp. 2016 All Rights Reserved.
 
-  http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package obcpbft

--- a/consensus/obcpbft/fuzz_test.go
+++ b/consensus/obcpbft/fuzz_test.go
@@ -59,9 +59,11 @@ func TestFuzz(t *testing.T) {
 
 	mock := newFuzzMock()
 	primary := newPbftCore(0, loadConfig(), mock)
+	primary.manager.start()
 	defer primary.close()
 	mock = newFuzzMock()
 	backup := newPbftCore(1, loadConfig(), mock)
+	backup.manager.start()
 	defer backup.close()
 
 	f := fuzz.New()

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -33,16 +33,13 @@ type obcBatch struct {
 
 	batchSize        int
 	batchStore       []*Request
-	batchTimer       *time.Timer
+	batchTimer       eventTimer
 	batchTimerActive bool
 	batchTimeout     time.Duration
 	inViewChange     bool
 
-	incomingChan     chan *batchMessage // Queues messages for processing by main thread
-	custodyTimerChan chan custodyInfo   // Queues complaints
-	execChan         chan *execInfo     // Signals an execution event
-	viewChanged      chan struct{}      // Signals that a view change has occurred
-	idleChan         chan struct{}      // Used in unit testing to check for idleness
+	incomingChan chan *batchMessage // Queues messages for processing by main thread
+	idleChan     chan struct{}      // Idle channel, to be removed
 
 	complainer   *complainer
 	deduplicator *deduplicator
@@ -78,6 +75,11 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	logger.Debug("Replica %d obtaining startup information", id)
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager = newEventManagerImpl(op) // TODO, this is hacky, eventually rip it out
+	etf := newEventTimerFactoryImpl(op.pbft.manager)
+	op.pbft.newViewTimer.halt()
+	op.pbft.newViewTimer = etf.createTimer()
+	op.pbft.manager.start()
 
 	op.batchSize = config.GetInt("general.batchSize")
 	op.batchStore = nil
@@ -87,20 +89,15 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	}
 
 	op.incomingChan = make(chan *batchMessage)
-	op.custodyTimerChan = make(chan custodyInfo)
-	op.execChan = make(chan *execInfo)
 
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()
 
-	// create non-running timer
-	op.batchTimer = time.NewTimer(100 * time.Hour) // XXX ugly
-	op.batchTimer.Stop()
+	op.batchTimer = etf.createTimer()
 
 	op.idleChan = make(chan struct{})
-	op.viewChanged = make(chan struct{})
+	close(op.idleChan) // TODO remove eventually
 
-	go op.main()
 	return op
 }
 
@@ -108,7 +105,7 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 // the stack. New transaction requests are broadcast to all replicas,
 // so that the current primary will receive the request.
 func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
-	op.incomingChan <- &batchMessage{
+	op.pbft.manager.queue() <- batchMessageEvent{
 		msg:    ocMsg,
 		sender: senderHandle,
 	}
@@ -118,14 +115,14 @@ func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
 
 // Complain is necessary to implement complaintHandler
 func (op *obcBatch) Complain(hash string, req *Request, primaryFail bool) {
-	logger.Debug("Replica %d processing complaint from custodian", op.pbft.id)
-	op.custodyTimerChan <- custodyInfo{hash, req, primaryFail}
+	c := complaintEvent{hash, req, primaryFail}
+	op.pbft.manager.queue() <- c
 }
 
 // Close tells us to release resources we are holding
 func (op *obcBatch) Close() {
 	op.complainer.Stop()
-	op.batchTimer.Reset(0)
+	op.batchTimer.stop()
 	op.pbft.close()
 }
 
@@ -202,7 +199,7 @@ func (op *obcBatch) validate(txRaw []byte) error {
 
 // execute an opaque request which corresponds to an OBC Transaction
 func (op *obcBatch) execute(seqNo uint64, raw []byte) {
-	op.execChan <- &execInfo{
+	op.pbft.manager.queue() <- batchExecEvent{
 		seqNo: seqNo,
 		raw:   raw,
 	}
@@ -245,21 +242,11 @@ func (op *obcBatch) executeImpl(seqNo uint64, raw []byte) {
 	_ = result // XXX what to do with the result?
 	_, err = op.stack.CommitTxBatch(id, meta)
 
-	op.pbft.execDone()
+	op.pbft.execDoneSync()
 }
 
-// signal when a view-change happened, this is the PBFT thread, don't modify internal state and give it back!
 func (op *obcBatch) viewChange(curView uint64) {
-
-	// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
-	// in a different batch, but PBFT core can't see through the opaque structure to see this
-	// so, on view change, we rely on the fact that the complaint service will resubmit requests
-	// and instead zero the outstandingReqs map ourselves
-	op.pbft.outstandingReqs = make(map[string]*Request)
-
-	logger.Debug("Replica %d PBFT view change thread attempting to signal batch thread", op.pbft.id)
-
-	go func() { op.viewChanged <- struct{}{} }()
+	// TODO, remove
 }
 
 // =============================================================================
@@ -306,7 +293,7 @@ func (op *obcBatch) sendBatch() error {
 
 	// process internally
 	logger.Info("Creating batch with %d requests", len(reqBlock.Requests))
-	op.pbft.request(reqsPacked, op.pbft.id)
+	op.pbft.requestSync(reqsPacked, op.pbft.id)
 
 	return nil
 }
@@ -358,7 +345,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 		if err != nil {
 			panic("Cannot map sender's PeerID to a valid replica ID")
 		}
-		op.pbft.receive(pbftMsg, senderID)
+		op.pbft.receiveSync(pbftMsg, senderID)
 	} else if complaint := batchMsg.GetComplaint(); complaint != nil {
 		if op.pbft.primary(op.pbft.view) == op.pbft.id && op.pbft.activeView {
 			return op.leaderProcReq(complaint)
@@ -388,7 +375,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 // this request raced with a later one and lost, then we need to
 // repackage this request's payload into a new request and resubmit
 // it.
-func (op *obcBatch) resubmitStaleRequest(c custodyInfo) {
+func (op *obcBatch) resubmitStaleRequest(c complaintEvent) {
 	oldReq := c.req.(*Request)
 
 	if !op.complainer.InCustody(oldReq) {
@@ -407,83 +394,78 @@ func (op *obcBatch) resubmitStaleRequest(c custodyInfo) {
 }
 
 // allow the primary to send a batch when the timer expires
-func (op *obcBatch) main() {
-	for {
-		logger.Debug("Replica %d batch main thread looping", op.pbft.id)
-		select {
-		case <-op.pbft.closed:
-			close(op.idleChan)
-			return
-		case ocMsg := <-op.incomingChan:
-			if err := op.processMessage(ocMsg.msg, ocMsg.sender); nil != err {
-				logger.Error("Error processing message: %v", err)
-			}
-		case <-op.batchTimer.C:
-			logger.Info("Replica %d batch timer expired", op.pbft.id)
-			if op.pbft.activeView && (len(op.batchStore) > 0) {
-				op.sendBatch()
-			}
-		case <-op.viewChanged:
-			logger.Debug("Replica %d batch thread recognizing new view", op.pbft.id)
-			op.inViewChange = false
-			if op.batchTimerActive {
-				op.stopBatchTimer()
-			}
-
-			op.complainer.Restart()
-			for _, pair := range op.complainer.CustodyElements() {
-				logger.Info("Replica %d resubmitting request under custody: %s", op.pbft.id, pair.Hash)
-				op.submitToLeader(pair.Request)
-			}
-		case c := <-op.custodyTimerChan:
-			if !op.deduplicator.IsNew(c.req.(*Request)) {
-				op.resubmitStaleRequest(c)
-				continue
-			}
-
-			if !c.complaint {
-				logger.Warning("Batch replica %d custody expired, complaining: %s", op.pbft.id, c.hash)
-				op.broadcastMsg(&BatchMessage{&BatchMessage_Complaint{c.req.(*Request)}})
-			} else {
-				if !op.inViewChange && op.pbft.activeView {
-					logger.Debug("Batch replica %d complaint timeout expired for %s", op.pbft.id, c.hash)
-					op.inViewChange = true
-					op.pbft.injectChan <- func() { op.pbft.sendViewChange() }
-				} else {
-					logger.Debug("Batch replica %d complaint timeout expired for %s while in view change", op.pbft.id, c.hash)
-				}
-			}
-		case execInfo := <-op.execChan:
-			op.executeImpl(execInfo.seqNo, execInfo.raw)
-		case op.idleChan <- struct{}{}:
-			// Only used to detect thread idleness during unit tests
+func (op *obcBatch) processEvent(event event) event {
+	logger.Debug("Replica %d batch main thread looping", op.pbft.id)
+	switch event.eventType() {
+	case batchMessageEventID:
+		ocMsg := event.(batchMessageEvent)
+		if err := op.processMessage(ocMsg.msg, ocMsg.sender); nil != err {
+			logger.Error("Error processing message: %v", err)
 		}
+		return nil
+	case batchTimerEventID:
+		logger.Info("Replica %d batch timer expired", op.pbft.id)
+		if op.pbft.activeView && (len(op.batchStore) > 0) {
+			op.sendBatch()
+		}
+	case viewChangedEventID:
+		// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
+		// in a different batch, but PBFT core can't see through the opaque structure to see this
+		// so, on view change, we rely on the fact that the complaint service will resubmit requests
+		// and instead zero the outstandingReqs map ourselves
+		op.pbft.outstandingReqs = make(map[string]*Request)
+
+		logger.Debug("Replica %d batch thread recognizing new view", op.pbft.id)
+		op.inViewChange = false
+		if op.batchTimerActive {
+			op.stopBatchTimer()
+		}
+
+		op.complainer.Restart()
+		for _, pair := range op.complainer.CustodyElements() {
+			logger.Info("Replica %d resubmitting request under custody: %s", op.pbft.id, pair.Hash)
+			op.submitToLeader(pair.Request)
+		}
+	case batchExecEventID:
+		execInfo := event.(batchExecEvent)
+		op.executeImpl(execInfo.seqNo, execInfo.raw)
+	case complaintEventID:
+		c := event.(complaintEvent)
+		logger.Debug("Replica %d processing complaint from custodian", op.pbft.id)
+		if !op.deduplicator.IsNew(c.req.(*Request)) {
+			op.resubmitStaleRequest(c)
+			break
+		}
+
+		if !c.complaint {
+			logger.Warning("Batch replica %d custody expired, complaining: %s", op.pbft.id, c.hash)
+			op.broadcastMsg(&BatchMessage{&BatchMessage_Complaint{c.req.(*Request)}})
+		} else {
+			if !op.inViewChange && op.pbft.activeView {
+				logger.Debug("Batch replica %d complaint timeout expired for %s", op.pbft.id, c.hash)
+				op.inViewChange = true
+				op.pbft.sendViewChange()
+			} else {
+				logger.Debug("Batch replica %d complaint timeout expired for %s while in view change", op.pbft.id, c.hash)
+			}
+		}
+	default:
+		return op.pbft.processEvent(event)
 	}
+
+	return nil
 }
 
 func (op *obcBatch) startBatchTimer() {
-	op.batchTimer.Reset(op.batchTimeout)
+	op.batchTimer.reset(op.batchTimeout, batchTimerEvent{})
 	logger.Debug("Replica %d started the batch timer", op.pbft.id)
 	op.batchTimerActive = true
 }
 
 func (op *obcBatch) stopBatchTimer() {
-	op.batchTimer.Stop()
+	op.batchTimer.stop()
 	logger.Debug("Replica %d stopped the batch timer", op.pbft.id)
 	op.batchTimerActive = false
-	select {
-	case <-op.pbft.closed:
-		return
-	default:
-	}
-loopBatch:
-	for {
-		select {
-		case <-op.batchTimer.C:
-		default:
-			break loopBatch
-		}
-	}
 }
 
 // Wraps a payload into a batch message, packs it and wraps it into

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -186,14 +186,13 @@ func TestBatchStaleCustody(t *testing.T) {
 	req1 := createOcMsgWithChainTx(1)
 	op.RecvMsg(req1, &pb.PeerID{})
 	op.RecvMsg(createOcMsgWithChainTx(2), &pb.PeerID{})
-	<-op.idleChannel()
+	op.pbft.manager.queue() <- nil
 	op.pbft.currentExec = new(uint64) // so that pbft.execDone doesn't get unhappy
 	*op.pbft.currentExec = 1
 	rblock2raw, _ := proto.Marshal(&RequestBlock{[]*Request{reqs[1]}})
 	op.executeImpl(1, rblock2raw)
 	time.Sleep(500 * time.Millisecond)
-	<-op.idleChannel()
-
+	op.pbft.manager.queue() <- nil
 	if len(reqs) != 3 || !reflect.DeepEqual(reqs[2].Payload, req1.Payload) {
 		t.Error("expected resubmitted request")
 	}

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -44,6 +44,7 @@ func newObcClassic(id uint64, config *viper.Viper, stack consensus.Stack) *obcCl
 	logger.Debug("Replica %d obtaining startup information", id)
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager.start()
 
 	op.idleChan = make(chan struct{})
 	close(op.idleChan)

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -83,6 +83,7 @@ func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSiev
 	op.restoreBlockNumber()
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager.start()
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()
 

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -147,6 +147,8 @@ func makePBFTNetwork(N int, initFNs ...func(pe *pbftEndpoint)) *pbftNetwork {
 			fn(pe)
 		}
 
+		pe.pbft.manager.start()
+
 		return pe
 
 	}

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -73,6 +73,7 @@ func TestMaliciousPrePrepare(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -125,6 +126,7 @@ func TestIncompletePayload(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -370,6 +372,7 @@ func TestViewChangeWatermarksMovement(t *testing.T) {
 		},
 		broadcastImpl: func(b []byte) {},
 	})
+	instance.manager.start()
 	instance.activeView = false
 	instance.view = 1
 	instance.lastExec = 10
@@ -786,6 +789,7 @@ func TestSendQueueThrottling(t *testing.T) {
 
 	mock := &omniProto{}
 	instance := newPbftCore(0, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -820,6 +824,7 @@ func TestSendQueueThrottling(t *testing.T) {
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -845,6 +850,7 @@ func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 func TestWitnessFallBehindMissingPrePrepare(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -996,6 +1002,7 @@ func TestRequestTimerDuringViewChange(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -1048,6 +1055,7 @@ func TestReplicaCrash1(t *testing.T) {
 	for id := 0; id < 2; id++ {
 		pe := net.pbftEndpoints[id]
 		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc)
+		pe.pbft.manager.start()
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.K = 2
@@ -1190,6 +1198,7 @@ func TestReplicaCrash3(t *testing.T) {
 		config := loadConfig()
 		config.Set("general.K", "2")
 		pe.pbft = newPbftCore(uint64(id), config, pe.sc)
+		pe.pbft.manager.start()
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.requestTimeout = 200 * time.Millisecond

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1272,6 +1272,7 @@ func TestReplicaPersistQSet(t *testing.T) {
 		},
 	}
 	p := newPbftCore(1, loadConfig(), stack)
+	p.manager.start()
 	req := &Request{
 		Timestamp: &gp.Timestamp{Seconds: 1, Nanos: 0},
 		Payload:   []byte("foo"),
@@ -1284,6 +1285,8 @@ func TestReplicaPersistQSet(t *testing.T) {
 		Request:        req,
 		ReplicaId:      uint64(0),
 	}}}, uint64(0))
+	p.manager.queue() <- nil
+	p.close()
 
 	p = newPbftCore(1, loadConfig(), stack)
 	if !p.prePrepared(hashReq(req), 0, 1) {

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -433,7 +433,7 @@ func (instance *pbftCore) processNewView2(nv *NewView) error {
 
 	logger.Debug("Replica %d done cleaning view change artifacts, calling into consumer", instance.id)
 
-	instance.consumer.viewChange(instance.view)
+	instance.manager.inject(viewChangedEvent{})
 
 	return nil
 }


### PR DESCRIPTION
## Description

This changeset removes the batch plugin thread, and instead has it rely on the event manager thread introduced in #1586.
## Motivation and Context

This is the second in a series of changesets (see PR #1586) designed to eliminate the plugin threads from PBFT.  As this is in a series, it does not explicitly fix any particular issue, but it is work towards eliminating the race conditions (by eliminating go routines).

As with #1586, this changeset contains some hacky things and TODOs, pieces marked for eventual removal, etc.  This is intentional.

If @corecode could please review.
## How Has This Been Tested?

This has passed the pbft unit tests locally, and the CI should confirm the changeset doesn't break anything.  Because there is no new function, just re-routing of execution flow, the existing tests should be adequate.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
