### PR TITLE
Add a test for chaincode over HTTP

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -380,7 +380,7 @@ chaincode:
     startuptimeout: 1000
 
     #timeout in millisecs for deploying chaincode from a remote repository.
-    deploytimeout: 30000
+    deploytimeout: 60000
 
     #mode - options are "dev", "net"
     #dev - in dev mode, user runs the chaincode after starting validator from

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -365,7 +365,7 @@ func TestHTTPExecuteDeployTransaction(t *testing.T) {
 	// The chaincode used here cannot be from the hyperledger repo
 	// itself or it won't be downloaded because it will be found
 	// in GOPATH, which would defeat the test
-	executeDeployTransaction(t, "http://github.com/lehors/fabric/examples/chaincode/go/chaincode_example01")
+	executeDeployTransaction(t, "http://github.com/hyperledger/fabric-test-resources/examples/chaincode/go/chaincode_example01")
 }
 
 // Check the correctness of the final state after transaction execution.

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -361,14 +361,12 @@ func TestGopathExecuteDeployTransaction(t *testing.T) {
 }
 
 // Test deploy of a transaction with a chaincode over HTTP.
-/*
 func TestHTTPExecuteDeployTransaction(t *testing.T) {
 	// The chaincode used here cannot be from the hyperledger repo
 	// itself or it won't be downloaded because it will be found
 	// in GOPATH, which would defeat the test
 	executeDeployTransaction(t, "http://github.com/lehors/fabric/examples/chaincode/go/chaincode_example01")
 }
-*/
 
 // Check the correctness of the final state after transaction execution.
 func checkFinalState(uuid string, chaincodeID string) error {

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -362,7 +362,7 @@ func TestGopathExecuteDeployTransaction(t *testing.T) {
 
 // Test deploy of a transaction with a chaincode over HTTP.
 func TestHTTPExecuteDeployTransaction(t *testing.T) {
-	// The chaincode used here cannot be from the hyperledger repo
+	// The chaincode used here cannot be from the fabric repo
 	// itself or it won't be downloaded because it will be found
 	// in GOPATH, which would defeat the test
 	executeDeployTransaction(t, "http://github.com/hyperledger/fabric-test-resources/examples/chaincode/go/chaincode_example01")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This PR adds a unit test to cover the code in getCodeFromHTTP in core/chaincode/platforms/golang/hash.go
The test currently depends on my fork of the project because the code must reside outside the Fabric repo. It would however be better to have it located in a separate repo within the HLP.
See related discussion on PR #1556 and Issue #737.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1597
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

make unit-test
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Arnaud J Le Hors lehors@us.ibm.com
