### PR TITLE
Modifying chaincode invoke response message

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -437,7 +437,7 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 
 		rw.WriteHeader(http.StatusOK)
 		fmt.Fprintf(rw, "{\"OK\": \"%s\"}", urlEncodedCert)
-		restLogger.Debug("Sucessfully retrieved enrollment certificate for secure context '%s'", enrollmentID)
+		restLogger.Debug("Successfully retrieved enrollment certificate for secure context '%s'", enrollmentID)
 	} else {
 		// Security must be enabled to request enrollment certificates
 		rw.WriteHeader(http.StatusBadRequest)
@@ -573,7 +573,7 @@ func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web
 
 		rw.WriteHeader(http.StatusOK)
 		fmt.Fprintf(rw, "{\"OK\": %s}", string(jsonResponse))
-		restLogger.Debug("Sucessfully retrieved transaction certificates for secure context '%s'", enrollmentID)
+		restLogger.Debug("Successfully retrieved transaction certificates for secure context '%s'", enrollmentID)
 	} else {
 		// Security must be enabled to request transaction certificates
 		rw.WriteHeader(http.StatusBadRequest)
@@ -806,7 +806,7 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 
 	rw.WriteHeader(http.StatusOK)
 	fmt.Fprintf(rw, "{\"OK\": \"Successfully deployed chainCode.\",\"message\":\""+chainID+"\"}")
-	restLogger.Info("Successfuly deployed chainCode: " + chainID + ".\n")
+	restLogger.Info("Successfully deployed chainCode: " + chainID + ".\n")
 }
 
 // Invoke executes a specified function within a target Chaincode.
@@ -941,9 +941,9 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	txuuid := resp.Msg
 
 	rw.WriteHeader(http.StatusOK)
-	// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
+	// Make a clarification in the invoke response message, that the transaction has been successfully submitted but not completed
 	fmt.Fprintf(rw, "{\"OK\": \"Successfully submitted invoke transaction.\",\"message\": \"%s\"}", string(txuuid))
-	restLogger.Info("Successfuly submitted invoke transaction (%s).\n", string(txuuid))
+	restLogger.Info("Successfully submitted invoke transaction (%s).\n", string(txuuid))
 }
 
 // Query performs the requested query on the target Chaincode.
@@ -1312,11 +1312,11 @@ func (s *ServerOpenchainREST) ProcessChaincode(rw web.ResponseWriter, req *web.R
 		fmt.Fprintf(rw, string(jsonResponse))
 	}
 
-	// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
+	// Make a clarification in the invoke response message, that the transaction has been successfully submitted but not completed
 	if *(requestPayload.Method) == "invoke" {
-		restLogger.Info(fmt.Sprintf("REST successfuly submitted invoke transaction: %s", string(jsonResponse)))
+		restLogger.Info(fmt.Sprintf("REST successfully submitted invoke transaction: %s", string(jsonResponse)))
 	} else {
-		restLogger.Info(fmt.Sprintf("REST sucessfully %s chaincode: %s", *(requestPayload.Method), string(jsonResponse)))
+		restLogger.Info(fmt.Sprintf("REST successfully %s chaincode: %s", *(requestPayload.Method), string(jsonResponse)))
 	}
 
 	return
@@ -1469,7 +1469,7 @@ func (s *ServerOpenchainREST) processChaincodeDeploy(spec *pb.ChaincodeSpec) rpc
 	//
 
 	result := formatRPCOK(chainID)
-	restLogger.Info(fmt.Sprintf("Successfuly deployed chainCode: %s", chainID))
+	restLogger.Info(fmt.Sprintf("Successfully deployed chainCode: %s", chainID))
 
 	return result
 }
@@ -1605,8 +1605,8 @@ func (s *ServerOpenchainREST) processChaincodeInvokeOrQuery(method string, spec 
 		//
 
 		result = formatRPCOK(txuuid)
-		// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
-		restLogger.Info(fmt.Sprintf("Successfuly submitted invoke transaction with txuuid (%s)", txuuid))
+		// Make a clarification in the invoke response message, that the transaction has been successfully submitted but not completed
+		restLogger.Info(fmt.Sprintf("Successfully submitted invoke transaction with txuuid (%s)", txuuid))
 	}
 
 	if method == "query" {
@@ -1644,7 +1644,7 @@ func (s *ServerOpenchainREST) processChaincodeInvokeOrQuery(method string, spec 
 		//
 
 		result = formatRPCOK(val)
-		restLogger.Info(fmt.Sprintf("Successfuly queried chaincode: %s", val))
+		restLogger.Info(fmt.Sprintf("Successfully queried chaincode: %s", val))
 	}
 
 	return result

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -941,8 +941,9 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	txuuid := resp.Msg
 
 	rw.WriteHeader(http.StatusOK)
-	fmt.Fprintf(rw, "{\"OK\": \"Successfully invoked chainCode.\",\"message\": \"%s\"}", string(txuuid))
-	restLogger.Info("Successfuly invoked chainCode with txuuid (%s)\n", string(txuuid))
+	// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
+	fmt.Fprintf(rw, "{\"OK\": \"Successfully submitted invoke transaction.\",\"message\": \"%s\"}", string(txuuid))
+	restLogger.Info("Successfuly submitted invoke transaction (%s).\n", string(txuuid))
 }
 
 // Query performs the requested query on the target Chaincode.
@@ -1310,7 +1311,13 @@ func (s *ServerOpenchainREST) ProcessChaincode(rw web.ResponseWriter, req *web.R
 		rw.WriteHeader(http.StatusOK)
 		fmt.Fprintf(rw, string(jsonResponse))
 	}
-	restLogger.Info(fmt.Sprintf("REST sucessfully %s chaincode: %s", *(requestPayload.Method), string(jsonResponse)))
+
+	// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
+	if *(requestPayload.Method) == "invoke" {
+		restLogger.Info(fmt.Sprintf("REST successfuly submitted invoke transaction: %s", string(jsonResponse)))
+	} else {
+		restLogger.Info(fmt.Sprintf("REST sucessfully %s chaincode: %s", *(requestPayload.Method), string(jsonResponse)))
+	}
 
 	return
 }
@@ -1598,7 +1605,8 @@ func (s *ServerOpenchainREST) processChaincodeInvokeOrQuery(method string, spec 
 		//
 
 		result = formatRPCOK(txuuid)
-		restLogger.Info(fmt.Sprintf("Successfuly invoked chainCode with txuuid (%s)", txuuid))
+		// Make a clarification in the invoke response message, that the transaction has been successfuly submitted but not completed
+		restLogger.Info(fmt.Sprintf("Successfuly submitted invoke transaction with txuuid (%s)", txuuid))
 	}
 
 	if method == "query" {


### PR DESCRIPTION
## Description

Modifying existing chaincode invoke response message and log message to clarify that the invoke transaction has been _submitted_, but not completed. 
## Motivation and Context

This change is made to clarify that the submission of a transaction does not guarantee it's successful execution. The previous response message has always returned "success", which misled the end user and resulted in issue #835.

Fixes #835
## How Has This Been Tested?

I verified that the new response and log message were visible whenever a chaincode invoke request took place. All the current UTs pass and no new tests are needed for this change.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Modifying chaincode invoke response message to clarify that the
transaction has been successfully submitted, but not completed.

Fixes #835

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
