### PR TITLE
Fix some of Issue 1309

### DIFF
--- a/peer/main.go
+++ b/peer/main.go
@@ -308,7 +308,7 @@ func main() {
 
 	// Init the crypto layer
 	if err := crypto.Init(); err != nil {
-		panic(fmt.Errorf("Failed initializing the crypto layer: %s", err))
+		panic(fmt.Errorf("Failed to initialize the crypto layer: %s", err))
 	}
 
 	// On failure Cobra prints the usage message and error string, so we only
@@ -436,7 +436,7 @@ func serve(args []string) error {
 		if core.SecurityEnabled() {
 			logger.Info("Privacy enabled status: true")
 		} else {
-			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+			panic(errors.New("Privacy cannot be enabled as requested because security is disabled"))
 		}
 	} else {
 		logger.Info("Privacy enabled status: false")
@@ -844,7 +844,7 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 			logger.Warning("Username supplied but security is disabled.")
 		}
 		if viper.GetBool("security.privacy") {
-			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+			panic(errors.New("Privacy cannot be enabled as requested because security is disabled"))
 		}
 	}
 

--- a/peer/main.go
+++ b/peer/main.go
@@ -432,7 +432,15 @@ func serve(args []string) error {
 	}
 
 	logger.Info("Security enabled status: %t", core.SecurityEnabled())
-	logger.Info("Privacy enabled status: %t", viper.GetBool("security.privacy"))
+	if viper.GetBool("security.privacy") {
+		if core.SecurityEnabled() {
+			logger.Info("Privacy enabled status: true")
+		} else {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+		}
+	} else {
+		logger.Info("Privacy enabled status: false")
+	}
 
 	var opts []grpc.ServerOption
 	if comm.TLSEnabled() {
@@ -831,6 +839,13 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 			// Unexpected error
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
 		}
+	} else {
+		if chaincodeUsr != undefinedParamValue {
+			logger.Warning("Username supplied but security is disabled.")
+		}
+		if viper.GetBool("security.privacy") {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+		}
 	}
 
 	chaincodeDeploymentSpec, err := devopsClient.Deploy(context.Background(), spec)
@@ -920,6 +935,13 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 			}
 			// Unexpected error
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
+		}
+	} else {
+		if chaincodeUsr != undefinedParamValue {
+			logger.Warning("Username supplied but security is disabled.")
+		}
+		if viper.GetBool("security.privacy") {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
 		}
 	}
 

--- a/peer/main.go
+++ b/peer/main.go
@@ -430,7 +430,15 @@ func serve(args []string) error {
 	}
 
 	logger.Info("Security enabled status: %t", core.SecurityEnabled())
-	logger.Info("Privacy enabled status: %t", viper.GetBool("security.privacy"))
+	if viper.GetBool("security.privacy") {
+		if core.SecurityEnabled() {
+			logger.Info("Privacy enabled status: true")
+		} else {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+		}
+	} else {
+		logger.Info("Privacy enabled status: false")
+	}
 
 	var opts []grpc.ServerOption
 	if peer.TlsEnabled() {
@@ -829,6 +837,13 @@ func chaincodeDeploy(cmd *cobra.Command, args []string) (err error) {
 			// Unexpected error
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
 		}
+	} else {
+		if chaincodeUsr != undefinedParamValue {
+			logger.Warning("Username supplied but security is disabled.")
+		}
+		if viper.GetBool("security.privacy") {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+		}
 	}
 
 	chaincodeDeploymentSpec, err := devopsClient.Deploy(context.Background(), spec)
@@ -918,6 +933,13 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 			}
 			// Unexpected error
 			panic(fmt.Errorf("Fatal error when checking for client login token: %s\n", err))
+		}
+	} else {
+		if chaincodeUsr != undefinedParamValue {
+			logger.Warning("Username supplied but security is disabled.")
+		}
+		if viper.GetBool("security.privacy") {
+			logger.Error("Privacy cannot be enabled as requested because security is disabled")
 		}
 	}
 

--- a/peer/main.go
+++ b/peer/main.go
@@ -941,7 +941,7 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 			logger.Warning("Username supplied but security is disabled.")
 		}
 		if viper.GetBool("security.privacy") {
-			logger.Error("Privacy cannot be enabled as requested because security is disabled")
+			panic(errors.New("Privacy cannot be enabled as requested because security is disabled"))
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This PR makes the peer command fail when it is configured to enable privacy while security is off and spit out a warning if a username is provided with security is off.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Addresses some of issue #1309
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

```
$ CORE_SECURITY_ENABLED=false CORE_SECURITY_PRIVACY=true ./peer node start
23:35:42.864 [crypto] main -> INFO 001 Log level recognized 'info', set to INFO
23:35:42.876 [main] serve -> INFO 003 Security enabled status: false
panic: Privacy cannot be enabled as requested because security is disabled

goroutine 1 [running]:
panic(0xd033e0, 0xc820246960)
        /opt/go/src/runtime/panic.go:464 +0x3e6
main.serve(0x155ca10, 0x0, 0x0, 0x0, 0x0)
        /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:439 +0x1c62
main.glob.func3(0x151f160, 0x155ca10, 0x0, 0x0, 0x0, 0x0)
        /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:96 +0x41
github.com/hyperledger/fabric/vendor/github.com/spf13/cobra.(*Command).execute(0x151f160, 0x155ca10, 0x0, 0x0, 0x0, 0x0)
        /opt/gopath/src/github.com/hyperledger/fabric/vendor/github.com/spf13/cobra/command.go:497 +0x62c
github.com/hyperledger/fabric/vendor/github.com/spf13/cobra.(*Command).Execute(0x151ede0, 0x0, 0x0)
        /opt/gopath/src/github.com/hyperledger/fabric/vendor/github.com/spf13/cobra/command.go:584 +0x46a
main.main()
        /opt/gopath/src/github.com/hyperledger/fabric/peer/main.go:316 +0x18d9

```

```
$ CORE_SECURITY_ENABLED=false ./peer chaincode deploy -u jim -n mycc -c '{"Function":"init", "Args": ["a","100", "b", "200"]}'
23:43:02.942 [crypto] main -> INFO 001 Log level recognized 'info', set to INFO
23:43:02.958 [main] chaincodeDeploy -> WARN 002 Username supplied but security is disabled.
mycc

```
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:Arnaud J Le Hors lehors@us.ibm.com
