### PR TITLE
Add a new ./build area

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,16 @@ $(GOPATH)/bin/%:
 	$(eval TOOL = ${subst $(GOPATH)/bin/,,${@}})
 	$(MAKE) gotool.$(TOOL)
 
+build/bin:
+	mkdir -p $@
+
 .PHONY: protos
 protos:
 	./devenv/compile_protos.sh
 
 .PHONY: clean
 clean:
+	-@rm -rf build ||:
 	-@rm -f .*image-dummy ||:
 	-@rm -f ./peer/peer ||:
 	-@rm -f ./membersrvc/membersrvc ||:

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -106,7 +106,7 @@ echo "PS1=\"\u@hyperledger-devenv:v$BASEIMAGE_RELEASE-$DEVENV_REVISION:\w$ \"" >
 # configure vagrant specific environment
 cat <<EOF >/etc/profile.d/vagrant-devenv.sh
 # Expose the devenv/tools in the $PATH
-export PATH=\$PATH:/hyperledger/devenv/tools
+export PATH=\$PATH:/hyperledger/devenv/tools:/hyperledger/build/bin
 export VAGRANT=1
 export CGO_CFLAGS=" "
 export CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"


### PR DESCRIPTION
This change adds a (currently unused) ./build area managed by the top-level Makefile
## Description

Right now, binaries are scattered in different places:
1. go-tools are written to $GOPATH/bin
2. peer/membershipsvcs stay in their src directory
3. chaintool is committed to ./devenv/tools

It would be nice if our build supported a more transitory location that aggregates build artifacts.  However, it will also be helpful if certain binaries could be on the $PATH.

Therefore, this patch introduces two main concepts:
1. The build manages a ./build dir by creating it on demand (currently no consumers) and cleaning it up as part of "make clean".
2. We modify vagrant such that ./build/bin is on the path.

In the future, we can emit specific build artifacts (such as peer, membersvcs, and even chaintool when/if it makes its way into the tree) to ./build/bin.

This means people will be able to simply say "peer node xxx" rather than "cd ./peer; ./peer node xxx" 
## Motivation and Context

This change will improve the overall build architecture (less slop spread around the filesystem) as well as the user experience (no FQP wrangling required to launch processes like ./peer/peer).

We introduce it now, without explicit users, so that we can amortize the requirement for a vagrant destroy/up cycle with some other non-related PRs like #1529 that need to go in ASAP.  We also want to give people a chance to get their vagrant paths updated before we change out the binary locations for things like peer sometime in the future.
## How Has This Been Tested?
1. ran "make build/bin" to ensure directory is created
2. ran "make clean" to ensure directory is cleaned up
3. ran "make clean" again to ensure make does not blow up if the directory doesn't exist.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
