### PR TITLE
Busywork changes 5/26/2006

### DIFF
--- a/tools/busywork/bin/README.md
+++ b/tools/busywork/bin/README.md
@@ -25,7 +25,7 @@ by other major scripts or test drivers. Scripts are typically documented in a
 * [fabricLogger](fabricLogger) is a simple script that converts a blockchain
   into a text file listing of transaction IDs.
   
-* [networkStatus](networkStatis) is a script that reports on the status of
+* [networkStatus](networkStatus) is a script that reports on the status of
   Hyperledger fabric peer networks created with **busywork** tools, with an
   option to be used as a background *watchdog* on the health of the network. 
 

--- a/tools/busywork/bin/README.md
+++ b/tools/busywork/bin/README.md
@@ -109,10 +109,15 @@ and applications create (if necessary) and use `~/.busywork` as the
 in the **BUSYWORK_HOME** depending on which **busywork** tools are being
 used.
 
-* `chaincodes` This file lists chaincode deployments. Each line contains 2
-  fields: 1) The chaincode name or ID; and 2) the chaincode path.
+* `chaincodes` This file lists chaincode deployments. Each line contains
+  The chaincode name or ID, the chaincode path, the initialization function
+  and its arguments.
 
-* `fabricLog` The is a text representation of the blockchain created by the
+* `dev-vp*-*` If you excute the `make cclogs` target of the
+  [Makefile](Makefile) the chaincode logs will be dumped into these
+  directories.
+
+* `fabricLog` This is a text representation of the blockchain created by the
   [fabricLogger](fabricLogger) process that driver scripts invoke to validate
   transaction execution.
   
@@ -121,8 +126,11 @@ used.
   
 * `network` The network configuration is described [below](#network).
 
+* `pprof.*` If you use the [pprofClient](pprofClient) to collect profiles the
+  profile files will be placed here by default.
+
 * `vp[0,...N]/` These directories contain the validating peer databases
-  `/data` and their `/stderr` and `stdout` logs.
+  `/data` and their `/stderr` and `/stdout` logs.
   
 * `*.chain` These files are created by the [checkAgreement](checkAgreement)
   script, and represent the blockchains as recorded on the different peers in

--- a/tools/busywork/bin/README.md
+++ b/tools/busywork/bin/README.md
@@ -1,8 +1,9 @@
 # bin
 
 This directory contains several executable scripts and a
-[Makefile](Makefile). You may find it useful to put this directory in your
-**PATH**. 
+[Makefile](Makefile). You may find it *useful* to put this directory in your
+**PATH**, however this is never *required* for the **busywork** components to
+work correctly.
 
 Many simple "scripts" are actually implemented as make targets, and are
 documeted at the top of the Makefile. Make targets are provided for various
@@ -11,25 +12,37 @@ fabric networks and obtaining logs from containers. Some of the make targets
 are similar to those found in the fabric/Makefile, however are defined with a
 slightly different sensibility.
 
-The following major support scripts are provided. Scripts are typically
-documented in a *usage* string embedded at the top of the script.
+## Major Scripts
 
-* [checkAgreement](checkAgreement) is a script that uses the **fabricLogger**
-  (see below) to check that all of the peers in a network agree on the
-  contents of the blockchain.
+The following major support scripts are provided. These scripts are called out
+by other major scripts or test drivers. Scripts are typically documented in a
+*usage* string embedded at the top of the script.
+
+* [checkAgreement](checkAgreement) is a script that uses the
+  [fabricLogger](fabricLogger) (see below) to check that all of the peers in a
+  network agree on the contents of the blockchain.
 
 * [fabricLogger](fabricLogger) is a simple script that converts a blockchain
   into a text file listing of transaction IDs.
   
-* [userModeNetwork](userModeNetwork) is a script defines Hyperledger fabric
-  peer networks as simple networks of user-mode processes, that is, networks
-  that do not rely on Docker-compose or multiple physical nodes. The concept
-  of a user-mode network is discussed [below](#userModeNetwork).
+* [networkStatus](networkStatis) is a script that reports on the status of
+  Hyperledger fabric peer networks created with **busywork** tools, with an
+  option to be used as a background *watchdog* on the health of the network. 
+
+* [pprofClient](pprofClient) is a script that takes profiles from the
+  profiling server built into the Hyperledger fabric peer.
+
+* [userModeNetwork](userModeNetwork) is a script that defines Hyperledger
+  fabric peer networks as simple networks of user-mode processes, that is,
+  networks that do not rely on Docker-compose, or multiple physical or virtual
+  nodes. The concept of a user-mode network is discussed
+  [below](#userModeNetwork).
   
-* [wait-for-it](wait-for-it) is a script that waits for a network service to
-  be available with an optional timeout. **busywork** applications use
-  `wait-for-it` to sequence network startup correctly.
+* [wait-for-it](wait-for-it) is a general-purpose script that waits for a
+  network service to be available with an optional timeout. **busywork**
+  applications use `wait-for-it` to correctly sequence network startup.
   
+
 <a name="userModeNetwork"></a>
 ## User-Mode Networks
 
@@ -55,6 +68,15 @@ an example of setting up a 4-node network with security, PBFT Sieve consensus
 and DEBUG-level logging in the peers
 
     userModeNetwork -security -sieve -peerLogging debug 4
+	
+Another advantage of a user-mode network can be that the peer processes are
+executed in the environment of the call of
+[userModeNetwork](userModeNetwork). This makes it very easy to override
+default configuration parameters from the command line or from a script. For
+example
+
+    CORE_SECURITY_TCERT_BATCH_SIZE=1000 userModeNetwork -security -sieve 4
+	
 	
 <a name="caveats"></a>
 ## User-Mode Caveats
@@ -87,6 +109,9 @@ and applications create (if necessary) and use `~/.busywork` as the
 in the **BUSYWORK_HOME** depending on which **busywork** tools are being
 used.
 
+* `chaincodes` This file lists chaincode deployments. Each line contains 2
+  fields: 1) The chaincode name or ID; and 2) the chaincode path.
+
 * `fabricLog` The is a text representation of the blockchain created by the
   [fabricLogger](fabricLogger) process that driver scripts invoke to validate
   transaction execution.
@@ -94,7 +119,7 @@ used.
 * `membersrvc/` This directory contains the **membersrvc** database (`/data` -
   TBD) and the `/stderr` and `/stdout` logs from the **membersrvc** server.
   
-* `network` The network configuraation is described [below](#network).
+* `network` The network configuration is described [below](#network).
 
 * `vp[0,...N]/` These directories contain the validating peer databases
   `/data` and their `/stderr` and `stdout` logs.

--- a/tools/busywork/bin/README.md
+++ b/tools/busywork/bin/README.md
@@ -55,7 +55,7 @@ their network service interfaces, databases and logging directories are
 unique. A description of the [network configuration](#network) is written to
 `$BUSYWORK_HOME/network`, and the **busywork** tools refer to this configuration
 by default in order to examine and control the network. The databases and
-logging directories are stored in the [$BUSYWORK_HOME](BUSYWORK_HOME.md)
+logging directories are stored in the [$BUSYWORK_HOME](#busywork-home)
 directory.
 
 Starting a user-mode network of 10 peers running PBFT batch consensus is as as
@@ -82,7 +82,7 @@ example
 ## User-Mode Caveats
 
 Docker is still currently required for chaincode containers, so currently
-users *are* still required to have *root* access and/or sudo-less permission
+users are still required to have *root* access and/or sudo-less permission
 to control Docker. One goal of this project is to completely eliminate the
 *requirement* for Docker from the development and test environment however,
 and allow networks to be reliably set up and tested by normal users sharing a
@@ -151,46 +151,50 @@ used.
     "networkMode": "user",
     "chaincodeMode": "vm",
     "host": "local",
-    "date": "2016/05/17+18:53:07",
+    "date": "2016/05/27+08:15:45",
     "createdBy": "userModeNetwork",
     "security": "true",
     "consensus": "sieve",
+    "peerProfileServer": "true",
     "membersrvc":
         { "service": "0.0.0.0:50051",
-          "profile": "0.0.0.0:44971",
-          "pid": "62328"
+          "pid": "93244"
         },
     "peers": [
         { "id": "vp0",
-          "grpc": "0.0.0.0:35547",
-          "rest": "0.0.0.0:36097",
-          "events": "0.0.0.0:33355",
-          "profile": "0.0.0.0:35510",
-          "pid": "62358"
+          "grpc": "0.0.0.0:42580",
+          "rest": "0.0.0.0:38048",
+          "events": "0.0.0.0:45311",
+          "cli": "0.0.0.0:44155",
+          "profile": "0.0.0.0:44024",
+          "pid": "93269"
         }
         ,
         { "id": "vp1",
-          "grpc": "0.0.0.0:35540",
-          "rest": "0.0.0.0:40712",
-          "events": "0.0.0.0:41232",
-          "profile": "0.0.0.0:37337",
-          "pid": "62362"
+          "grpc": "0.0.0.0:34801",
+          "rest": "0.0.0.0:43718",
+          "events": "0.0.0.0:41947",
+          "cli": "0.0.0.0:43596",
+          "profile": "0.0.0.0:40860",
+          "pid": "93273"
         }
         ,
         { "id": "vp2",
-          "grpc": "0.0.0.0:44523",
-          "rest": "0.0.0.0:39215",
-          "events": "0.0.0.0:42639",
-          "profile": "0.0.0.0:40144",
-          "pid": "62370"
+          "grpc": "0.0.0.0:39656",
+          "rest": "0.0.0.0:36277",
+          "events": "0.0.0.0:36991",
+          "cli": "0.0.0.0:40268",
+          "profile": "0.0.0.0:34522",
+          "pid": "93281"
         }
         ,
         { "id": "vp3",
-          "grpc": "0.0.0.0:42380",
-          "rest": "0.0.0.0:35422",
-          "events": "0.0.0.0:42112",
-          "profile": "0.0.0.0:42939",
-          "pid": "62378"
+          "grpc": "0.0.0.0:36270",
+          "rest": "0.0.0.0:42204",
+          "events": "0.0.0.0:41790",
+          "cli": "0.0.0.0:44141",
+          "profile": "0.0.0.0:45035",
+          "pid": "93289"
         }
     ]
 }

--- a/tools/busywork/bin/checkAgreement
+++ b/tools/busywork/bin/checkAgreement
@@ -175,7 +175,9 @@ if {!$p_dir} {
 }
 
 if {[null [parms explicitPeers]]} {
-    busywork::networkToArray ::parms network.
+    if {[catch {busywork::networkToArray ::parms network.} msg]} {
+        errorExit $msg
+    }
     parms peers [parms network.peer.restAddresses]
 } else {
     parms peers [addPortToHosts [parms explicitPeers] [parms port]]

--- a/tools/busywork/bin/fabricLogger
+++ b/tools/busywork/bin/fabricLogger
@@ -147,7 +147,9 @@ debug {} "$argv0 $argv"
 parms followPoll [durationToMs [parms followPoll]]
 
 if {[null [parms explicitPeers]]} {
-    busywork::networkToArray ::parms network.
+    if {[catch {busywork::networkToArray ::parms network.} msg]} {
+        errorExit $msg
+    }
     parms peers [parms network.peer.restAddresses]
     if {[parms network.consensus] eq "noops"} {
         parms peers [first [parms peers]]
@@ -192,6 +194,15 @@ atErrorExit {killPIDs}
 
 # TODO : Move block access to ::fabric package procedures
 
+proc forceBreakOrErrorExit {i_token} {
+    if {[parms force]} {
+        err {} "Continuing after error (-force mode)"
+        return -code break
+    } else {
+        httpErrorExit $i_token
+    }
+}
+
 set log [parms log]
 set follow [parms follow]
 set block [parms block]
@@ -203,21 +214,19 @@ while {1} {
 
         set peer [peerList next]
 
-        if {[catch {
-            http::geturl http://$peer/chain/blocks/$block
-        } token]} {
+        if {[catch {http::geturl http://$peer/chain/blocks/$block} token]} {
             if {$retry > 0} {
                 if {$retry == [parms retry]} {
-                    warn warn \
-                        "$peer @ block $block : " \
+                    warn {} \
+                        "$peer @ block $block: " \
                         "Retrying after catastrophic HTTP error"
+                }
+                http::cleanup $token
+                continue
             }
-            continue
-        }
-        errorExit \
-                "$peer @ block $block : ::http::geturl failed " \
-                "with [parms retry] retries\n" \
-                $::errorInfo
+            errorExit \
+                "$peer @ block $block: ::http::geturl failed " \
+                "with [parms retry] retries : $token"
         }
     
         if {[http::ncode $token] == 404} {
@@ -236,130 +245,82 @@ while {1} {
             
             if {$retry > 0} {
                 if {$retry == [parms retry]} {
-                    warn warn \
-                        "$peer @ block $block : " \
+                    warn {} \
+                        "$peer @ block $block: " \
                         "Retrying after HTTP error return"
                 }
+                http::cleanup $token
                 continue
             }
             
-            err err \
+            err {} \
                 "REST API call to $peer for block $block failed " \
                 "with [parms retry] retries"
-            err err "HTTP 'ncode' = '[http::ncode $token]'"
-            err err "Full HTTP token dump below; Aborting"
-            foreach {k v} [array get $token] {err err "    $k $v"}
-            exit 1
+            httpErrorExit $token
         }
         
-        set parse [json::json2dict [http::data $token]]
-        
+        if {[catch {json::json2dict [http::data $token]} parse]} {
+            err {} "$peer @ block $block: JSON response does not parse: $parse"
+            forceBreakOrErrorExit $token
+        }
+            
         if {$block != 0} {
             
-            set force 0
             if {[catch {dict get $parse transactions} transactions]} {
-                
-                if {[parms force]} {
-
-                    err {} \
-                        "Block $block JSON response does not parse; " \
-                        "Continuing (-force mode)."
-                    set force 1
-
-                } else {
-
-                    err {} "Block $block JSON response does not parse"
-                    err {} "HTTP 'ncode' = '[http::ncode $token]'"
-                    err {} "Full HTTP token dump below; Aborting"
-                    foreach {k v} [array get $token] {
-                        err {} "    $k $v"
-                    }
-                    exit 1
-                }
+                err {} \
+                    "$peer @ block $block: " \
+                    "Error getting transactions: $transactions"
+                forceBreakOrErrorExit $token
             }
 
-            if {!$force} {
-
-                if {[null $transactions]} {
-
-                    err {} "Block $block contains no transactions"
-                    err {} "HTTP 'ncode' = '[http::ncode $token]'"
-                    err {} "Full HTTP token dump below; Aborting"
-                    foreach {k v} [array get $token] {
-                        err {} "    $k $v"
-                    }
-                    exit 1
-                }
-
-                foreach tx $transactions {
+            foreach tx $transactions {
                 
-                    # The chaincodeID comes back as bytes so that it can be
-                    # encrypted. We don't log it or the timestamp now. The
-                    # "UUID" for type 1 (deploy) transactions is actually the
-                    # chaincode name.
-                    
-                    if {[catch {
-                        set type [dict get $tx type]
-                        set uuid [dict get $tx uuid]}]} {
-                        
-                        if {[parms force]} {
-
-                            err {} \
-                                "Block $block contains a malformed " \
-                                "transaction; Continuing (-force mode)"
-
-                        } else {
-
-                            errorExit \
-                                "Error: Block $block contains a malformed " \
-                                "transaction!\n" \
-                                "Transaction JSON keys : [dict keys $tx]"
-                        }
-
-                    } else {
-                    
-                        switch $type {
-                            1 {
-                                puts $log "d $uuid"
-                            }
-                            2 {
-                                puts $log "i $uuid"
-                            }
-                            default {
-                                if {[parms force]} {
-
-                                    err {} \
-                                        "Block $block has a transaction " \
-                                        "with an illegal type $d; " \
-                                        "Continuing (-force mode)"
-
-                                } else {
-                                    
-                                    errorExit \
-                                        "Block $block has a transaction with " \
-                                        "an illegal type $d"
-                                }
-                            }
-                        }
+                # The chaincodeID comes back as bytes so that it can be
+                # encrypted. We don't log it or the timestamp now. The
+                # "UUID" for type 1 (deploy) transactions is actually the
+                # chaincode name.
+                
+                if {[catch {dict get $tx type} type]} {
+                    err {} \
+                        "$peer @ block $block: " \
+                        "Error parsing type field: $type"
+                    forceBreakOrErrorExit $token
+                }
+                if {[catch {dict get $tx uuid} uuid]} {
+                    err {} "$peer @ block $block: " \
+                        "Error parsing uuid field: $uuid"
+                    forceBreakOrErrorExit $token
+                }
+                switch $type {
+                    1 {
+                        puts $log "d $uuid"
+                    }
+                    2 {
+                        puts $log "i $uuid"
+                    }
+                    default {
+                        err {} "$peer @ block $block: " \
+                            "Illegal transaction type: $type"
+                        forceBreakOrErrorExit $token
                     }
                 }
             }
         }
-        
+
         http::cleanup $token
         puts $log "b $block"
-        
+
         if {$follow} {flush $log}
-        
+
         set lastBlock $block
         incr block
-        
+
         break
     }
-    
+
     if {$retry != [parms retry]} {
         note note \
-            "$peer @ block $lastBlock : " \
-            "Success after [expr {[parms retry] - $retry}] HTTP retries"
+        "$peer @ block $lastBlock: " \
+        "Success after [expr {[parms retry] - $retry}] HTTP retries"
     }
 }

--- a/tools/busywork/bin/networkStatus
+++ b/tools/busywork/bin/networkStatus
@@ -1,0 +1,188 @@
+#!/usr/bin/tclsh
+
+# Copyright IBM Corp. 2016. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# 		 http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set usage {
+Usage: networkStatus ?... args ...?
+
+This script reads the $BUSYWORK_HOME/network file (if it exists) and reports
+on the status of Hyperledger fabric network processes. The script normally
+prints human-oriented reports on stderr; Use the -quiet option to suppress all
+but actual error messages.
+
+In the default mode the script exits normally if the network seems to be alive
+and well, otherwise with a non-0 return code. A polling mode is also provided
+that allows the script to serve as a watchdog process, with an optional
+callback in the event an error is detected.
+
+Optional arguments, with defaults after the colon:
+
+-h | -help | --help : N/A
+
+    If one of these argument forms is present then this usage message is
+    printed and the script exits normally.
+
+-home <busywork_home> : See below
+
+    This argument can be used to name a BUSYWORK_HOME directory to use for the
+    network on the command line. If not defined here then BUSYWORK_HOME is
+    taken from the environment, or if not present there, defaults to
+    ~/.busywork.
+
+-quiet | -verbose : -verbose
+
+    Select -quiet to suppress informative output, and simply return a 0 or
+    non-0 exit code to indicate success or failure.
+
+-poll <duration> : -1
+
+    Specify a non-negative polling interval for -poll to create a polling
+    network watchdog process.
+
+-onError : {}
+
+    The -onError parameter is a Tcl script that will be evaluted in the event
+    that an error in the network is detected. For example, test drivers may
+    specifiy a callback that signals the process that started the
+    networkStatus process:
+
+        exec networkStatus -poll 5s -onError "kill SIGINT [pid]"
+}
+
+############################################################################
+# Status reports by network mode
+############################################################################
+
+# User-mode networks are easy. We simply use 'ps' to query the PID of each
+# process and report based on the 'stat' of the process (if it exists).
+
+proc userModeNetwork {} {
+
+    while {1} {
+
+        set errors 0
+
+        note {} " User-mode Network Status"
+        note {} "Peer  PID   STAT : Status"
+        note {} "__________________________"
+
+        proc report {id pid stat status {level note}} {
+            $level {} [format "%5s %5s %3s : %s" $id $pid $stat $status]
+        }
+
+        set ids [parms network.peer.ids]
+        set pids [parms network.peer.pids]
+        if {[parms network.security]  eq "true"} {
+            set ids [concat CA $ids]
+            set pids [concat [parms network.membersrvc.pid] $pids]
+        }
+        
+        foreach id $ids pid $pids {
+
+            if {[catch {exec ps -p $pid -o stat h} stat]} {
+
+                report $id $pid {} "Process not found, assumed dead" err
+                incr errors
+
+            } else {
+
+                set error 0
+                switch [string range $stat 0 0] {
+                    D -
+                    R -
+                    S {
+                        set status OK
+                    }
+                    T {
+                        set status "Stopped - Considered an error"
+                        incr error
+                    }
+                    X {
+                        set status Dead
+                        inr error
+                    }
+                    Z {
+                        set status Zombie
+                        incr error
+                    }
+                    default {
+                        error "Unexpected process status $stat"
+                    }
+                }
+
+                incr errors $error
+                report $id $pid $stat $status [? $error err note]
+            }
+        }
+
+        if {$errors} {
+            errorExit "Aborting due to errors"
+        }
+
+        if {[parms poll] < 0} {
+            break
+        }
+        after [parms poll]
+    }
+}
+
+
+############################################################################
+# The script
+############################################################################
+
+lappend auto_path [file dirname [info script]]/../tcl
+
+package require busywork
+
+setLoggingPrefix status
+
+set options {
+    {enum {-h -help --help} parms(help)     0  p_help}
+    {key  -home             parms(home)    {}}
+    {bool {-quiet -verbose} parms(quiet)    0}
+    {key  -poll             parms(poll)    -1}
+    {key  -onError          parms(onError)  {} p_onError}
+}
+        
+mapKeywordArgs $argv $options
+
+if {$p_help} {
+    puts $usage
+    exit 0
+}
+
+setLoggingLevel {} [? [parms quiet] error note]
+
+parms home [busywork::home [parms home]]
+
+if {[catch {busywork::networkToArray ::parms network.} msg]} {
+    errorExit $msg
+}
+
+parms poll [durationToMs [parms poll]]
+
+if {$p_onError} {
+    atErrorExit [parms onError]
+}
+
+switch [parms network.networkMode] {
+    user {
+        userModeNetwork
+    }
+    default {
+        errorExit "Unsupported network mode : [parms network.networkMode]"
+    }
+}

--- a/tools/busywork/bin/pprofClient
+++ b/tools/busywork/bin/pprofClient
@@ -1,0 +1,329 @@
+#!/usr/bin/tclsh
+
+# Copyright IBM Corp. 2016. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# 		 http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set usage {
+Usage: pprofClient ?... args ...? [<peers>] <service>
+
+This script creates and manages connections to the Go 'pprof' profiling
+service that is embedded in the Hyperledger fabric peer. This server provides
+several profiling services that are documented in
+
+    http://golang.org/pkg/net/http/pprof
+
+Once generated the profiles are analyzed with "go tool pprof". Documentation
+for this tool is either incomplete or impossible to find - for a start you can
+try
+
+    go tool pprof --help
+
+or look at
+
+   https://blog.golang.org/profiling-go-programs
+
+The <service> argument of the script is the last portion of the "route" for
+the profiling service. Examples:
+
+   pprofClient profile             # Collect default 30-second profile
+   pprofClient profile?seconds=120 # Collect 120-second profile
+
+NOTE: THE 'PROFILE' ROUTE IS THE ONLY PROFILING FACILITY THAT APPEARS TO WORK
+AS DOCUMENTED WHEN CALLED FROM THIS SCRIPT. SOME CHANGES TO THE PEER WILL OR
+MAY BE REQUIRED TO ENABLE OTHER TYPES OF PROFILES.
+
+By default the script invokes the profiling <service> on every peer defined in
+the $BUSYWORK_HOME/network description, and writes the profile files to
+$BUSYWORK_HOME. To profile a subset of the default peers, provide the optional
+<peers> argument.  In this argument peers are addressed by number, using any
+form acceptable to the Tcl procedure enumerate{} (defined in
+busywork/tcl/lists.tcl).  Examples:
+
+    0            -> Peer 0
+    1,3,5        -> Peers 1, 3 and 5
+    1..3         -> Peers 1, 2 and 3
+    3..4,10,1..2 -> Peers 1, 2, 3, 4, and 10
+
+You can also use this script with any peer network by naming peer profiling
+ports with the -peers option, in which case the <peers> specification is not
+used (or allowed) and all of the peers named with -peers are targeted. The
+default profiling port is assumed to be 6060 for explicit peers that do not
+explicitly name a port, unless overidden with the -port option.
+
+Note that the Go 'pprof' tool does not allow the caller to specify the names
+of the profile files - they are named by the host:port of the profiling port,
+and given sequence numbers to make them unique. When this script is run
+against busywork networks, the final act of the script is to create symbolic
+links that substitute the host:port portion of the file names with the peer
+names (vp[0,...N]).  
+
+Optional arguments, with defaults after the colon:
+
+-h | -help | --help : N/A
+
+    If one of these argument forms is present then this usage message is
+    printed and the script exits normally.
+
+-home <busywork_home> : See below
+
+    This argument can be used to name a BUSYWORK_HOME directory where the
+    'network' file is located.  If not defined here then BUSYWORK_HOME is
+    taken from the environment, or if not present there, defaults to
+    ~/.busywork.
+
+-dir <profile_dir> : $BUSYWORK_HOME
+
+    This argument can be used to name a directory to store the profile files
+    other than the default $BUSYWORK_HOME. However, please read the
+    file-naming caveats above that relate to storing multiple profile files in
+    the same directory.
+
+-wait <duration> : 0s
+
+   If specified, wait this amount of time before executing the actual profiing
+   commands.
+
+-quiet | -verbose : -verbose
+
+   If -quiet is selected, then all output other than error messages is
+   suppressed. The default is -verbose which prints only a few message to
+   describe the action as it progresses.
+
+-tag <tag> : N/A
+
+   When multiple CPU profiles are stored into the same directory, the Go pprof
+   tool tags them with sequence numbers to make them unique. If -tag is
+   specified, these sequence numbers are replaced by the <tag> - Both in the
+   original file and the symbolic link. This can be useful for example if
+   profiles are created by parameter-sweeping runs: The <tag> can be used to
+   identify the parameter set of the run.
+
+-peers : N/A
+
+    Described above.
+
+-port : 6060
+
+    The default profile server port to use for explicitly defined peers
+    (-peers option) that do not name an explicit port.
+}
+
+
+############################################################################
+# The script
+############################################################################
+
+lappend auto_path [file dirname [info script]]/../tcl
+
+package require busywork
+
+setLoggingPrefix pprof
+
+set options {
+    {enum {-h -help --help} parms(help)      0 p_help}
+    {key  -home             parms(home)    {}}
+    {key  -dir              parms(dir)      {} p_dir}
+    {key  -wait             parms(wait)    0s}
+    {bool {-quiet -verbose} parms(quiet)    0}
+    {key  -tag              parms(tag)      {} p_tag}
+    {key  -peers            parms(peers)    {} p_peers}
+    {key  -port             parms(port)  6060}
+}
+        
+mapKeywordArgs $argv $options parms(other)
+
+if {$p_help} {
+    puts $usage
+    exit 0
+}
+
+if {[parms quiet]} {
+    setLoggingLevel {} error
+} else {
+    setLoggingLevel {} note
+}
+    
+parms home [busywork::home [parms home]]
+
+# Handle implicit vs. explict peers. With implicit peers we can give the files
+# recognizable names. With explicit peers we can only use the host:port as the
+# names. 
+
+if {$p_peers} {
+
+    # Explicit peers
+
+   if {[llength [parms other]] != 1} {
+       puts $usage
+       errorExit \
+           "With -peers there must be exactly 1 non-optional argument, " \
+           "the profiling service"
+   }
+   parms service [parms other]
+   parms ids [addPortToHosts [parms peers] [parms port]]
+   parms profileAddresses [parms ids]
+
+} else {
+    
+    # Implicit peers
+    
+    if {[catch {busywork::networkToArray ::parms network.} msg]} {
+        errorExit $msg
+    }
+    
+    switch [llength [parms other]] {
+        
+        1 {
+            # All peers
+            
+            parms service [parms other]
+            parms ids [parms network.peer.ids]
+            parms profileAddresses [parms network.peer.profileAddresses]
+        }
+        2 {
+            # Subset of peers
+            
+            set spec [first [parms other]]
+            parms service [second [parms other]]
+                      
+            if {[catch {enumerate $spec} result]} {
+                errorExit \
+                    "Error parsing peer specification : $result"
+            }
+            set nPeers [llength [parms network.peer.ids]]
+            
+            parms ids \
+                [mapeach n $result {
+                    if {$n > $nPeers} {
+                        errorExit "There is no $n\-th peer"
+                    }
+                    return [lindex [parms network.peer.ids] $n]
+                }]
+            parms profileAddresses \
+                [mapeach n $result {
+                    return [lindex [parms network.peer.profileAddresses] $n]
+                }]
+            
+        }
+        default {
+            puts $usage
+            errorExit "Invalid parameters"
+        }
+    }
+}
+
+
+# We 'fork' the children rather than simply executing the 'go tool pprof'
+# commands in the background to better report on any errors that may occur.
+# Following the examples in the web-docs, we use 'go tool pprof' to collect
+# the data; The tool writes the profiles into the directory named by
+# PPROF_TMPDIR.
+
+if {$p_dir} {
+    if {[catch {exec mkdir -p [parms dir]} why]} {
+        errorExit "Attempt to create [parms dir] failed : $why"
+    }
+    set ::env(PPROF_TMPDIR) [parms dir]
+} else {
+    parms dir [set ::env(PPROF_TMPDIR) [parms home]]
+}
+
+set wait [durationToMs [parms wait]]
+if {$wait != 0} {
+    note {} "Waiting [parms wait] to start profiling"
+    after $wait
+}
+
+if {[parms quiet]} {
+    set stdoe >&/dev/null
+} else {
+    set stdoe {}
+}
+
+foreach id [parms ids] target [parms profileAddresses] {
+    flush stdout
+    flush stderr
+    set pid [fork]
+    switch $pid {
+        -1 {
+            errorExit "Fork failed"
+        }
+        0 {
+            set url http://$target/debug/pprof/[parms service]
+            if {[catch \
+                     {eval exec -ignorestderr go tool pprof $url $stdoe </dev/null} \
+                     reason]} {
+                errorExit "'go tool pprof $url' failed : $reason"
+            }
+            exit 0
+        }
+        default {
+            lappend pids $pid
+        }
+    }
+}
+
+if {[waitPIDs $pids]} {
+    errorExit "One or more profiling processes failed"
+}
+
+
+# If the user named peers explicitly, then we're done. Otherwise, we try to
+# find the profile files that the tool just created and link the names given
+# by the tool with names based on the peer IDs. The Go pprof tool does not
+# support providing names for the profile files - it names them based on their
+# http addresses using the form 'pprof.<host+port>.<other junk>'.
+
+# The renaming-via-links being done here is not perfect in every case, and can
+# cause confusion (but NOT lost files) if profiles from multiple runs are
+# stored in the same directory.
+
+# This code is easier if we first switch to the profiling directory.
+
+if {!$p_peers} {
+    cd [parms dir]
+    foreach id [parms ids] target [parms profileAddresses] {
+        set idMap($target) $id
+    }
+    foreach file [glob pprof.*] {
+        if {[regexp {^pprof.([^:]+:\d+)(.*)(\d\d\d)(.*)} \
+                 $file match host a b c]} {
+            if {[info exists idMap($host)]} {
+                if {$p_tag} {
+                    set b [parms tag]
+                }
+                set reName pprof.$host$a$b$c
+                set newName pprof.$idMap($host)$a$b$c
+                if {![file exists $newName]} {
+                    if {$p_tag} {
+                        if {[catch {exec mv $file $reName} why]} {
+                            errorExit "Can't rename $file to $reName : $why"
+                        }
+                        if {[catch {exec ln -sf $reName $newName} code]} {
+                            errorExit \
+                                "Error linking $file to $newName : $code"
+                        }
+                        note {} "$newName -> $reName (from $file)"
+                    } else {
+                        if {[catch {exec ln -sf $file $newName} code]} {
+                            errorExit \
+                                "Error linking $file to $newName : $code"
+                        }
+                        note {} "$newName -> $file"
+                    }                        
+                }
+            }
+        }
+    }
+}

--- a/tools/busywork/bin/userModeNetwork
+++ b/tools/busywork/bin/userModeNetwork
@@ -98,10 +98,12 @@ Optional arguments, with defaults after the colon:
     NOT IMPLEMENTED. Currently, membersrvc logging levels must be controlled
     through the membersrvc.yaml file.
 
--profile | -noProfile : -noProfile
+-profile | -noProfile : -profile
 
-    If -profile is selected, then the profiling HTTP service of each peer is
-    started. Profiling the membersrvc server is currently not supported.
+    Since there is only trivial overhead to starting the profiling server
+    embedded in the peer, this server is started by default. Use -noProfile to
+    disable this if necessary.  Profiling the membersrvc server is currently
+    not supported.
 
 -stdio : Logging output goes to $BUSYWORK_HOME
 
@@ -143,7 +145,7 @@ proc pristine {} {
     catch {exec docker ps -a -q | xargs docker rm -f}
     
     note {} "    Removing all chaincode containers"
-    catch {exec docker images | egrep '^dev-|^<none>' |
+    catch {exec docker images | egrep '^dev-|^<none>' | \
         awk '{print $3}' | xargs docker rmi -f}
     
     # Clean out BUSYWORK_HOME. If this fails, we blindly assume that we need
@@ -181,7 +183,7 @@ set options {
     {key  -home                           parms(home)          {}           }
     {bool {-security -noSecurity}         parms(security)      0            }
     {enum {-noops -batch -classic -sieve} parms(consensus)     -batch       }
-    {bool {-profile -noProfile}           parms(profile)       0            }
+    {bool {-profile -noProfile}           parms(profile)       1            }
     {enum {-pristine -clean -dirty}       parms(clean)         -pristine}
     {key  -startupWait                    parms(startupWait)   10s}
     {key  -scriptLogging                  parms(scriptLogging) note   }
@@ -248,11 +250,11 @@ if {[parms security]} {
 
 
 # The following is a simple approach to creating a user-mode network.  Each
-# peer needs 4 ports: A gRPC port, a REST API port, an event-hub server port
-# and a profiling port.  We begin by creating 4 dummy servers for each
-# required peer, simply to reserve the dynamic TCP port numbers. As each
-# actual peer is started, we kill the dummy servers and bind the peer to the
-# now-free ports.
+# peer needs 5 ports: A gRPC port, a REST API port, an event-hub server port,
+# a CLI callback port and a profiling port.  We begin by creating dummy
+# servers for each required port, simply to reserve the dynamic TCP port
+# numbers. As each actual peer is started, we kill the dummy servers and bind
+# the peer to the now-free ports.
 
 # The membersrvc server is a bit simpler in that it only requires 1 port,
 # however for consistency we go ahead and allocate 4 ports for it as well.
@@ -264,7 +266,7 @@ if {[parms security]} {
 # Allocate/reserve TCP ports dynamically. Note that the fabric requires the
 # peers to be named "vp<n>". The membersrvc server does not have a name.
 
-set PORTS_PER_PEER 4
+set PORTS_PER_PEER 5
 
 set nServers [parms nPeers]
 if {[parms security]} {
@@ -323,7 +325,16 @@ set ::env(CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN) \
 # As we spin up the network we simulataneously create the log for the user as
 # well as the $BUSYWORK_HOME/network configuration file.
 
-note {} "Network Port Map:"
+note {} "Network Port and PID Map:"
+
+note {} "------------------------------------------------------------"
+note {} " PeerID |  gRPC  |  REST | Events |  CLI  | Profile |  PID "
+note {} "------------------------------------------------------------"
+
+proc networkTable {id grpc rest events cli profile pid} {
+    note {} [format "%7s |  %5s | %5s |  %5s | %5s |  %5s  | %5s" \
+                 $id $grpc $rest $events $cli $profile $pid]
+}
 
 set config [open $BUSYWORK_HOME/network w]
 
@@ -335,6 +346,7 @@ puts $config "    \"date\": \"[timestamp]\","
 puts $config "    \"createdBy\": \"userModeNetwork\","
 puts $config "    \"security\": \"[? [parms security] true false]\","
 puts $config "    \"consensus\": \"$CONSENSUS_TO_MODE([parms consensus])\","
+puts $config "    \"peerProfileServer\": \"[? [parms profile] true false]\","
 
 # Start membersrvc and wait until the service port is responding before
 # continuing. 
@@ -346,14 +358,13 @@ if {[parms security]} {
         set caStdout {}
         set caStderr {}
     } else {
-        set caStdout 1>$BUSYWORK_HOME/membersrvc/stdout
+        set caStdout >$BUSYWORK_HOME/membersrvc/stdout
         set caStderr 2>$BUSYWORK_HOME/membersrvc/stderr
     }
     
     # FABRIC BUG - membersrvc can only run on 50051
     #set service [first [third [first $caMap]]]
     set service {x 0.0.0.0 50051}
-    set profile [second [third [first $caMap]]]; # Note : not implemented
 
     set ::env(SERVER_PORT) :[port $service]
 
@@ -361,16 +372,12 @@ if {[parms security]} {
         close [first $clause]
     }
 
-    # FABRIC BUG - membersrvc can only run from $FABRIC/membersrvc
-    set pid [exec \
-                 sh -c "cd $FABRIC/membersrvc; ./membersrvc $caStdout $caStderr" &]
+    set pid [exec $FABRIC/membersrvc/membersrvc $caStdout $caStderr &]
 
-    note {} "---------------------------------------------------"
-    note {} " membersrvc : service = [port $service] : profile = [port $profile]"
-
+    networkTable CA [port $service] {} {} {} {} $pid
+    
     puts $config "    \"membersrvc\":"
     puts $config "        { \"service\": \"[server $service]\","
-    puts $config "          \"profile\": \"[server $profile]\","
     puts $config "          \"pid\": \"$pid\""
     puts $config "        },"
     
@@ -386,10 +393,6 @@ if {[parms security]} {
 
 # Now start the peers
 
-note {} "---------------------------------------------------"
-note {} "  N |  PeerID |  gRPC  |   REST | Events | Profile "
-note {} "---------------------------------------------------"
-
 puts $config "    \"peers\": \["
 
 foreach clause $peerMap {
@@ -402,14 +405,15 @@ foreach clause $peerMap {
         set peerStdout {}
         set peerStderr {}
     } else {
-        set peerStdout 1>$BUSYWORK_HOME/$peerID/stdout
+        set peerStdout >$BUSYWORK_HOME/$peerID/stdout
         set peerStderr 2>$BUSYWORK_HOME/$peerID/stderr
     }
 
     set grpc    [first $portMap]
     set rest    [second $portMap]
     set events  [third $portMap]
-    set profile [fourth $portMap]
+    set cli     [fourth $portMap]
+    set profile [fifth $portMap]
 
     set ::env(CORE_PEER_ID)                       $peerID
     set ::env(CORE_PEER_FILESYSTEMPATH)           $peerDatabase
@@ -417,6 +421,7 @@ foreach clause $peerMap {
     set ::env(CORE_PEER_LISTENADDRESS)            [server $grpc]
     set ::env(CORE_REST_ADDRESS)                  [server $rest]
     set ::env(CORE_PEER_VALIDATOR_EVENTS_ADDRESS) [server $events]
+    set ::env(CORE_CLI_ADDRESS)                   [server $cli]
     set ::env(CORE_PEER_PROFILE_LISTENADDRESS)    [server $profile]
             
     if {[parms nPeers] > 1} {
@@ -444,9 +449,8 @@ foreach clause $peerMap {
 
     set pid [exec $FABRIC/peer/peer node start $peerStdout $peerStderr &]
 
-    note {} [format "%3d | %7s |  %5s |  %5s |  %5s |  %5s" \
-                 $peerN $peerID \
-                 [port $grpc] [port $rest] [port $events] [port $profile]]
+    networkTable $peerID [port $grpc] [port $rest] [port $events] \
+        [port $cli] [port $profile] $pid
 
     if {$peerN != 0} {
         puts $config "        ,"
@@ -455,12 +459,13 @@ foreach clause $peerMap {
     puts $config "          \"grpc\": \"[server $grpc]\","
     puts $config "          \"rest\": \"[server $rest]\","
     puts $config "          \"events\": \"[server $events]\","
+    puts $config "          \"cli\": \"[server $cli]\","
     puts $config "          \"profile\": \"[server $profile]\","
     puts $config "          \"pid\": \"$pid\""
     puts $config "        }"
 }
 
-note {} "--------------------------------------------------"
+note {} "------------------------------------------------------------"
 
 puts $config "    \]"
 puts $config "}"

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -81,7 +81,7 @@ STRESS2 = ./driver \
 		-checkAgreement -dupCheck
 
 stress2b: 
-	@$(NETWORK) -peerLogging debug -batch 4
+	@$(NETWORK) -batch 4
 	@$(STRESS2)
 
 stress2c: 

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -81,7 +81,7 @@ STRESS2 = ./driver \
 		-checkAgreement -dupCheck
 
 stress2b: 
-	@$(NETWORK) -batch 4
+	@$(NETWORK) -peerLogging debug -batch 4
 	@$(STRESS2)
 
 stress2c: 

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -579,10 +579,11 @@ if {[parms deploy]} {
     foreach id [parms chaincodeIDs] {
         set peer [peerList next]
         set user [peerUser $peer]
-        set name [::fabric::deploy $peer $user $chaincode parms \
-                      [concat [list -id $id] [parms args]]]
+        set args [concat [list -id $id] [parms args]]
+        set name [::fabric::deploy $peer $user $chaincode parms $args]
         note {} "Deployed $id as $name"
-        exec echo "$name $chaincode" >> $BUSYWORK_HOME/chaincodes
+        set args [quote [concat parms $args]]
+        exec echo "$name $chaincode $args" >> $BUSYWORK_HOME/chaincodes
         lappend chaincodeNames $name
     }
     parms chaincodeNames $chaincodeNames

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -25,7 +25,7 @@ driver:
           - Drives a fixed number of transactions into the network
           - Chaincodes, arrays and peers to target are generated randomly
           - However, in the end all arrays get the same count
-    o Finally, validate the final state of all counters
+    o Finally, validates the final state of all counters
 
 By default, the peer network is defined by the $BUSYWORK_HOME/network file.
 However, if one or more peers are provided on the command line, those explicit
@@ -41,6 +41,13 @@ Optional parameters. Default values are given after the colon:
 -h | -help | --help : None
     
     Print this usage message and exit normally.
+
+-home <busywork_home> : See below
+
+    This argument can be used to name a non-default BUSYWORK_HOME directory.
+    network on the command line. If not defined here then BUSYWORK_HOME is
+    taken from the environmnent, or if not present there, defaults to
+    ~/.busywork.
 
 -targetPeers <n> : All
     
@@ -211,7 +218,31 @@ Optional parameters. Default values are given after the colon:
     the client, or from the consistency check. Even with -force, the script
     will fail with an abnormal exit code if any errors were encountered.
 
--checkAgreement <extraAargs> : Extra arguments (possible empty) for checkAgreement
+-watchdogPoll <duration> : 5s
+
+    By default a busywork 'networkStatus' process is started and runs in the
+    background to monitor the network every 5s and kill the driver if network
+    nodes die. If the -watchdogPoll option is negative, or if -force is
+    specified, or if explicit peers are specified, then the watchdog process
+    is not started. (The final restriction could be removed with some work on
+    the 'networkStatus' script.)
+
+-pprofClient <args> : No profiling
+
+    If the -pprofClient option is provided, then a busywork 'pprofClient'
+    process will be started immediately after the driver threads are started,
+    where the <args> are passed to the pprofClient process. See the
+    pprofClient script for details on parameters to pprofClient. A typical use
+    might look something like
+
+        -pprofClient "-wait 5 0 profile?seconds=60"
+
+    which waits 5 seconds for the network to "warm up" before starting the
+    profile, then collects a 60-second CPU profile of peer 0 into the
+    $BUSYWORK_HOME directory.
+
+-checkAgreement <extraAargs> : Extra arguments (possibly empty) for
+                               checkAgreement
 
     If selected and there are at least 2 peers, the ../bin/checkAgreement
     procedure will be run at the end of the run to ensure that all peers agree
@@ -261,6 +292,7 @@ setLoggingPrefix driver
 
 set options {
     {enum    {-h -help --help}     parms(help)              0 p_help}
+    {key     -home                 parms(home)             {}}
     {key     -targetPeers          parms(targetPeers)       0 p_targetPeers}
     {bool    {-security -noSecurity} parms(security)        0}
     {key     -targetUsers          parms(targetUsers)       0 p_targetUsers}
@@ -284,6 +316,8 @@ set options {
     {key     -finalWait            parms(finalWait)         10s}
     {bool    {-keepLog -noKeepLog} parms(keepLog)           0}
     {bool    {-force -noForce}     parms(force)             0}
+    {key     -watchdogPoll         parms(watchdogPoll)      5s}
+    {key     -pprofClient          parms(pprofClient)       {} p_pprofClient}
     {key     -checkAgreement       parms(checkAgreementArgs) {} p_checkAgreement}
     {key     -retry                parms(retry)             0}
     {key     -args                 parms(args)              {}}
@@ -303,6 +337,9 @@ parms client driver
 
 note {} "$argv0 $argv"
 
+set BUSYWORK_HOME [busywork::home [parms home]]
+
+
 # Start log timestamping if selected. Do quick consistency checks.
 
 setLoggingTimestamp [parms timestamp]
@@ -320,7 +357,9 @@ if {[parms interlock] && [parms finalInterlock]} {
 # in the network configuration.
 
 if {[null [parms explicitPeers]]} {
-    busywork::networkToArray ::parms network.
+    if {[catch {busywork::networkToArray ::parms network.} msg]} {
+        errorExit $msg
+    }
     parms originalPeers [parms network.peer.restAddresses]
     parms security [? {[parms network.security] eq "true"} 1 0]
 } else {
@@ -416,7 +455,8 @@ parms arraySizes $sizes
 # Setup
 ############################################################################
 
-# Start an fabricLogger process, logging to a temporary file.
+# Start a fabricLogger process, logging to a temporary file. Start a polling
+# networkStatus process with a killer-callback (under most conditions).
 
 set logger [::busywork::Logger new \
                 -peers "[parms loggingPeers]" \
@@ -424,7 +464,20 @@ set logger [::busywork::Logger new \
                 -retry [parms retry] \
                 [? [parms timestamp] -timestamp -noTimestamp] \
                 [? [parms force] -noKillOnError -killOnError]]
-                
+
+parms watchdogPoll [durationToMs [parms watchdogPoll]]
+if {[null [parms explicitPeers]] &&
+    ![parms force] && ([parms watchdogPoll] >= 0)} {
+    if {[catch \
+             {exec [busywork::bin]/networkStatus \
+                  -poll [parms watchdogPoll]ms -quiet \
+                  -onError "kill SIGINT [pid]" &} \
+             pid]} {
+        errorExit "Error starting networkStatus : $pid"
+    }
+    killAtExit SIGINT $pid
+}
+
 
 ############################################################################
 # Security
@@ -529,6 +582,7 @@ if {[parms deploy]} {
         set name [::fabric::deploy $peer $user $chaincode parms \
                       [concat [list -id $id] [parms args]]]
         note {} "Deployed $id as $name"
+        exec echo "$name $chaincode" >> $BUSYWORK_HOME/chaincodes
         lappend chaincodeNames $name
     }
     parms chaincodeNames $chaincodeNames
@@ -563,21 +617,22 @@ if {[parms deploy]} {
 
 } else {
 
-    note {} "-noDeploy mode : Getting chaincode names from the Blockchain"
-    set peer [lindex [parms peers] 0]
-    if {[catch {eval exec [parms fabricLogger] [parms loggingPeers] | grep ^d} data]} {
-        errorExit \
-            "Getting chaincode names from the blockchain failed " \
-            "for some reason; Aborting"
+    note {} "-noDeploy mode : Getting chaincode names $BUSYWORK_HOME/chaincodes"
+
+    # Note: The file ends in a newline, hence splitting on \n yields a final
+    # empty string that we eliminate. If this execution fails for any reason
+    # then "lines" contains an error string.
+    if {[catch \
+             {butlast [split [read [open $BUSYWORK_HOME/chaincodes r]] \n]} \
+             lines]} {
+        errorExit "Reading $BUSYWORK_HOME/chaincodes failed : $lines"
     }
-    set lines [split $data \n]
     if {[llength $lines] != [llength [parms chaincodeIDs]]} {
         errorExit \
             "-noDeploy mode : We found [llength $lines] chaincode deployments " \
-            "in the Blockchain, but were expecting " \
-            [llength [parms chaincodeIDs]]
+            "registered but were expecting [llength [parms chaincodeIDs]]"
     }
-    parms chaincodeNames [mapeach line $lines {return [lindex $line 1]}]
+    parms chaincodeNames [mapeach line $lines {return [lindex $line 0]}]
 }
 
 
@@ -755,6 +810,17 @@ for {set i 0} {$i < [parms clients]} {incr i} {
     }
 }
 
+# Start a 'pprofClient' if requested. 
+
+if {$p_pprofClient} {
+    if {[catch \
+             {eval exec [busywork::bin]/pprofClient [parms pprofClient] &} \
+             pid]} {
+        errorExit "Starting pprofClient failed : $pid"
+    }
+    parms pprofClientPID $pid
+}
+
 # Note that the 'errors' variable is initialized here. We carry on in the
 # event of errors until the final agreement check.
 
@@ -766,6 +832,15 @@ if {!$errors} {
     set rate [format %.2f [expr {$totalTransactions / $seconds}]]
     note {} "Transaction rate : $rate per second ($totalTransactions / $seconds)"
 }
+
+if {$p_pprofClient} {
+    if {[null [wait -nohang [parms pprofClientPID]]]} {
+        warn {} \
+            "The pprofClient process (PID [parms pprofClientPID]) is " \
+            " still running. The profile may be distorted by inactivity."
+    }
+}
+
 
 # Finally, check the results for correctness. For the most accurate completed
 # transaction rates you need to -interlock, as it is likely that not all

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -163,6 +163,13 @@ Optional parameters. Default values are given after the colon:
     and all create transactions are generated as quickly as possible by the
     base driver.
 
+-txDelay <duration> : 0
+-peerDelay <duration> : 0
+-netDelay <duration> : 0
+
+    These are delays added after each transaction (-txDelay), each burst to a
+    peer (-peerDelay) and each burst to the network (-netDelay).
+
 -interlock | -noInterlock : -noInterlock
 
     If -interlock is specified, then each client waits after each network
@@ -309,6 +316,9 @@ set options {
     {key     -transactions         parms(transactions)      1}
     {key     -peerBurst            parms(peerBurst)         1}
     {key     -netBurst             parms(netBurst)          1}
+    {key     -txDelay              parms(txDelay)           0}
+    {key     -peerDelay            parms(peerDelay)         0}
+    {key     -netDelay             parms(netDelay)          0}
     {bool    {-interlock -noInterlock} parms(interlock)     0}
     {bool    -finalInterlock       parms(finalInterlock)    0}
     {key     -interlockTimeout     parms(interlockTimeout)  60s}
@@ -450,6 +460,12 @@ if {[string is integer [parms size]]} {
 }
 parms arraySizes $sizes
 
+
+# Normalize delays to milliseconds
+
+parms txDelay [durationToMs [parms txDelay]]
+parms peerDelay [durationToMs [parms peerDelay]]
+parms netDelay [durationToMs [parms netDelay]]
 
 ############################################################################
 # Setup
@@ -779,7 +795,16 @@ proc clientRoutine {i_logger} {
                          $peer [peerUser $peer] \
                          $chaincodeName increment $arrayName \
                          [parms retry]]
+                if {[parms txDelay]} {
+                    after [parms txDelay]
+                }
             }
+            if {[parms peerDelay]} {
+                after [parms peerDelay]
+            }
+        }
+        if {[parms netDelay]} {
+            after [parms netDelay]
         }
     }
 }

--- a/tools/busywork/tcl/io.tcl
+++ b/tools/busywork/tcl/io.tcl
@@ -83,7 +83,6 @@ proc errorExit {args} {
     if {[null $args]} {
         err err Aborting
     } else {
-        err err "Aborting on error described below:"
         eval err err $args
     }
     exit 1
@@ -297,3 +296,29 @@ oo::class create NonblockingGets {
         return $d_line
     }
 }
+
+
+############################################################################
+# httpTokenDump i_token {i_level err} {i_module {}}
+# httpErrorExit i_token
+
+# It can be helpful for error diagnosis to dump the entire contents of an HTTP
+# token when an error is encountered. That's what these routines do.
+
+proc httpTokenDump {i_token {i_level err} {i_module {}}} {
+
+    package require http
+
+    $i_level $i_module "Full HTTP token dump"
+    $i_level $i_module "HTTP 'ncode' = '[http::ncode $i_token]'"
+    foreach {k v} [array get $i_token] {
+        $i_level $i_module "    $k $v"
+    }
+}
+                    
+proc httpErrorExit {i_token} {
+
+    httpTokenDump $i_token
+    errorExit
+}
+

--- a/tools/busywork/tcl/io.tcl
+++ b/tools/busywork/tcl/io.tcl
@@ -322,3 +322,19 @@ proc httpErrorExit {i_token} {
     errorExit
 }
 
+
+############################################################################
+# quote i_l
+
+# 'quote' wraps each element of i_l in "" and returns the new list *as a
+# string*. 
+
+proc quote {i_l} {
+    set ans ""
+    set space ""
+    foreach x $i_l {
+        set ans "$ans$space\"$x\""
+        set space " "
+    }
+    return $ans
+}

--- a/tools/busywork/tcl/lists.tcl
+++ b/tools/busywork/tcl/lists.tcl
@@ -309,7 +309,7 @@ proc range {args} {
 proc enumerate {i_spec} {
 
     if {[llength $i_spec] != 1} {
-        error "Non-atomic specifcification '$i_spec'"
+        error "Non-atomic specification '$i_spec'"
     }
     
     set specs [split $i_spec ,]
@@ -324,6 +324,9 @@ proc enumerate {i_spec} {
                 [concat $enumeration [range $min [expr {$max + 1}]]]
     
         } else {
+            if {![string is integer $spec]} {
+                error "Expecting an integer : $spec"
+            }
             lappend enumeration $spec
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This changeset only touches files in fabric/tools/busywork

This changeset includes the following major features:
1. Added the 'networkStatus' script that reports busywork network
   status, and can also be used as a watchdog. The counters/driver
   now supports this script.
2. Added the 'pprofClient' script that interfaces to the
   profiling server in the peer and can also be used as a
   watchdog. The counters/driver now supports this script.

Minor updates:

fabricLogger has better error reporting
userModeNetwork starts the profiling server by default now (it should not hurt anything to do this normally).
Added the CLI port to userModeNetwork : Note, I've never tested CLI with user-mode networks as there has never been a need for it.
Doc. updates
Varius minor fixes
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

See above.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

I've been testing all of this stuff over the last few days as I have been developing it, esp. to collect profiles of peer networks.

In the very near future I hope that a few busywork tests will become part of the CI testing. For the moment I don't have tests for busywork itself, I'll have to think about what that would mean.

No Go code was changed.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [?] Either no new tests are required by this change, OR I added new tests
- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
