### PR TITLE
Changing asset management input formatting to base64

### DIFF
--- a/examples/chaincode/go/asset_management/README.md
+++ b/examples/chaincode/go/asset_management/README.md
@@ -29,7 +29,7 @@ A possible work-flow could be the following:
 1. Alice is the deployer of the chaincode;
 2. Alice wants to assign the administrator role to Bob;
 3. Alice obtains, via an out-of-band channel, a TCert of Bob, let us call this certificate *BobCert*;
-4. Alice constructs a deploy transaction, as described in *application-ACL.md*,  setting the transaction metadata to *DER(BobCert)*.
+4. Alice constructs a deploy transaction, as described in *application-ACL.md*,  setting the transaction metadata to *BobCert*.
 5. Alice submits the transaction to the fabric network.
 
 Notice that Alice can assign to herself the role of administrator.
@@ -45,7 +45,7 @@ A possible work-flow could be the following:
 1. Bob is the administrator of the chaincode;
 2. Bob wants to assign the asset 'Picasso' to Charlie;
 3. Bob obtains, via an out-of-band channel, a TCert of Charlie, let us call this certificate *CharlieCert*;
-4. Bob constructs an execute transaction, as described in *application-ACL.md*, to invoke the *assign* function passing as parameters *('Picasso', DER(CharlieCert))*. 
+4. Bob constructs an execute transaction, as described in *application-ACL.md*, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
 5. Bob submits the transaction to the fabric network.
 
 ## *transfer(asset, user)*
@@ -59,7 +59,7 @@ A possible work-flow could be the following:
 1. Charlie is the owner of 'Picasso';
 2. Charlie wants to transfer the ownership of 'Picasso' to Dave;
 3. Charlie obtains, via an out-of-band channel, a TCert of Dave, let us call this certificate *DaveCert*;
-4. Charlie constructs an execute transaction, as described in *application-ACL.md*, to invoke the *transfer* function passing as parameters *('Picasso', DER(DaveCert))*. 
+4. Charlie constructs an execute transaction, as described in *application-ACL.md*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
 5. Charlie submits the transaction to the fabric network.
 
 ## *query(asset)*

--- a/examples/chaincode/go/asset_management/README.md
+++ b/examples/chaincode/go/asset_management/README.md
@@ -45,7 +45,7 @@ A possible work-flow could be the following:
 1. Bob is the administrator of the chaincode;
 2. Bob wants to assign the asset 'Picasso' to Charlie;
 3. Bob obtains, via an out-of-band channel, a TCert of Charlie, let us call this certificate *CharlieCert*;
-4. Bob constructs an execute transaction, as described in *application-ACL.md*, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
+4. Bob constructs an invoke transaction, as described in *application-ACL.md*, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
 5. Bob submits the transaction to the fabric network.
 
 ## *transfer(asset, user)*
@@ -59,7 +59,7 @@ A possible work-flow could be the following:
 1. Charlie is the owner of 'Picasso';
 2. Charlie wants to transfer the ownership of 'Picasso' to Dave;
 3. Charlie obtains, via an out-of-band channel, a TCert of Dave, let us call this certificate *DaveCert*;
-4. Charlie constructs an execute transaction, as described in *application-ACL.md*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
+4. Charlie constructs an invoke transaction, as described in *application-ACL.md*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
 5. Charlie submits the transaction to the fabric network.
 
 ## *query(asset)*

--- a/examples/chaincode/go/asset_management/app/README.md
+++ b/examples/chaincode/go/asset_management/app/README.md
@@ -34,7 +34,7 @@ Notice that, to assign ownership of assets, Bob has to use *BobCert* to authenti
 ### Bob assigns the asset 'Picasso' to Charlie
 
 1. Bob obtains, via an out-of-band channel, a TCert of Charlie, let us call this certificate *CharlieCert*;
-2. Bob constructs an execute transaction, as described in *application-ACL.md* using *BobCert* to gain access, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
+2. Bob constructs an invoke transaction, as described in *application-ACL.md* using *BobCert* to gain access, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
 3. Bob submits the transaction to the fabric network.
 
 Charlie is now the owner of 'Picasso'.
@@ -44,7 +44,7 @@ Notice that, to transfer the ownership of 'Picasso', Charlie has to use *Charlie
 ### Charlie transfers the ownership of 'Picasso' to Dave
 
 1. Charlie obtains, via an out-of-band channel, a TCert of Dave, let us call this certificate *DaveCert*;
-2. Charlie constructs an execute transaction, as described in *application-ACL.md* using *CharlieCert*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
+2. Charlie constructs an invoke transaction, as described in *application-ACL.md* using *CharlieCert*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
 3. Charlie submits the transaction to the fabric network.
 
 Dave is now the owner of 'Picasso'

--- a/examples/chaincode/go/asset_management/app/README.md
+++ b/examples/chaincode/go/asset_management/app/README.md
@@ -34,7 +34,7 @@ Notice that, to assign ownership of assets, Bob has to use *BobCert* to authenti
 ### Bob assigns the asset 'Picasso' to Charlie
 
 1. Bob obtains, via an out-of-band channel, a TCert of Charlie, let us call this certificate *CharlieCert*;
-2. Bob constructs an execute transaction, as described in *application-ACL.md* using *BobCert* to gain access, to invoke the *assign* function passing as parameters *('Picasso', DER(CharlieCert))*. 
+2. Bob constructs an execute transaction, as described in *application-ACL.md* using *BobCert* to gain access, to invoke the *assign* function passing as parameters *('Picasso', Base64(DER(CharlieCert)))*. 
 3. Bob submits the transaction to the fabric network.
 
 Charlie is now the owner of 'Picasso'.
@@ -44,7 +44,7 @@ Notice that, to transfer the ownership of 'Picasso', Charlie has to use *Charlie
 ### Charlie transfers the ownership of 'Picasso' to Dave
 
 1. Charlie obtains, via an out-of-band channel, a TCert of Dave, let us call this certificate *DaveCert*;
-2. Charlie constructs an execute transaction, as described in *application-ACL.md* using *CharlieCert*, to invoke the *transfer* function passing as parameters *('Picasso', DER(DaveCert))*. 
+2. Charlie constructs an execute transaction, as described in *application-ACL.md* using *CharlieCert*, to invoke the *transfer* function passing as parameters *('Picasso', Base64(DER(DaveCert)))*. 
 3. Charlie submits the transaction to the fabric network.
 
 Dave is now the owner of 'Picasso'

--- a/examples/chaincode/go/asset_management/app/app.go
+++ b/examples/chaincode/go/asset_management/app/app.go
@@ -1,3 +1,19 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/examples/chaincode/go/asset_management/app/app.go
+++ b/examples/chaincode/go/asset_management/app/app.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
 	"github.com/hyperledger/fabric/core/crypto"
 	pb "github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
 	"google.golang.org/grpc"
-	"os"
-	"reflect"
-	"time"
-	"fmt"
 )
 
 var (

--- a/examples/chaincode/go/asset_management/app/app_internal.go
+++ b/examples/chaincode/go/asset_management/app/app_internal.go
@@ -1,3 +1,19 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/examples/chaincode/go/asset_management/app/app_internal.go
+++ b/examples/chaincode/go/asset_management/app/app_internal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
+	"encoding/base64"
 )
 
 var (
@@ -168,7 +169,10 @@ func assignOwnershipInternal(invoker crypto.Client, invokerCert crypto.Certifica
 		return nil, err
 	}
 
-	chaincodeInput := &pb.ChaincodeInput{Function: "assign", Args: []string{asset, string(newOwnerCert.GetCertificate())}}
+	chaincodeInput := &pb.ChaincodeInput{
+		Function: "assign",
+		Args: []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
+	}
 	chaincodeInputRaw, err := proto.Marshal(chaincodeInput)
 	if err != nil {
 		return nil, err
@@ -217,7 +221,10 @@ func transferOwnershipInternal(owner crypto.Client, ownerCert crypto.Certificate
 		return nil, err
 	}
 
-	chaincodeInput := &pb.ChaincodeInput{Function: "transfer", Args: []string{asset, string(newOwnerCert.GetCertificate())}}
+	chaincodeInput := &pb.ChaincodeInput{
+		Function: "transfer",
+		Args: []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
+	}
 	chaincodeInputRaw, err := proto.Marshal(chaincodeInput)
 	if err != nil {
 		return nil, err

--- a/examples/chaincode/go/asset_management/app/app_internal.go
+++ b/examples/chaincode/go/asset_management/app/app_internal.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/chaincode/platforms"
@@ -15,7 +17,6 @@ import (
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
-	"encoding/base64"
 )
 
 var (
@@ -171,7 +172,7 @@ func assignOwnershipInternal(invoker crypto.Client, invokerCert crypto.Certifica
 
 	chaincodeInput := &pb.ChaincodeInput{
 		Function: "assign",
-		Args: []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
+		Args:     []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
 	}
 	chaincodeInputRaw, err := proto.Marshal(chaincodeInput)
 	if err != nil {
@@ -223,7 +224,7 @@ func transferOwnershipInternal(owner crypto.Client, ownerCert crypto.Certificate
 
 	chaincodeInput := &pb.ChaincodeInput{
 		Function: "transfer",
-		Args: []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
+		Args:     []string{asset, base64.StdEncoding.EncodeToString(newOwnerCert.GetCertificate())},
 	}
 	chaincodeInputRaw, err := proto.Marshal(chaincodeInput)
 	if err != nil {

--- a/examples/chaincode/go/asset_management/asset_management.go
+++ b/examples/chaincode/go/asset_management/asset_management.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/op/go-logging"
+	"encoding/hex"
 )
 
 var myLogger = logging.MustGetLogger("asset_mgm")
@@ -55,11 +56,15 @@ func (t *AssetManagementChaincode) Init(stub *shim.ChaincodeStub, function strin
 	// The metadata will contain the certificate of the administrator
 	adminCert, err := stub.GetCallerMetadata()
 	if err != nil {
+		myLogger.Debug("Failed getting metadata")
 		return nil, errors.New("Failed getting metadata.")
 	}
 	if len(adminCert) == 0 {
+		myLogger.Debug("Invalid admin certificate. Empty.")
 		return nil, errors.New("Invalid admin certificate. Empty.")
 	}
+
+	myLogger.Debug("The administrator is [%x]", adminCert)
 
 	stub.PutState("admin", adminCert)
 
@@ -76,7 +81,10 @@ func (t *AssetManagementChaincode) assign(stub *shim.ChaincodeStub, args []strin
 	}
 
 	asset := args[0]
-	owner := []byte(args[1])
+	owner, err := hex.DecodeString(args[1])
+	if err != nil {
+		return nil, errors.New("Failed decodinf owner")
+	}
 
 	// Verify the identity of the caller
 	// Only an administrator can invoker assign
@@ -119,7 +127,10 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	}
 
 	asset := args[0]
-	newOwner := []byte(args[1])
+	newOwner, err := hex.DecodeString(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("Failed decoding owner")
+	}
 
 	// Verify the identity of the caller
 	// Only the owner can transfer one of his assets
@@ -167,6 +178,9 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	if err != nil {
 		return nil, errors.New("Failed inserting row.")
 	}
+
+	myLogger.Debug("New owener of [%s] is [% x]", asset, newOwner)
+
 
 	myLogger.Debug("Transfer...done")
 

--- a/examples/chaincode/go/asset_management/asset_management.go
+++ b/examples/chaincode/go/asset_management/asset_management.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/op/go-logging"
-	"encoding/hex"
+	"encoding/base64"
 )
 
 var myLogger = logging.MustGetLogger("asset_mgm")
@@ -81,7 +81,7 @@ func (t *AssetManagementChaincode) assign(stub *shim.ChaincodeStub, args []strin
 	}
 
 	asset := args[0]
-	owner, err := hex.DecodeString(args[1])
+	owner, err := base64.StdEncoding.DecodeString(args[1])
 	if err != nil {
 		return nil, errors.New("Failed decodinf owner")
 	}
@@ -127,7 +127,7 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	}
 
 	asset := args[0]
-	newOwner, err := hex.DecodeString(args[1])
+	newOwner, err := base64.StdEncoding.DecodeString(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("Failed decoding owner")
 	}
@@ -179,7 +179,7 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 		return nil, errors.New("Failed inserting row.")
 	}
 
-	myLogger.Debug("New owener of [%s] is [% x]", asset, newOwner)
+	myLogger.Debug("New owner of [%s] is [% x]", asset, newOwner)
 
 
 	myLogger.Debug("Transfer...done")

--- a/examples/chaincode/go/asset_management/asset_management.go
+++ b/examples/chaincode/go/asset_management/asset_management.go
@@ -17,12 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
+
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/op/go-logging"
-	"encoding/base64"
 )
 
 var myLogger = logging.MustGetLogger("asset_mgm")
@@ -180,7 +181,6 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	}
 
 	myLogger.Debug("New owner of [%s] is [% x]", asset, newOwner)
-
 
 	myLogger.Debug("Transfer...done")
 

--- a/examples/chaincode/go/asset_management/asset_management.go
+++ b/examples/chaincode/go/asset_management/asset_management.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/op/go-logging"
-	"encoding/hex"
 	"encoding/base64"
 )
 
@@ -128,7 +127,7 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	}
 
 	asset := args[0]
-	newOwner, err := hex.DecodeString(args[1])
+	newOwner, err := base64.StdEncoding.DecodeString(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("Failed decoding owner")
 	}

--- a/examples/chaincode/go/asset_management/asset_management.go
+++ b/examples/chaincode/go/asset_management/asset_management.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/op/go-logging"
+	"encoding/hex"
 	"encoding/base64"
 )
 
@@ -45,8 +46,8 @@ func (t *AssetManagementChaincode) Init(stub *shim.ChaincodeStub, function strin
 
 	// Create ownership table
 	err := stub.CreateTable("AssetsOwnership", []*shim.ColumnDefinition{
-		&shim.ColumnDefinition{"Asset", shim.ColumnDefinition_STRING, true},
-		&shim.ColumnDefinition{"Owner", shim.ColumnDefinition_BYTES, false},
+		&shim.ColumnDefinition{Name: "Asset", Type: shim.ColumnDefinition_STRING, Key: true},
+		&shim.ColumnDefinition{Name: "Owner", Type: shim.ColumnDefinition_BYTES, Key: false},
 	})
 	if err != nil {
 		return nil, errors.New("Failed creating AssetsOnwership table.")
@@ -127,7 +128,7 @@ func (t *AssetManagementChaincode) transfer(stub *shim.ChaincodeStub, args []str
 	}
 
 	asset := args[0]
-	newOwner, err := base64.StdEncoding.DecodeString(args[1])
+	newOwner, err := hex.DecodeString(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("Failed decoding owner")
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Some of the functions exposed by the asset management chaincode take in input byte arrays. Because the fabric supports only the string type, a proper encoding must be used to avoid loosing information and to be agnostic to the different platforms used.
## Motivation and Context

This change is required to allow the client-sdk to properly invoke the asset management chaincode. Without a proper formatting, converting a byte array to string in node is meaningless.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

The code has been tested against the node client-sdk currently in development. 
The companion asset management app (golang) has been updated to reflect the new encoding.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
