### PR TITLE
Fixes for Makefile issues 1534 and 1609

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ peer: base-image
 membersrvc:
 	cd membersrvc; CGO_CFLAGS=" " CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
 
-unit-test: peer-image
+unit-test: peer-image gotools
 	@echo "Running unit-tests"
 	$(eval CID := $(shell docker run -dit -p 30303:30303 hyperledger-peer peer node start))
 	@go test -timeout=20m $(shell go list $(PKGNAME)/... | grep -v /vendor/ | grep -v /examples/)

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,7 @@ membersrvc:
 	cd membersrvc; CGO_CFLAGS=" " CGO_LDFLAGS="$(CGO_LDFLAGS)" go build
 
 unit-test: peer-image gotools
-	@echo "Running unit-tests"
-	$(eval CID := $(shell docker run -dit -p 30303:30303 hyperledger-peer peer node start))
-	@go test -timeout=20m $(shell go list $(PKGNAME)/... | grep -v /vendor/ | grep -v /examples/)
-	@docker kill $(CID)
+	@./scripts/goUnitTests.sh
 	@touch .peerimage-dummy
 	@touch .caimage-dummy
 

--- a/scripts/goUnitTests.sh
+++ b/scripts/goUnitTests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo -n "Obtaining list of tests to run.."
+PKGS=`go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/`
+echo "DONE!"
+
+echo -n "Starting peer.."
+CID=`docker run -dit -p 30303:30303 hyperledger-peer peer node start`
+cleanup() {
+    echo "Stopping peer.."
+    docker kill $CID 2>&1 > /dev/null
+}
+trap cleanup 0
+echo "DONE!"
+
+echo "Running tests..."
+go test -timeout=20m $PKGS


### PR DESCRIPTION
Makefile fix rollup:  Fixes #1534 and #1609 
## Description

The makefile has been enhanced in two primary ways
1. We now make unit-test depend on gotools so we can ensure that the protoc-gen-go prerequisite is met before running the tests (Issue #1609).
2. We moved unit-test execution to a script so that we can instrument proper cleanup of the docker-based peer (Issue #1534)
## Motivation and Context

Bug squashing
## How Has This Been Tested?

"make unit-test" has been driven through various scenarios, such as making sure "make clean unit-test" properly rebuild tools, and that unit-test failures do not leave the peer running.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
