### PR TITLE
Begin removing legacy PBFT methods

### DIFF
--- a/consensus/obcpbft/deduplicator.go
+++ b/consensus/obcpbft/deduplicator.go
@@ -1,20 +1,17 @@
 /*
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+Copyright IBM Corp. 2016 All Rights Reserved.
 
-  http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package obcpbft

--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -87,16 +87,21 @@ func (em *eventManagerImpl) queue() chan<- interface{} {
 	return em.events
 }
 
-// inject can only safely be called by the eventManager thread itself, it skips the queue
-func (em *eventManagerImpl) inject(event interface{}) {
+// sendEvent performs the event loop on a receiver to completion
+func sendEvent(receiver eventReceiver, event interface{}) {
 	next := event
 	for {
 		// If an event returns something non-nil, then process it as a new event
-		next = em.receiver.processEvent(next)
+		next = receiver.processEvent(next)
 		if next == nil {
 			break
 		}
 	}
+}
+
+// inject can only safely be called by the eventManager thread itself, it skips the queue
+func (em *eventManagerImpl) inject(event interface{}) {
+	sendEvent(em.receiver, event)
 }
 
 // eventLoop is where the event thread loops, delivering events

--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -290,3 +290,6 @@ type complaintEvent custodyInfo
 
 // batchExecEvent is sent when a batch execution should take place
 type batchExecEvent execInfo
+
+// returnRequestEvent is sent by pbft when we are forwarded a request
+type returnRequestEvent *Request

--- a/consensus/obcpbft/events_test.go
+++ b/consensus/obcpbft/events_test.go
@@ -22,26 +22,20 @@ import (
 )
 
 // mockEventID is equivalent to MIN_INT to prevent collisions
-const mockEventID eventType = eventType(^0)
-
 type mockEvent struct{}
 
-func (mev *mockEvent) eventType() eventType {
-	return mockEventID
-}
-
 type mockReceiver struct {
-	processEventImpl func(event event) event
+	processEventImpl func(event interface{}) interface{}
 }
 
-func (mr *mockReceiver) processEvent(event event) event {
+func (mr *mockReceiver) processEvent(event interface{}) interface{} {
 	if mr.processEventImpl != nil {
 		return mr.processEventImpl(event)
 	}
 	return nil
 }
 
-func newMockManager(processEvent func(event event) event) eventManager {
+func newMockManager(processEvent func(event interface{}) interface{}) eventManager {
 	return newEventManagerImpl(&mockReceiver{
 		processEventImpl: processEvent,
 	})
@@ -49,8 +43,8 @@ func newMockManager(processEvent func(event event) event) eventManager {
 
 // Starts an event timer, waits for the event to be delivered
 func TestEventTimerStart(t *testing.T) {
-	events := make(chan event)
-	mr := newMockManager(func(event event) event {
+	events := make(chan interface{})
+	mr := newMockManager(func(event interface{}) interface{} {
 		events <- event
 		return nil
 	})
@@ -73,8 +67,8 @@ func TestEventTimerStart(t *testing.T) {
 
 // Starts an event timer, resets it twice, expects second output
 func TestEventTimerHardReset(t *testing.T) {
-	events := make(chan event)
-	mr := newMockManager(func(event event) event {
+	events := make(chan interface{})
+	mr := newMockManager(func(event interface{}) interface{} {
 		events <- event
 		return nil
 	})
@@ -100,8 +94,8 @@ func TestEventTimerHardReset(t *testing.T) {
 
 // Starts an event timer, soft resets it twice, expects first output
 func TestEventTimerSoftReset(t *testing.T) {
-	events := make(chan event)
-	mr := newMockManager(func(event event) event {
+	events := make(chan interface{})
+	mr := newMockManager(func(event interface{}) interface{} {
 		events <- event
 		return nil
 	})
@@ -127,8 +121,8 @@ func TestEventTimerSoftReset(t *testing.T) {
 
 // Starts an event timer, then stops it before delivery is possible, should not receive event
 func TestEventTimerStop(t *testing.T) {
-	events := make(chan event)
-	mr := newMockManager(func(event event) event {
+	events := make(chan interface{})
+	mr := newMockManager(func(event interface{}) interface{} {
 		events <- event
 		return nil
 	})
@@ -154,7 +148,7 @@ func TestEventTimerStop(t *testing.T) {
 func TestEventManagerLoop(t *testing.T) {
 	success := make(chan struct{})
 	m2 := &mockEvent{}
-	mr := newMockManager(func(event event) event {
+	mr := newMockManager(func(event interface{}) interface{} {
 		if event != m2 {
 			return m2
 		}

--- a/consensus/obcpbft/external.go
+++ b/consensus/obcpbft/external.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import (
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+// --------------------------------------------------------------
+//
+// external contains all of the functions which
+// are intended to be called from outside of the obcpbft package
+//
+// --------------------------------------------------------------
+
+type externalEventReceiver struct {
+	manager eventManager
+}
+
+// RecvMsg is called by the stack when a new message is received
+func (eer *externalEventReceiver) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
+	eer.manager.queue() <- batchMessageEvent{
+		msg:    ocMsg,
+		sender: senderHandle,
+	}
+	return nil
+}
+
+// StateUpdated is a signal from the stack that it has fast-forwarded its state
+func (eer *externalEventReceiver) StateUpdated(seqNo uint64, id []byte) {
+	eer.manager.queue() <- stateUpdatedEvent{
+		seqNo: seqNo,
+		id:    id,
+	}
+}
+
+// StateUpdating is a signal from the stack that state transfer has started
+func (eer *externalEventReceiver) StateUpdating(seqNo uint64, id []byte) {
+	eer.manager.queue() <- stateUpdatingEvent{
+		seqNo: seqNo,
+		id:    id,
+	}
+}

--- a/consensus/obcpbft/fuzz_test.go
+++ b/consensus/obcpbft/fuzz_test.go
@@ -59,9 +59,11 @@ func TestFuzz(t *testing.T) {
 
 	mock := newFuzzMock()
 	primary := newPbftCore(0, loadConfig(), mock)
+	primary.manager.start()
 	defer primary.close()
 	mock = newFuzzMock()
 	backup := newPbftCore(1, loadConfig(), mock)
+	backup.manager.start()
 	defer backup.close()
 
 	f := fuzz.New()

--- a/consensus/obcpbft/fuzz_test.go
+++ b/consensus/obcpbft/fuzz_test.go
@@ -93,8 +93,8 @@ func TestFuzz(t *testing.T) {
 			senderID = nv.ReplicaId
 		}
 
-		primary.recvMsgSync(msg, senderID)
-		backup.recvMsgSync(msg, senderID)
+		primary.manager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
+		backup.manager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
 	}
 
 	logging.Reset()
@@ -160,7 +160,7 @@ func TestMinimalFuzz(t *testing.T) {
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
 		for _, ep := range net.endpoints {
-			ep.(*pbftEndpoint).pbft.recvMsgSync(msg, msg.GetRequest().ReplicaId)
+			ep.(*pbftEndpoint).pbft.manager.queue() <- &pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 		}
 		if err != nil {
 			t.Fatalf("Request failed: %s", err)

--- a/consensus/obcpbft/legacyshim.go
+++ b/consensus/obcpbft/legacyshim.go
@@ -1,0 +1,89 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+// --------------------------------------------------------
+//
+// legacyShim is a temporary measure to allow the non-batch
+// plugins to continue to function until they are completely
+// deprecated
+//
+// --------------------------------------------------------
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+)
+
+type legacyShim struct {
+	manager eventManager
+}
+
+// stateUpdated is an event telling us that the application fast-forwarded its state
+func (instance *pbftCore) stateUpdated(seqNo uint64, id []byte) {
+	logger.Debug("Replica %d queueing message that it has caught up via state transfer", instance.id)
+	instance.manager.queue() <- stateUpdatedEvent{
+		seqNo: seqNo,
+		id:    id,
+	}
+}
+
+// stateUpdating is an event telling us that the application is fast-forwarding its state
+func (instance *pbftCore) stateUpdating(seqNo uint64, id []byte) {
+	logger.Debug("Replica %d queueing message that state transfer has been initiated", instance.id)
+	instance.manager.queue() <- stateUpdatingEvent{
+		seqNo: seqNo,
+		id:    id,
+	}
+}
+
+// handle new consensus requests
+func (instance *pbftCore) request(msgPayload []byte, senderID uint64) error {
+	msg := &Message{&Message_Request{&Request{Payload: msgPayload,
+		ReplicaId: senderID}}}
+	instance.manager.queue() <- pbftMessageEvent{
+		sender: senderID,
+		msg:    msg,
+	}
+	return nil
+}
+
+// handle internal consensus messages
+func (instance *pbftCore) receive(msgPayload []byte, senderID uint64) error {
+	msg := &Message{}
+	err := proto.Unmarshal(msgPayload, msg)
+	if err != nil {
+		return fmt.Errorf("Error unpacking payload from message: %s", err)
+	}
+
+	instance.manager.queue() <- pbftMessageEvent{
+		msg:    msg,
+		sender: senderID,
+	}
+
+	return nil
+}
+
+// TODO, this should not return an error
+func (instance *pbftCore) recvMsgSync(msg *Message, senderID uint64) (err error) {
+	instance.manager.queue() <- pbftMessageEvent{
+		msg:    msg,
+		sender: senderID,
+	}
+	return nil
+}

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -40,7 +40,7 @@ func (ce *consumerEndpoint) stop() {
 func (ce *consumerEndpoint) isBusy() bool {
 	pbft := ce.consumer.getPBFTCore()
 	if pbft.timerActive || pbft.skipInProgress || pbft.currentExec != nil {
-		ce.net.debugMsg("Reporting busy because of timer or skipInProgress or currentExec\n")
+		ce.net.debugMsg("Reporting busy because of timer (%v) or skipInProgress (%v) or currentExec (%v)\n", pbft.timerActive, pbft.skipInProgress, pbft.currentExec)
 		return true
 	}
 

--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -95,6 +95,23 @@ func createOcMsgWithChainTx(iter int64) (msg *pb.Message) {
 	return
 }
 
+// Create a message of type `Message_CHAIN_TRANSACTION`
+func createPbftRequestWithChainTx(iter int64, replica uint64) (msg *Request) {
+	txTime := &gp.Timestamp{Seconds: iter, Nanos: 0}
+	tx := &pb.Transaction{Type: pb.Transaction_CHAINCODE_DEPLOY,
+		Timestamp: txTime,
+		Payload:   []byte(fmt.Sprint(iter)),
+	}
+	txPacked, _ := proto.Marshal(tx)
+
+	msg = &Request{
+		Timestamp: txTime,
+		ReplicaId: replica,
+		Payload:   txPacked,
+	}
+	return
+}
+
 func generateBroadcaster(validatorCount int) (requestBroadcaster int) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	rndm := rand.New(seed)

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -31,6 +31,7 @@ import (
 type obcBatch struct {
 	obcGeneric
 	externalEventReceiver
+	pbft *pbftCore
 
 	batchSize        int
 	batchStore       []*Request

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -33,16 +33,13 @@ type obcBatch struct {
 
 	batchSize        int
 	batchStore       []*Request
-	batchTimer       *time.Timer
+	batchTimer       eventTimer
 	batchTimerActive bool
 	batchTimeout     time.Duration
 	inViewChange     bool
 
-	incomingChan     chan *batchMessage // Queues messages for processing by main thread
-	custodyTimerChan chan custodyInfo   // Queues complaints
-	execChan         chan *execInfo     // Signals an execution event
-	viewChanged      chan struct{}      // Signals that a view change has occurred
-	idleChan         chan struct{}      // Used in unit testing to check for idleness
+	incomingChan chan *batchMessage // Queues messages for processing by main thread
+	idleChan     chan struct{}      // Idle channel, to be removed
 
 	complainer   *complainer
 	deduplicator *deduplicator
@@ -78,6 +75,11 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	logger.Debug("Replica %d obtaining startup information", id)
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager = newEventManagerImpl(op) // TODO, this is hacky, eventually rip it out
+	etf := newEventTimerFactoryImpl(op.pbft.manager)
+	op.pbft.newViewTimer.halt()
+	op.pbft.newViewTimer = etf.createTimer()
+	op.pbft.manager.start()
 
 	op.batchSize = config.GetInt("general.batchSize")
 	op.batchStore = nil
@@ -87,20 +89,15 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	}
 
 	op.incomingChan = make(chan *batchMessage)
-	op.custodyTimerChan = make(chan custodyInfo)
-	op.execChan = make(chan *execInfo)
 
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()
 
-	// create non-running timer
-	op.batchTimer = time.NewTimer(100 * time.Hour) // XXX ugly
-	op.batchTimer.Stop()
+	op.batchTimer = etf.createTimer()
 
 	op.idleChan = make(chan struct{})
-	op.viewChanged = make(chan struct{})
+	close(op.idleChan) // TODO remove eventually
 
-	go op.main()
 	return op
 }
 
@@ -108,7 +105,7 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 // the stack. New transaction requests are broadcast to all replicas,
 // so that the current primary will receive the request.
 func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
-	op.incomingChan <- &batchMessage{
+	op.pbft.manager.queue() <- batchMessageEvent{
 		msg:    ocMsg,
 		sender: senderHandle,
 	}
@@ -118,14 +115,14 @@ func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
 
 // Complain is necessary to implement complaintHandler
 func (op *obcBatch) Complain(hash string, req *Request, primaryFail bool) {
-	logger.Debug("Replica %d processing complaint from custodian", op.pbft.id)
-	op.custodyTimerChan <- custodyInfo{hash, req, primaryFail}
+	c := complaintEvent{hash, req, primaryFail}
+	op.pbft.manager.queue() <- c
 }
 
 // Close tells us to release resources we are holding
 func (op *obcBatch) Close() {
 	op.complainer.Stop()
-	op.batchTimer.Reset(0)
+	op.batchTimer.stop()
 	op.pbft.close()
 }
 
@@ -202,7 +199,7 @@ func (op *obcBatch) validate(txRaw []byte) error {
 
 // execute an opaque request which corresponds to an OBC Transaction
 func (op *obcBatch) execute(seqNo uint64, raw []byte) {
-	op.execChan <- &execInfo{
+	op.pbft.manager.queue() <- batchExecEvent{
 		seqNo: seqNo,
 		raw:   raw,
 	}
@@ -245,21 +242,11 @@ func (op *obcBatch) executeImpl(seqNo uint64, raw []byte) {
 	_ = result // XXX what to do with the result?
 	_, err = op.stack.CommitTxBatch(id, meta)
 
-	op.pbft.execDone()
+	op.pbft.execDoneSync()
 }
 
-// signal when a view-change happened, this is the PBFT thread, don't modify internal state and give it back!
 func (op *obcBatch) viewChange(curView uint64) {
-
-	// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
-	// in a different batch, but PBFT core can't see through the opaque structure to see this
-	// so, on view change, we rely on the fact that the complaint service will resubmit requests
-	// and instead zero the outstandingReqs map ourselves
-	op.pbft.outstandingReqs = make(map[string]*Request)
-
-	logger.Debug("Replica %d PBFT view change thread attempting to signal batch thread", op.pbft.id)
-
-	go func() { op.viewChanged <- struct{}{} }()
+	// TODO, remove
 }
 
 // =============================================================================
@@ -306,7 +293,7 @@ func (op *obcBatch) sendBatch() error {
 
 	// process internally
 	logger.Info("Creating batch with %d requests", len(reqBlock.Requests))
-	op.pbft.request(reqsPacked, op.pbft.id)
+	op.pbft.requestSync(reqsPacked, op.pbft.id)
 
 	return nil
 }
@@ -358,7 +345,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 		if err != nil {
 			panic("Cannot map sender's PeerID to a valid replica ID")
 		}
-		op.pbft.receive(pbftMsg, senderID)
+		op.pbft.receiveSync(pbftMsg, senderID)
 	} else if complaint := batchMsg.GetComplaint(); complaint != nil {
 		if op.pbft.primary(op.pbft.view) == op.pbft.id && op.pbft.activeView {
 			return op.leaderProcReq(complaint)
@@ -388,7 +375,7 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 // this request raced with a later one and lost, then we need to
 // repackage this request's payload into a new request and resubmit
 // it.
-func (op *obcBatch) resubmitStaleRequest(c custodyInfo) {
+func (op *obcBatch) resubmitStaleRequest(c complaintEvent) {
 	oldReq := c.req.(*Request)
 
 	if !op.complainer.InCustody(oldReq) {
@@ -407,83 +394,78 @@ func (op *obcBatch) resubmitStaleRequest(c custodyInfo) {
 }
 
 // allow the primary to send a batch when the timer expires
-func (op *obcBatch) main() {
-	for {
-		logger.Debug("Replica %d batch main thread looping", op.pbft.id)
-		select {
-		case <-op.pbft.closed:
-			close(op.idleChan)
-			return
-		case ocMsg := <-op.incomingChan:
-			if err := op.processMessage(ocMsg.msg, ocMsg.sender); nil != err {
-				logger.Error("Error processing message: %v", err)
-			}
-		case <-op.batchTimer.C:
-			logger.Info("Replica %d batch timer expired", op.pbft.id)
-			if op.pbft.activeView && (len(op.batchStore) > 0) {
-				op.sendBatch()
-			}
-		case <-op.viewChanged:
-			logger.Debug("Replica %d batch thread recognizing new view", op.pbft.id)
-			op.inViewChange = false
-			if op.batchTimerActive {
-				op.stopBatchTimer()
-			}
-
-			op.complainer.Restart()
-			for _, pair := range op.complainer.CustodyElements() {
-				logger.Info("Replica %d resubmitting request under custody: %s", op.pbft.id, pair.Hash)
-				op.submitToLeader(pair.Request)
-			}
-		case c := <-op.custodyTimerChan:
-			if !op.deduplicator.IsNew(c.req.(*Request)) {
-				op.resubmitStaleRequest(c)
-				continue
-			}
-
-			if !c.complaint {
-				logger.Warning("Batch replica %d custody expired, complaining: %s", op.pbft.id, c.hash)
-				op.broadcastMsg(&BatchMessage{&BatchMessage_Complaint{c.req.(*Request)}})
-			} else {
-				if !op.inViewChange && op.pbft.activeView {
-					logger.Debug("Batch replica %d complaint timeout expired for %s", op.pbft.id, c.hash)
-					op.inViewChange = true
-					op.pbft.injectChan <- func() { op.pbft.sendViewChange() }
-				} else {
-					logger.Debug("Batch replica %d complaint timeout expired for %s while in view change", op.pbft.id, c.hash)
-				}
-			}
-		case execInfo := <-op.execChan:
-			op.executeImpl(execInfo.seqNo, execInfo.raw)
-		case op.idleChan <- struct{}{}:
-			// Only used to detect thread idleness during unit tests
+func (op *obcBatch) processEvent(event event) event {
+	logger.Debug("Replica %d batch main thread looping", op.pbft.id)
+	switch event.eventType() {
+	case batchMessageEventID:
+		ocMsg := event.(batchMessageEvent)
+		if err := op.processMessage(ocMsg.msg, ocMsg.sender); nil != err {
+			logger.Error("Error processing message: %v", err)
 		}
+		return nil
+	case batchTimerEventID:
+		logger.Info("Replica %d batch timer expired", op.pbft.id)
+		if op.pbft.activeView && (len(op.batchStore) > 0) {
+			op.sendBatch()
+		}
+	case viewChangedEventID:
+		// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
+		// in a different batch, but PBFT core can't see through the opaque structure to see this
+		// so, on view change, we rely on the fact that the complaint service will resubmit requests
+		// and instead zero the outstandingReqs map ourselves
+		op.pbft.outstandingReqs = make(map[string]*Request)
+
+		logger.Debug("Replica %d batch thread recognizing new view", op.pbft.id)
+		op.inViewChange = false
+		if op.batchTimerActive {
+			op.stopBatchTimer()
+		}
+
+		op.complainer.Restart()
+		for _, pair := range op.complainer.CustodyElements() {
+			logger.Info("Replica %d resubmitting request under custody: %s", op.pbft.id, pair.Hash)
+			op.submitToLeader(pair.Request)
+		}
+	case batchExecEventID:
+		execInfo := event.(batchExecEvent)
+		op.executeImpl(execInfo.seqNo, execInfo.raw)
+	case complaintEventID:
+		c := event.(complaintEvent)
+		logger.Debug("Replica %d processing complaint from custodian", op.pbft.id)
+		if !op.deduplicator.IsNew(c.req.(*Request)) {
+			op.resubmitStaleRequest(c)
+			break
+		}
+
+		if !c.complaint {
+			logger.Warning("Batch replica %d custody expired, complaining: %s", op.pbft.id, c.hash)
+			op.broadcastMsg(&BatchMessage{&BatchMessage_Complaint{c.req.(*Request)}})
+		} else {
+			if !op.inViewChange && op.pbft.activeView {
+				logger.Debug("Batch replica %d complaint timeout expired for %s", op.pbft.id, c.hash)
+				op.inViewChange = true
+				op.pbft.sendViewChange()
+			} else {
+				logger.Debug("Batch replica %d complaint timeout expired for %s while in view change", op.pbft.id, c.hash)
+			}
+		}
+	default:
+		return op.pbft.processEvent(event)
 	}
+
+	return nil
 }
 
 func (op *obcBatch) startBatchTimer() {
-	op.batchTimer.Reset(op.batchTimeout)
+	op.batchTimer.reset(op.batchTimeout, batchTimerEvent{})
 	logger.Debug("Replica %d started the batch timer", op.pbft.id)
 	op.batchTimerActive = true
 }
 
 func (op *obcBatch) stopBatchTimer() {
-	op.batchTimer.Stop()
+	op.batchTimer.stop()
 	logger.Debug("Replica %d stopped the batch timer", op.pbft.id)
 	op.batchTimerActive = false
-	select {
-	case <-op.pbft.closed:
-		return
-	default:
-	}
-loopBatch:
-	for {
-		select {
-		case <-op.batchTimer.C:
-		default:
-			break loopBatch
-		}
-	}
 }
 
 // Wraps a payload into a batch message, packs it and wraps it into

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -30,6 +30,7 @@ import (
 
 type obcBatch struct {
 	obcGeneric
+	externalEventReceiver
 
 	batchSize        int
 	batchStore       []*Request
@@ -80,6 +81,7 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	op.pbft.newViewTimer.halt()
 	op.pbft.newViewTimer = etf.createTimer()
 	op.pbft.manager.start()
+	op.externalEventReceiver.manager = op.pbft.manager
 
 	op.batchSize = config.GetInt("general.batchSize")
 	op.batchStore = nil
@@ -99,18 +101,6 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	close(op.idleChan) // TODO remove eventually
 
 	return op
-}
-
-// RecvMsg receives both CHAIN_TRANSACTION and CONSENSUS messages from
-// the stack. New transaction requests are broadcast to all replicas,
-// so that the current primary will receive the request.
-func (op *obcBatch) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
-	op.pbft.manager.queue() <- batchMessageEvent{
-		msg:    ocMsg,
-		sender: senderHandle,
-	}
-
-	return nil
 }
 
 // Complain is necessary to implement complaintHandler

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -186,14 +186,13 @@ func TestBatchStaleCustody(t *testing.T) {
 	req1 := createOcMsgWithChainTx(1)
 	op.RecvMsg(req1, &pb.PeerID{})
 	op.RecvMsg(createOcMsgWithChainTx(2), &pb.PeerID{})
-	<-op.idleChannel()
+	op.pbft.manager.queue() <- nil
 	op.pbft.currentExec = new(uint64) // so that pbft.execDone doesn't get unhappy
 	*op.pbft.currentExec = 1
 	rblock2raw, _ := proto.Marshal(&RequestBlock{[]*Request{reqs[1]}})
 	op.executeImpl(1, rblock2raw)
 	time.Sleep(500 * time.Millisecond)
-	<-op.idleChannel()
-
+	op.pbft.manager.queue() <- nil
 	if len(reqs) != 3 || !reflect.DeepEqual(reqs[2].Payload, req1.Payload) {
 		t.Error("expected resubmitted request")
 	}

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -27,7 +27,7 @@ import (
 )
 
 type obcClassic struct {
-	obcGeneric
+	legacyGenericShim
 
 	persistForward
 
@@ -36,14 +36,16 @@ type obcClassic struct {
 
 func newObcClassic(id uint64, config *viper.Viper, stack consensus.Stack) *obcClassic {
 	op := &obcClassic{
-		obcGeneric: obcGeneric{stack: stack},
+		legacyGenericShim: legacyGenericShim{
+			obcGeneric: obcGeneric{stack: stack},
+		},
 	}
 
 	op.persistForward.persistor = stack
 
 	logger.Debug("Replica %d obtaining startup information", id)
 
-	op.pbft = newPbftCore(id, config, op)
+	op.pbft = legacyPbftShim{newPbftCore(id, config, op)}
 	op.pbft.manager.start()
 
 	op.idleChan = make(chan struct{})

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -171,3 +171,13 @@ func (op *obcClassic) main() {
 func (op *obcClassic) idleChannel() <-chan struct{} {
 	return op.idleChan
 }
+
+// StateUpdated is a signal from the stack that it has fast-forwarded its state
+func (op *obcClassic) StateUpdated(seqNo uint64, id []byte) {
+	op.pbft.stateUpdated(seqNo, id)
+}
+
+// StateUpdating is a signal from the stack that state transfer has started
+func (op *obcClassic) StateUpdating(seqNo uint64, id []byte) {
+	op.pbft.stateUpdating(seqNo, id)
+}

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -44,6 +44,7 @@ func newObcClassic(id uint64, config *viper.Viper, stack consensus.Stack) *obcCl
 	logger.Debug("Replica %d obtaining startup information", id)
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager.start()
 
 	op.idleChan = make(chan struct{})
 	close(op.idleChan)

--- a/consensus/obcpbft/obc-classic_test.go
+++ b/consensus/obcpbft/obc-classic_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (op *obcClassic) getPBFTCore() *pbftCore {
-	return op.pbft
+	return op.legacyGenericShim.pbft.pbftCore
 }
 
 func obcClassicHelper(id uint64, config *viper.Viper, stack consensus.Stack) pbftConsumer {

--- a/consensus/obcpbft/obc-pbft.go
+++ b/consensus/obcpbft/obc-pbft.go
@@ -147,13 +147,3 @@ func (op *obcGeneric) getLastSeqNo() (uint64, error) {
 	proto.Unmarshal(raw, meta)
 	return meta.SeqNo, nil
 }
-
-// StateUpdated is a signal from the stack that it has fast-forwarded its state
-func (op *obcGeneric) StateUpdated(seqNo uint64, id []byte) {
-	op.pbft.stateUpdated(seqNo, id)
-}
-
-// StateUpdating is a signal from the stack that state transfer has started
-func (op *obcGeneric) StateUpdating(seqNo uint64, id []byte) {
-	op.pbft.stateUpdating(seqNo, id)
-}

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -83,6 +83,7 @@ func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSiev
 	op.restoreBlockNumber()
 
 	op.pbft = newPbftCore(id, config, op)
+	op.pbft.manager.start()
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()
 

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -31,7 +31,7 @@ import (
 )
 
 type obcSieve struct {
-	obcGeneric
+	legacyGenericShim
 
 	id             uint64
 	epoch          uint64
@@ -74,15 +74,17 @@ type msgWithSender struct {
 
 func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSieve {
 	op := &obcSieve{
-		obcGeneric: obcGeneric{stack: stack},
-		id:         id,
+		legacyGenericShim: legacyGenericShim{
+			obcGeneric: obcGeneric{stack: stack},
+		},
+		id: id,
 	}
 	op.queuedExec = make(map[uint64]*Execute)
 	op.persistForward.persistor = stack
 
 	op.restoreBlockNumber()
 
-	op.pbft = newPbftCore(id, config, op)
+	op.pbft = legacyPbftShim{newPbftCore(id, config, op)}
 	op.pbft.manager.start()
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()

--- a/consensus/obcpbft/obc-sieve_test.go
+++ b/consensus/obcpbft/obc-sieve_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (op *obcSieve) getPBFTCore() *pbftCore {
-	return op.pbft
+	return op.legacyGenericShim.pbft.pbftCore
 }
 
 func obcSieveHelper(id uint64, config *viper.Viper, stack consensus.Stack) pbftConsumer {
@@ -43,6 +43,8 @@ func TestSieveNetwork(t *testing.T) {
 	validatorCount := 4
 	net := makeConsumerNetwork(validatorCount, obcSieveHelper)
 	defer net.stop()
+
+	net.debug = true
 
 	req1 := createOcMsgWithChainTx(1)
 	net.endpoints[1].(*consumerEndpoint).consumer.RecvMsg(req1, net.endpoints[generateBroadcaster(validatorCount)].getHandle())

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -278,6 +278,8 @@ func (instance *pbftCore) processEvent(e interface{}) interface{} {
 		logger.Info("Replica %d view change timer expired, sending view change", instance.id)
 		instance.timerActive = false
 		instance.sendViewChange()
+	case *pbftMessage:
+		return pbftMessageEvent(*et)
 	case pbftMessageEvent:
 		msg := et
 		logger.Debug("Replica %d received incoming message from %v", instance.id, msg.sender)
@@ -325,7 +327,7 @@ func (instance *pbftCore) processEvent(e interface{}) interface{} {
 	case viewChangedEvent:
 		instance.consumer.viewChange(instance.view)
 	default:
-		logger.Warning("Replica %d received an unknown message type", instance.id)
+		logger.Warning("Replica %d received an unknown message type %T", instance.id, et)
 	}
 
 	if err != nil {
@@ -538,9 +540,9 @@ func (instance *pbftCore) recvMsg(msg *Message, senderID uint64) (interface{}, e
 	} else if req := msg.GetReturnRequest(); req != nil {
 		// it's ok for sender ID and replica ID to differ; we're sending the original request message
 		return returnRequestEvent(req), nil
-	} else {
-		return nil, fmt.Errorf("Invalid message: %v", msg)
 	}
+
+	return nil, fmt.Errorf("Invalid message: %v", msg)
 }
 
 func (instance *pbftCore) recvRequest(req *Request) error {

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -147,6 +147,8 @@ func makePBFTNetwork(N int, initFNs ...func(pe *pbftEndpoint)) *pbftNetwork {
 			fn(pe)
 		}
 
+		pe.pbft.manager.start()
+
 		return pe
 
 	}

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -73,24 +73,20 @@ func TestMaliciousPrePrepare(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
-	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
 	digest1 := "hi there"
 	request2 := &Request{Payload: []byte("other"), ReplicaId: uint64(generateBroadcaster(instance.replicaCount))}
 
-	pbftMsg := &Message{&Message_PrePrepare{&PrePrepare{
+	pbftMsg := &Message_PrePrepare{&PrePrepare{
 		View:           0,
 		SequenceNumber: 1,
 		RequestDigest:  digest1,
 		Request:        request2,
 		ReplicaId:      0,
-	}}}
-	err := instance.recvMsgSync(pbftMsg, 0)
-	if err != nil {
-		t.Fatalf("Failed to handle PBFT message: %s", err)
-	}
+	}}
+	sendEvent(instance, pbftMsg)
 }
 
 func TestWrongReplicaID(t *testing.T) {
@@ -129,7 +125,6 @@ func TestIncompletePayload(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
-	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -139,7 +134,7 @@ func TestIncompletePayload(t *testing.T) {
 		mock.broadcastImpl = func(msgPayload []byte) {
 			t.Errorf(errMsg, args...)
 		}
-		_ = instance.recvMsgSync(msg, broadcaster)
+		sendEvent(instance, pbftMessageEvent{msg: msg, sender: broadcaster})
 	}
 
 	checkMsg(&Message{}, "Expected to reject empty message")
@@ -151,15 +146,11 @@ func TestIncompletePayload(t *testing.T) {
 func TestNetwork(t *testing.T) {
 	validatorCount := 7
 	net := makePBFTNetwork(validatorCount)
-	defer net.stop()
 
-	msg := createOcMsgWithChainTx(1)
-	err := net.pbftEndpoints[0].pbft.request(msg.Payload, uint64(generateBroadcaster(validatorCount)))
-	if err != nil {
-		t.Fatalf("Request failed: %s", err)
-	}
+	msg := createPbftRequestWithChainTx(1, uint64(generateBroadcaster(validatorCount)))
+	net.pbftEndpoints[0].pbft.manager.queue() <- msg
 
-	err = net.process()
+	err := net.process()
 	if err != nil {
 		t.Fatalf("Processing failed: %s", err)
 	}
@@ -218,7 +209,7 @@ func TestCheckpoint(t *testing.T) {
 			t.Fatalf("Failed to marshal TX block: %s", err)
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
-		net.pbftEndpoints[0].pbft.recvMsgSync(msg, msg.GetRequest().ReplicaId)
+		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 
 		net.process()
 	}
@@ -293,18 +284,23 @@ func TestLostPrePrepare(t *testing.T) {
 		ReplicaId: uint64(generateBroadcaster(validatorCount)),
 	}
 
-	_ = net.pbftEndpoints[0].pbft.recvRequest(req)
+	net.pbftEndpoints[0].pbft.manager.queue() <- (req)
 
 	// clear all messages sent by primary
 	msg := <-net.msgs
+	prePrep := &Message{}
+	err := proto.Unmarshal(msg.msg, prePrep)
+	if err != nil {
+		t.Fatalf("Error unmarshaling message")
+	}
 	net.clearMessages()
 
 	// deliver pre-prepare to subset of replicas
 	for _, pep := range net.pbftEndpoints[1 : len(net.pbftEndpoints)-1] {
-		pep.pbft.receive(msg.msg, uint64(msg.src))
+		pep.pbft.manager.queue() <- prePrep.GetPrePrepare()
 	}
 
-	err := net.process()
+	err = net.process()
 	if err != nil {
 		t.Fatalf("Processing failed: %s", err)
 	}
@@ -346,15 +342,15 @@ func TestInconsistentPrePrepare(t *testing.T) {
 		return preprep
 	}
 
-	_ = net.pbftEndpoints[0].pbft.recvRequest(makePP(1).Request)
+	net.pbftEndpoints[0].pbft.manager.queue() <- makePP(1).Request
 
 	// clear all messages sent by primary
 	net.clearMessages()
 
 	// replace with fake messages
-	_ = net.pbftEndpoints[1].pbft.recvPrePrepare(makePP(1))
-	_ = net.pbftEndpoints[2].pbft.recvPrePrepare(makePP(2))
-	_ = net.pbftEndpoints[3].pbft.recvPrePrepare(makePP(3))
+	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(1)
+	net.pbftEndpoints[2].pbft.manager.queue() <- makePP(2)
+	net.pbftEndpoints[3].pbft.manager.queue() <- makePP(3)
 
 	net.process()
 
@@ -506,7 +502,7 @@ func TestViewChange(t *testing.T) {
 			t.Fatalf("Failed to marshal TX block: %s", err)
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
-		err = net.pbftEndpoints[0].pbft.recvMsgSync(msg, msg.GetRequest().ReplicaId)
+		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 		if err != nil {
 			t.Fatalf("Request failed: %s", err)
 		}
@@ -571,15 +567,15 @@ func TestInconsistentDataViewChange(t *testing.T) {
 		return preprep
 	}
 
-	_ = net.pbftEndpoints[0].pbft.recvRequest(makePP(0).Request)
+	net.pbftEndpoints[0].pbft.manager.queue() <- makePP(0).Request
 
 	// clear all messages sent by primary
 	net.clearMessages()
 
 	// replace with fake messages
-	_ = net.pbftEndpoints[1].pbft.recvPrePrepare(makePP(1))
-	_ = net.pbftEndpoints[2].pbft.recvPrePrepare(makePP(1))
-	_ = net.pbftEndpoints[3].pbft.recvPrePrepare(makePP(0))
+	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(1)
+	net.pbftEndpoints[2].pbft.manager.queue() <- makePP(1)
+	net.pbftEndpoints[3].pbft.manager.queue() <- makePP(0)
 
 	err := net.process()
 	if err != nil {
@@ -631,14 +627,14 @@ func TestViewChangeWithStateTransfer(t *testing.T) {
 
 	// Have primary advance the sequence number past a checkpoint for replicas 0,1,2
 	for i := int64(1); i <= 3; i++ {
-		_ = net.pbftEndpoints[0].pbft.recvRequest(makePP(i).Request)
+		net.pbftEndpoints[0].pbft.manager.queue() <- makePP(i).Request
 
 		// clear all messages sent by primary
 		net.clearMessages()
 
-		_ = net.pbftEndpoints[0].pbft.recvPrePrepare(makePP(i))
-		_ = net.pbftEndpoints[1].pbft.recvPrePrepare(makePP(i))
-		_ = net.pbftEndpoints[2].pbft.recvPrePrepare(makePP(i))
+		net.pbftEndpoints[0].pbft.manager.queue() <- makePP(i)
+		net.pbftEndpoints[1].pbft.manager.queue() <- makePP(i)
+		net.pbftEndpoints[2].pbft.manager.queue() <- makePP(i)
 
 		err = net.process()
 		if err != nil {
@@ -659,7 +655,7 @@ func TestViewChangeWithStateTransfer(t *testing.T) {
 
 	fmt.Println("Done with stage 3")
 
-	_ = net.pbftEndpoints[1].pbft.recvRequest(makePP(5).Request)
+	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(5).Request
 	err = net.process()
 	if err != nil {
 		t.Fatalf("Processing failed: %s", err)
@@ -699,17 +695,13 @@ func TestNewViewTimeout(t *testing.T) {
 
 	broadcaster := uint64(generateBroadcaster(validatorCount))
 
-	txTime := &gp.Timestamp{Seconds: 1, Nanos: 0}
-	tx := &pb.Transaction{Type: pb.Transaction_CHAINCODE_DEPLOY, Timestamp: txTime}
-	txPacked, _ := proto.Marshal(tx)
-	msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: broadcaster}}}
-	msgPacked, _ := proto.Marshal(msg)
+	req := createPbftRequestWithChainTx(1, broadcaster)
 
 	go net.processContinually()
 
 	// This will eventually trigger 1's request timeout
 	// We check that one single timed out replica will not keep trying to change views by itself
-	net.pbftEndpoints[1].pbft.receive(msgPacked, broadcaster)
+	net.pbftEndpoints[1].pbft.manager.queue() <- req
 	fmt.Println("Debug: Sleeping 1")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 1")
@@ -720,7 +712,7 @@ func TestNewViewTimeout(t *testing.T) {
 	// However, 2 does not know about the missing request, and therefore the request will not be
 	// pre-prepared and finally executed.
 	replica1Disabled = true
-	net.pbftEndpoints[3].pbft.receive(msgPacked, broadcaster)
+	net.pbftEndpoints[3].pbft.manager.queue() <- req
 	fmt.Println("Debug: Sleeping 2")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 2")
@@ -728,7 +720,7 @@ func TestNewViewTimeout(t *testing.T) {
 	// So far, we are in view 2, and replica 1 and 3 (who got the request) in view change to view 3.
 	// Submitting the request to 0 will eventually trigger its view-change timeout, which will make
 	// all replicas move to view 3 and finally process the request.
-	net.pbftEndpoints[0].pbft.receive(msgPacked, broadcaster)
+	net.pbftEndpoints[0].pbft.manager.queue() <- req
 	fmt.Println("Debug: Sleeping 3")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 3")
@@ -759,8 +751,10 @@ func TestViewChangeUpdateSeqNo(t *testing.T) {
 
 	go net.processContinually()
 
-	msg := createOcMsgWithChainTx(1)
-	net.pbftEndpoints[0].pbft.request(msg.Payload, uint64(generateBroadcaster(validatorCount)))
+	broadcaster := uint64(generateBroadcaster(validatorCount))
+
+	req := createPbftRequestWithChainTx(1, broadcaster)
+	net.pbftEndpoints[0].pbft.manager.queue() <- req
 	time.Sleep(5 * millisUntilTimeout)
 	// Now we all have executed seqNo 100.  After triggering a
 	// view change, the new primary should pick up right after
@@ -770,8 +764,8 @@ func TestViewChangeUpdateSeqNo(t *testing.T) {
 	net.pbftEndpoints[1].pbft.sendViewChange()
 	time.Sleep(5 * millisUntilTimeout)
 
-	msg = createOcMsgWithChainTx(2)
-	net.pbftEndpoints[1].pbft.request(msg.Payload, uint64(generateBroadcaster(validatorCount)))
+	req = createPbftRequestWithChainTx(2, broadcaster)
+	net.pbftEndpoints[1].pbft.manager.queue() <- req
 	time.Sleep(5 * millisUntilTimeout)
 
 	net.stop()
@@ -792,7 +786,6 @@ func TestSendQueueThrottling(t *testing.T) {
 
 	mock := &omniProto{}
 	instance := newPbftCore(0, loadConfig(), mock)
-	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -804,17 +797,11 @@ func TestSendQueueThrottling(t *testing.T) {
 	}
 	defer instance.close()
 
-	i := 0
-	sendReq := func() {
-		i++
-		instance.recvRequest(&Request{
-			Timestamp: &gp.Timestamp{Seconds: int64(i), Nanos: 0},
-			Payload:   []byte(fmt.Sprintf("%d", i)),
-		})
-	}
-
 	for j := 0; j < 4; j++ {
-		sendReq()
+		sendEvent(instance, &Request{
+			Timestamp: &gp.Timestamp{Seconds: int64(j), Nanos: 0},
+			Payload:   []byte(fmt.Sprintf("%d", j)),
+		})
 	}
 
 	expected := 2
@@ -827,13 +814,12 @@ func TestSendQueueThrottling(t *testing.T) {
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
-	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
 	defer instance.close()
 
-	instance.recvCheckpoint(&Checkpoint{
+	sendEvent(instance, &Checkpoint{
 		SequenceNumber: 6,
 		ReplicaId:      0,
 	})
@@ -843,7 +829,7 @@ func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	// This causes the list of high checkpoints to grow to be f+1
 	// even though there are not f+1 checkpoints witnessed outside our range
 	// historically, this caused an index out of bounds error
-	instance.recvCheckpoint(&Checkpoint{
+	sendEvent(instance, &Checkpoint{
 		SequenceNumber: 10,
 		ReplicaId:      3,
 	})
@@ -853,13 +839,12 @@ func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 func TestWitnessFallBehindMissingPrePrepare(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
-	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
 	defer instance.close()
 
-	instance.recvCommit(&Commit{
+	sendEvent(instance, &Commit{
 		SequenceNumber: 2,
 		ReplicaId:      0,
 	})
@@ -888,10 +873,7 @@ func TestFallBehind(t *testing.T) {
 
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
 
-		err = net.pbftEndpoints[0].pbft.recvMsgSync(msg, msg.GetRequest().ReplicaId)
-		if err != nil {
-			t.Fatalf("Request failed: %s", err)
-		}
+		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 
 		if skipThree {
 			// Send the request for consensus to everone but replica 3
@@ -958,22 +940,13 @@ func TestPbftF0(t *testing.T) {
 	net := makePBFTNetwork(1)
 	defer net.stop()
 
-	// Create a message of type: `Message_CHAIN_TRANSACTION`
-	txTime := &gp.Timestamp{Seconds: 1, Nanos: 0}
-	tx := &pb.Transaction{Type: pb.Transaction_CHAINCODE_DEPLOY, Timestamp: txTime, Payload: []byte("TestNetwork")}
-	txPacked, err := proto.Marshal(tx)
-	if err != nil {
-		t.Fatalf("Failed to marshal TX block: %s", err)
-	}
+	req := createPbftRequestWithChainTx(1, 0)
 
 	pep0 := net.pbftEndpoints[0]
 
-	err = pep0.pbft.request(txPacked, 0)
-	if err != nil {
-		t.Fatalf("Request failed: %s", err)
-	}
+	pep0.pbft.manager.queue() <- req
 
-	err = net.process()
+	err := net.process()
 	if err != nil {
 		t.Fatalf("Processing failed: %s", err)
 	}
@@ -987,9 +960,9 @@ func TestPbftF0(t *testing.T) {
 			t.Errorf("Instance %d executed more than one transaction", pep.id)
 			continue
 		}
-		if !reflect.DeepEqual(pep.sc.lastExecution, txPacked) {
+		if !reflect.DeepEqual(pep.sc.lastExecution, req.Payload) {
 			t.Errorf("Instance %d executed wrong transaction, %x should be %x",
-				pep.id, pep.sc.lastExecution, txPacked)
+				pep.id, pep.sc.lastExecution, req.Payload)
 		}
 	}
 }
@@ -1023,7 +996,7 @@ func TestRequestTimerDuringViewChange(t *testing.T) {
 		ReplicaId: 1, // Not the primary
 	}
 
-	instance.recvRequest(req)
+	instance.manager.queue() <- req
 
 	time.Sleep(100 * time.Millisecond)
 }
@@ -1052,7 +1025,7 @@ func TestReplicaCrash1(t *testing.T) {
 		}
 	}
 
-	net.pbftEndpoints[0].pbft.recvRequest(mkreq(1))
+	net.pbftEndpoints[0].pbft.manager.queue() <- mkreq(1)
 	net.process()
 
 	for id := 0; id < 2; id++ {
@@ -1065,8 +1038,8 @@ func TestReplicaCrash1(t *testing.T) {
 		pe.pbft.L = 2 * pe.pbft.K
 	}
 
-	net.pbftEndpoints[0].pbft.recvRequest(mkreq(2))
-	net.pbftEndpoints[0].pbft.recvRequest(mkreq(3))
+	net.pbftEndpoints[0].pbft.manager.queue() <- mkreq(2)
+	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(3))
 	net.process()
 
 	for _, pep := range net.pbftEndpoints {
@@ -1129,15 +1102,15 @@ func TestReplicaCrash2(t *testing.T) {
 		}
 	}
 
-	net.pbftEndpoints[0].pbft.recvRequest(mkreq(1))
+	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(1))
 	net.process()
 
 	logger.Info("stopping filtering")
 	filterMsg = false
 	primary := net.pbftEndpoints[0].pbft.primary(net.pbftEndpoints[0].pbft.view)
-	net.pbftEndpoints[primary].pbft.recvRequest(mkreq(2))
-	net.pbftEndpoints[primary].pbft.recvRequest(mkreq(3))
-	net.pbftEndpoints[primary].pbft.recvRequest(mkreq(4))
+	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(2))
+	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(3))
+	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(4))
 	go net.processContinually()
 	time.Sleep(5 * time.Second)
 
@@ -1191,7 +1164,7 @@ func TestReplicaCrash3(t *testing.T) {
 	}
 
 	for i := int64(1); i <= 8; i++ {
-		net.pbftEndpoints[0].pbft.recvRequest(mkreq(i))
+		net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(i))
 	}
 	net.process() // vp0,1,2 should have a stable checkpoint for seqNo 8
 
@@ -1212,7 +1185,7 @@ func TestReplicaCrash3(t *testing.T) {
 
 	// Because vp2 is 'offline', and vp3 is still at the genesis block, the network needs to make a view change
 
-	net.pbftEndpoints[0].pbft.recvRequest(mkreq(9))
+	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(9))
 	net.process()
 
 	// Now vp0,1,3 should be in sync with 9 executions in view 1, and vp2 should be at 8 executions in view 0
@@ -1275,20 +1248,18 @@ func TestReplicaPersistQSet(t *testing.T) {
 		},
 	}
 	p := newPbftCore(1, loadConfig(), stack)
-	p.manager.start()
 	req := &Request{
 		Timestamp: &gp.Timestamp{Seconds: 1, Nanos: 0},
 		Payload:   []byte("foo"),
 		ReplicaId: uint64(0),
 	}
-	p.recvMsgSync(&Message{&Message_PrePrepare{&PrePrepare{
+	sendEvent(p, &PrePrepare{
 		View:           0,
 		SequenceNumber: 1,
 		RequestDigest:  hashReq(req),
 		Request:        req,
 		ReplicaId:      uint64(0),
-	}}}, uint64(0))
-	p.manager.queue() <- nil
+	})
 	p.close()
 
 	p = newPbftCore(1, loadConfig(), stack)

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -73,6 +73,7 @@ func TestMaliciousPrePrepare(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -125,6 +126,7 @@ func TestIncompletePayload(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -370,6 +372,7 @@ func TestViewChangeWatermarksMovement(t *testing.T) {
 		},
 		broadcastImpl: func(b []byte) {},
 	})
+	instance.manager.start()
 	instance.activeView = false
 	instance.view = 1
 	instance.lastExec = 10
@@ -786,6 +789,7 @@ func TestSendQueueThrottling(t *testing.T) {
 
 	mock := &omniProto{}
 	instance := newPbftCore(0, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -820,6 +824,7 @@ func TestSendQueueThrottling(t *testing.T) {
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -845,6 +850,7 @@ func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 func TestWitnessFallBehindMissingPrePrepare(t *testing.T) {
 	mock := &omniProto{}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -996,6 +1002,7 @@ func TestRequestTimerDuringViewChange(t *testing.T) {
 		},
 	}
 	instance := newPbftCore(1, loadConfig(), mock)
+	instance.manager.start()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -1048,6 +1055,7 @@ func TestReplicaCrash1(t *testing.T) {
 	for id := 0; id < 2; id++ {
 		pe := net.pbftEndpoints[id]
 		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc)
+		pe.pbft.manager.start()
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.K = 2
@@ -1190,6 +1198,7 @@ func TestReplicaCrash3(t *testing.T) {
 		config := loadConfig()
 		config.Set("general.K", "2")
 		pe.pbft = newPbftCore(uint64(id), config, pe.sc)
+		pe.pbft.manager.start()
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.requestTimeout = 200 * time.Millisecond

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1272,6 +1272,7 @@ func TestReplicaPersistQSet(t *testing.T) {
 		},
 	}
 	p := newPbftCore(1, loadConfig(), stack)
+	p.manager.start()
 	req := &Request{
 		Timestamp: &gp.Timestamp{Seconds: 1, Nanos: 0},
 		Payload:   []byte("foo"),
@@ -1284,6 +1285,8 @@ func TestReplicaPersistQSet(t *testing.T) {
 		Request:        req,
 		ReplicaId:      uint64(0),
 	}}}, uint64(0))
+	p.manager.queue() <- nil
+	p.close()
 
 	p = newPbftCore(1, loadConfig(), stack)
 	if !p.prePrepared(hashReq(req), 0, 1) {

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -433,7 +433,7 @@ func (instance *pbftCore) processNewView2(nv *NewView) error {
 
 	logger.Debug("Replica %d done cleaning view change artifacts, calling into consumer", instance.id)
 
-	instance.consumer.viewChange(instance.view)
+	instance.manager.inject(viewChangedEvent{})
 
 	return nil
 }


### PR DESCRIPTION
## Description

This changeset is yet another in the long series of #1586 #1595 and #1614.

It begins to remove the non-event based mechanisms which were used to inject work into PBFT.  It moves some of them into a legacy structure for continued support of classic/sieve, and removes dependency on those methods from the PBFT core tests.
## Motivation and Context

This is part of a series PRs designed to remove the multithreading from PBFT and to turn it into more of a simple state machine.  There is very little new code in this changeset, just restructuring and API modifcations.  As with the other PRs in this series, review from @corecode especially is requested, though review from @kchristidis @tuand27613 and others is always welcome.

(And, as with the previous in the patch series, this is not the final patch, there remains considerable ugliness, which will be removed in the following series)
## How Has This Been Tested?

This has been tested via the obcpbft unit tests locally.  Relying on CI for the remainder.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
