### PR TITLE
Adding a warning header to REST /devops response

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -671,7 +671,7 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST deploying chaincode...")
 
 	// This endpoint has been deprecated. Add a warning header to all responses.
-	rw.Header().Set("Warning", "199 - /devops/deploy endpoint has been deprecated. Use /chaincode endpoint instead.")
+	rw.Header().Set("Warning", "299 - /devops/deploy endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeSpec
@@ -817,7 +817,7 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST invoking chaincode...")
 
 	// This endpoint has been deprecated. Add a warning header to all responses.
-	rw.Header().Set("Warning", "199 - /devops/invoke endpoint has been deprecated. Use /chaincode endpoint instead.")
+	rw.Header().Set("Warning", "299 - /devops/invoke endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec
@@ -956,7 +956,7 @@ func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST querying chaincode...")
 
 	// This endpoint has been deprecated. Add a warning header to all responses.
-	rw.Header().Set("Warning", "199 - /devops/query endpoint has been deprecated. Use /chaincode endpoint instead.")
+	rw.Header().Set("Warning", "299 - /devops/query endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -670,6 +670,9 @@ func (s *ServerOpenchainREST) GetTransactionByUUID(rw web.ResponseWriter, req *w
 func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST deploying chaincode...")
 
+	// This endpoint has been deprecated. Add a warning header to all responses.
+	rw.Header().Set("Warning", "199 - /devops/deploy endpoint has been deprecated. Use /chaincode endpoint instead.")
+
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeSpec
 	err := jsonpb.Unmarshal(req.Body, &spec)
@@ -813,6 +816,9 @@ func (s *ServerOpenchainREST) Deploy(rw web.ResponseWriter, req *web.Request) {
 func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST invoking chaincode...")
 
+	// This endpoint has been deprecated. Add a warning header to all responses.
+	rw.Header().Set("Warning", "199 - /devops/invoke endpoint has been deprecated. Use /chaincode endpoint instead.")
+
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec
 	err := jsonpb.Unmarshal(req.Body, &spec)
@@ -948,6 +954,9 @@ func (s *ServerOpenchainREST) Invoke(rw web.ResponseWriter, req *web.Request) {
 // Query performs the requested query on the target Chaincode.
 func (s *ServerOpenchainREST) Query(rw web.ResponseWriter, req *web.Request) {
 	restLogger.Info("REST querying chaincode...")
+
+	// This endpoint has been deprecated. Add a warning header to all responses.
+	rw.Header().Set("Warning", "199 - /devops/query endpoint has been deprecated. Use /chaincode endpoint instead.")
 
 	// Decode the incoming JSON payload
 	var spec pb.ChaincodeInvocationSpec


### PR DESCRIPTION
## Description

This PR is opened after receiving comments from @srderson on PR #1576. This change adds a warning header to the HTTP response received from the deprecated /devops endpoint. The warning header indicates that the endpoint is deprecated and is superceeded by the new /chaincode endpoint.
## Motivation and Context

This change is necessary to warn users of the REST API that the /devops endpoint is being deprecated and is now superceeded by the /chaincode endpoint. Users should transition to using the /chaincode endpoint as the /devops endpoint will eventually be removed.

Fixes #1101
## How Has This Been Tested?

I tested this change by sending requests to the /devops/deploy, /devops/invoke, and /devops/query endpoints and confirming that the correct warning header was returned in the response payload. This issue does not require new test cases as the code change simply adds a new warning header to an existing request, not new functionality.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Adding a warning header to warn the client of deprecated /devops
endpoint.

Fixes #1101

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
