### PR TITLE
Protect against nil pointer dereference in execDoneSync

### DIFF
--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -894,7 +894,9 @@ func (instance *pbftCore) execDoneSync() {
 		}
 
 	} else {
-		logger.Debug("Replica %d had execDoneSync called, but there is no current execution", instance.id)
+		// XXX This masks a bug, this should not be called when currentExec is nil
+		logger.Warning("Replica %d had execDoneSync called, flagging ourselves as out of date", instance.id)
+		instance.skipInProgress = true
 	}
 	instance.currentExec = nil
 

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1291,3 +1291,8 @@ func TestReplicaPersistDelete(t *testing.T) {
 		t.Error("expected no persisted entry")
 	}
 }
+
+func TestNilCurrentExec(t *testing.T) {
+	p := newPbftCore(1, loadConfig(), &omniProto{})
+	p.execDoneSync() // Per issue 1538, this would cause a Nil pointer dereference
+}


### PR DESCRIPTION
## Description

This changeset directly protects against a nil pointer dereference in `execDoneSync`
## Motivation and Context

The code in `execDoneSync` did not protect against dereferencing the `currentExec` pointer even if it was nil, sometimes resulting in crashes.

This should fix #1538, though confirmation from @bmos299 would be appreciated.
## How Has This Been Tested?

This is a simple change, and should be obviously correct.  Although the value of a new test case for this is dubious, I've included a very short unit test case which exhibits the behavior before the change, but not after.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
