### PR TITLE
Issue 1671 clear Go Report card issues/warnings in membersrvc

### DIFF
--- a/membersrvc/ca/eca.go
+++ b/membersrvc/ca/eca.go
@@ -418,7 +418,7 @@ func (ecaa *ECAA) ReadUserSet(ctx context.Context, in *pb.ReadUserSetReq) (*pb.U
 			var role int
 
 			err = rows.Scan(&id, &role)
-			users = append(users, &pb.User{&pb.Identity{Id : id}, pb.Role(role)})
+			users = append(users, &pb.User{&pb.Identity{Id: id}, pb.Role(role)})
 		}
 		err = rows.Err()
 	}

--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -322,7 +322,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, in *pb.TCertCreateSe
 		set = append(set, &pb.TCert{raw, ks})
 	}
 
-	return &pb.TCertCreateSetResp{Certs: &pb.CertSet{ Ts: in.Ts, Id: in.Id, Key: kdfKey, Certs: set}}, nil
+	return &pb.TCertCreateSetResp{Certs: &pb.CertSet{Ts: in.Ts, Id: in.Id, Key: kdfKey, Certs: set}}, nil
 }
 
 // Generate encrypted extensions to be included into the TCert (TCertIndex, EnrollmentID and attributes).

--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -36,9 +36,9 @@ import (
 	"path/filepath"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	"github.com/hyperledger/fabric/core/util"
-	"github.com/hyperledger/fabric/core/crypto/primitives"
 	membersrvc "github.com/hyperledger/fabric/membersrvc/protos"
 
 	_ "fmt"
@@ -125,7 +125,7 @@ func requestTLSCertificate(t *testing.T) {
 
 	pubraw, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
 	now := time.Now()
-	timestamp := google_protobuf.Timestamp{ Seconds: int64(now.Second()), Nanos: int32(now.Nanosecond())}
+	timestamp := google_protobuf.Timestamp{Seconds: int64(now.Second()), Nanos: int32(now.Nanosecond())}
 
 	req := &membersrvc.TLSCertCreateReq{
 		&timestamp,

--- a/membersrvc/ca/validity_period_test.go
+++ b/membersrvc/ca/validity_period_test.go
@@ -415,8 +415,11 @@ func stopOpenchain(t *testing.T) {
 	serverClient := pb.NewAdminClient(clientConn)
 
 	status, err := serverClient.StopServer(context.Background(), &google_protobuf.Empty{})
+	if err != nil {
+		t.Logf("Failed to stop: %v", err)
+		t.Fail()
+	}
 	t.Logf("Current status: %s", status)
-
 }
 
 func registerChaincodeSupport(chainname chaincode.ChainName, grpcServer *grpc.Server, secHelper crypto.Peer) {


### PR DESCRIPTION
Minor `gofmt` issues and not using a returned `err` value from StopServer() in one of the tests.
## Description

Ran `gofmt -s -w` on the "offending" files + calling `t.Logf()` + `t.Fail()` on  error.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1671
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
