### PR TITLE
Support "peer network ls" besides list

### DIFF
--- a/peer/main.go
+++ b/peer/main.go
@@ -155,8 +155,8 @@ var networkLoginCmd = &cobra.Command{
 // }
 
 var networkListCmd = &cobra.Command{
-	Use:   "ls",
-	Aliases: []string{"list"},
+	Use:   "list",
+	Aliases: []string{"ls"},
 	Short: "Lists all network peers.",
 	Long:  `Returns a list of all existing network connections for the target peer node, includes both validating and non-validating peers.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/peer/main.go
+++ b/peer/main.go
@@ -156,7 +156,7 @@ var networkLoginCmd = &cobra.Command{
 
 var networkListCmd = &cobra.Command{
 	Use:   "ls",
-	Aliases:   ["list"],
+	Aliases: []string{"list"},
 	Short: "Lists all network peers.",
 	Long:  `Returns a list of all existing network connections for the target peer node, includes both validating and non-validating peers.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/peer/main.go
+++ b/peer/main.go
@@ -155,7 +155,8 @@ var networkLoginCmd = &cobra.Command{
 // }
 
 var networkListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "ls",
+	Aliases:   ["list"],
 	Short: "Lists all network peers.",
 	Long:  `Returns a list of all existing network connections for the target peer node, includes both validating and non-validating peers.`,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Let `peer network` cmd support `ls` as well, besides `list`
## Description

<!--- Describe your changes in detail. -->

Support `ls` as alias to `list`, which is popular in Linux world.

To keep compatible with old version, still keep `list` cmd, too.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

No open issue.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Passed `make check`, while the change needs no additional test cases.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Baohua Yang baohyang@cn.ibm.com
