### PR TITLE
Add assertion to test case confirming non-existent block is nil

### DIFF
--- a/core/ledger/ledger_test.go
+++ b/core/ledger/ledger_test.go
@@ -205,6 +205,9 @@ func TestLedgerPutRawBlock(t *testing.T) {
 	if !bytes.Equal(newBlock.PreviousBlockHash, previousHash) {
 		t.Fatalf("Expected new block to properly set its previous hash")
 	}
+
+	// Assert that a non-existent block is nil
+	testutil.AssertNil(t, ledgerTestWrapper.GetBlockByNumber(2))
 }
 
 func TestLedgerSetRawState(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

As part of debugging issue #1091, a one line addition was added to the PutRawBlock test case to assert that a non-existent block is nil.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

If `ledger.PutRawBlock` is called for a value higher than the current chain height and then `ledger.GetBlockByNumber` is called for a value between the previous chain height and the newly added raw block, the returned block should be `nil`. There was no test confirming this.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

This is an addition to an existing test case. The test case has been run and passes.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
