### PR TITLE
Issue 1558 Fix go vet issues in fabric/membersrvc/ca 

### DIFF
--- a/membersrvc/ca/eca.go
+++ b/membersrvc/ca/eca.go
@@ -254,7 +254,7 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 		}
 
 		out, err := ecies.Process(tok)
-		return &pb.ECertCreateResp{nil, nil, nil, &pb.Token{out}}, err
+		return &pb.ECertCreateResp{Certs: nil, Chain: nil, Pkchain: nil, Tok: &pb.Token{Tok: out}}, err
 
 	case state == 1:
 		// ensure that the same encryption key is signed that has been used for the challenge
@@ -317,7 +317,8 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 			obcECKey = ecap.eca.obcPub
 		}
 
-		return &pb.ECertCreateResp{&pb.CertPair{sraw, eraw}, &pb.Token{ecap.eca.obcKey}, obcECKey, nil}, nil
+		return &pb.ECertCreateResp{Certs: &pb.CertPair{Sign: sraw, Enc: eraw}, Chain: &pb.Token{Tok: ecap.eca.obcKey}, Pkchain: obcECKey, Tok: nil}, nil
+
 	}
 
 	return nil, errors.New("Invalid (=expired) certificate creation token provided.")
@@ -417,7 +418,7 @@ func (ecaa *ECAA) ReadUserSet(ctx context.Context, in *pb.ReadUserSetReq) (*pb.U
 			var role int
 
 			err = rows.Scan(&id, &role)
-			users = append(users, &pb.User{&pb.Identity{id}, pb.Role(role)})
+			users = append(users, &pb.User{&pb.Identity{Id : id}, pb.Role(role)})
 		}
 		err = rows.Err()
 	}

--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -322,7 +322,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, in *pb.TCertCreateSe
 		set = append(set, &pb.TCert{raw, ks})
 	}
 
-	return &pb.TCertCreateSetResp{&pb.CertSet{in.Ts, in.Id, kdfKey, set}}, nil
+	return &pb.TCertCreateSetResp{Certs: &pb.CertSet{ Ts: in.Ts, Id: in.Id, Key: kdfKey, Certs: set}}, nil
 }
 
 // Generate encrypted extensions to be included into the TCert (TCertIndex, EnrollmentID and attributes).
@@ -605,7 +605,7 @@ func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsR
 			}
 
 			if ts != timestamp {
-				sets = append(sets, &pb.CertSet{&protobuf.Timestamp{Seconds: timestamp, Nanos: 0}, &pb.Identity{id}, kdfKey, certs})
+				sets = append(sets, &pb.CertSet{Ts: &protobuf.Timestamp{Seconds: timestamp, Nanos: 0}, Id: &pb.Identity{Id: id}, Key: kdfKey, Certs: certs})
 
 				timestamp = ts
 				certs = nil
@@ -618,7 +618,7 @@ func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsR
 			return nil, err
 		}
 
-		sets = append(sets, &pb.CertSet{&protobuf.Timestamp{Seconds: timestamp, Nanos: 0}, &pb.Identity{id}, kdfKey, certs})
+		sets = append(sets, &pb.CertSet{Ts: &protobuf.Timestamp{Seconds: timestamp, Nanos: 0}, Id: &pb.Identity{Id: id}, Key: kdfKey, Certs: certs})
 	}
 	if err = users.Err(); err != nil {
 		return nil, err

--- a/membersrvc/ca/tlsca.go
+++ b/membersrvc/ca/tlsca.go
@@ -116,7 +116,7 @@ func (tlscap *TLSCAP) CreateCertificate(ctx context.Context, in *pb.TLSCertCreat
 		return nil, err
 	}
 
-	return &pb.TLSCertCreateResp{&pb.Cert{raw}, &pb.Cert{tlscap.tlsca.raw}}, nil
+	return &pb.TLSCertCreateResp{Cert: &pb.Cert{Cert: raw}, RootCert: &pb.Cert{Cert: tlscap.tlsca.raw}}, nil
 }
 
 // ReadCertificate reads an enrollment certificate from the TLSCA.

--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -32,17 +32,16 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
-	"google/protobuf"
+	google_protobuf "google/protobuf"
 	"path/filepath"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	"github.com/hyperledger/fabric/core/util"
-
-	_ "fmt"
-
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	membersrvc "github.com/hyperledger/fabric/membersrvc/protos"
+
+	_ "fmt"
 )
 
 var (
@@ -126,7 +125,7 @@ func requestTLSCertificate(t *testing.T) {
 
 	pubraw, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
 	now := time.Now()
-	timestamp := google_protobuf.Timestamp{int64(now.Second()), int32(now.Nanosecond())}
+	timestamp := google_protobuf.Timestamp{ Seconds: int64(now.Second()), Nanos: int32(now.Nanosecond())}
 
 	req := &membersrvc.TLSCertCreateReq{
 		&timestamp,

--- a/membersrvc/ca/validity_period.go
+++ b/membersrvc/ca/validity_period.go
@@ -119,7 +119,7 @@ func invokeChaincode(chaincodeInvSpec *obc.ChaincodeInvocationSpec) error {
 		return err
 	}
 
-	Info.Println("Successfully invoked validity period update: %v(%s)", chaincodeInvSpec, string(resp.Msg))
+	Info.Println(fmt.Sprintf("Successfully invoked validity period update: %v(%s)", chaincodeInvSpec, string(resp.Msg)))
 
 	return nil
 }

--- a/membersrvc/ca/validity_period.go
+++ b/membersrvc/ca/validity_period.go
@@ -119,7 +119,7 @@ func invokeChaincode(chaincodeInvSpec *obc.ChaincodeInvocationSpec) error {
 		return err
 	}
 
-	Info.Println("Successfully invoked validity period update: %s(%s)", chaincodeInvSpec, string(resp.Msg))
+	Info.Println("Successfully invoked validity period update: %v(%s)", chaincodeInvSpec, string(resp.Msg))
 
 	return nil
 }

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -250,7 +250,7 @@ func queryChaincode(chaincodeInvSpec *pb.ChaincodeInvocationSpec, t *testing.T) 
 		return nil, fmt.Errorf("Error invoking validity period update system chaincode: %s", err)
 	}
 
-	t.Logf("Successfully invoked validity period update: %s(%s)", chaincodeInvSpec, string(resp.Msg))
+	t.Logf("Successfully invoked validity period update: %v(%s)", chaincodeInvSpec, string(resp.Msg))
 
 	return resp, nil
 }

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -407,7 +407,7 @@ func startOpenchain(t *testing.T) error {
 func stopOpenchain(t *testing.T) {
 	clientConn, err := peer.NewPeerClientConnection()
 	if err != nil {
-		t.Log(fmt.Errorf("Error trying to connect to local peer:", err))
+		t.Log(fmt.Errorf("Error trying to connect to local peer: %v", err))
 		t.Fail()
 	}
 

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -98,17 +98,17 @@ func TestValidityPeriod(t *testing.T) {
 
 	// 6. Compare the values
 	if validityPeriodA != validityPeriodFromLedgerA {
-		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriodA, validityPeriodFromLedgerA)
+		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %d, Actual: %d", validityPeriodA, validityPeriodFromLedgerA)
 		t.Fail()
 	}
 
 	if validityPeriodB != validityPeriodFromLedgerB {
-		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %s, Actual: %s", validityPeriodB, validityPeriodFromLedgerB)
+		t.Logf("Validity period read from ledger must be equals tothe one obtained by querying the Openchain. Expected: %d, Actual: %d", validityPeriodB, validityPeriodFromLedgerB)
 		t.Fail()
 	}
 
 	if validityPeriodB-validityPeriodA != updateInterval {
-		t.Logf("Validity period difference must be equal to the update interval. Expected: %s, Actual: %s", updateInterval, validityPeriodB-validityPeriodA)
+		t.Logf("Validity period difference must be equal to the update interval. Expected: %d, Actual: %d", updateInterval, validityPeriodB-validityPeriodA)
 		t.Fail()
 	}
 


### PR DESCRIPTION
Fix `go vet` issues in `fabric/membersrvc/ca`, following @srderson's work from last week.
## Description

Changes include the following fixes:
Go vet fixes (composite literal that used unkeyed fields)
Go vet fixes (wrong formatting directives for validityPeriod, updateInterval and err
Go vet fixes (no formatting directive in Errorf call)
Go vet fixes (unresolvable package + wrong fmt type)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1558 
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
