### PR TITLE
pbft: add null request "keep alives"

### DIFF
--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -49,6 +49,10 @@ general:
 
         # How long may a view change take
         viewchange: 2s
+
+        # Interval to send "keep-alive" null requests.  Set to 0 to disable.
+        nullrequest: 0s
+
 ################################################################################
 #
 #   SECTION: EXECUTOR

--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -298,3 +298,6 @@ type batchExecEvent execInfo
 
 // returnRequestEvent is sent by pbft when we are forwarded a request
 type returnRequestEvent *Request
+
+// nullRequestEvent provides "keep-alive" null requests
+type nullRequestEvent struct{}

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -392,6 +392,8 @@ func (instance *pbftCore) processNewView2(nv *NewView) error {
 	logger.Info("Replica %d accepting new-view to view %d", instance.id, instance.view)
 
 	instance.stopTimer()
+	instance.nullRequestTimer.stop()
+
 	instance.activeView = true
 	delete(instance.newViewStore, instance.view-1)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Optionally send periodic null request "keep alives" when the pbft network is idle.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1454
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

unit tests, behave
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
