### PR TITLE
use a separate lock for grpc send operatons

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -71,6 +71,8 @@ type nextStateInfo struct {
 // Handler responsbile for management of Peer's side of chaincode stream
 type Handler struct {
 	sync.RWMutex
+	//peer to shim grpc serializer. User only in serialSend
+	serialLock  sync.RWMutex
 	ChatStream  ccintf.ChaincodeStream
 	FSM         *fsm.FSM
 	ChaincodeID *pb.ChaincodeID
@@ -102,8 +104,8 @@ func shortuuid(uuid string) string {
 }
 
 func (handler *Handler) serialSend(msg *pb.ChaincodeMessage) error {
-	handler.Lock()
-	defer handler.Unlock()
+	handler.serialLock.Lock()
+	defer handler.serialLock.Unlock()
 	if err := handler.ChatStream.Send(msg); err != nil {
 		chaincodeLogger.Error(fmt.Sprintf("Error sending %s: %s", msg.Type.String(), err))
 		return fmt.Errorf("Error sending %s: %s", msg.Type.String(), err)

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -72,7 +72,7 @@ type nextStateInfo struct {
 type Handler struct {
 	sync.RWMutex
 	//peer to shim grpc serializer. User only in serialSend
-	serialLock  sync.RWMutex
+	serialLock  sync.Mutex
 	ChatStream  ccintf.ChaincodeStream
 	FSM         *fsm.FSM
 	ChaincodeID *pb.ChaincodeID

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -46,7 +46,7 @@ func (handler *Handler) triggerNextState(msg *pb.ChaincodeMessage, send bool) {
 type Handler struct {
 	sync.RWMutex
 	//shim to peer grpc serializer. User only in serialSend
-	serialLock sync.RWMutex
+	serialLock sync.Mutex
 	To         string
 	ChatStream PeerChaincodeStream
 	FSM        *fsm.FSM

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -45,6 +45,8 @@ func (handler *Handler) triggerNextState(msg *pb.ChaincodeMessage, send bool) {
 // Handler handler implementation for shim side of chaincode.
 type Handler struct {
 	sync.RWMutex
+	//shim to peer grpc serializer. User only in serialSend
+	serialLock sync.RWMutex
 	To         string
 	ChatStream PeerChaincodeStream
 	FSM        *fsm.FSM
@@ -65,8 +67,8 @@ func shortuuid(uuid string) string {
 }
 
 func (handler *Handler) serialSend(msg *pb.ChaincodeMessage) error {
-	handler.Lock()
-	defer handler.Unlock()
+	handler.serialLock.Lock()
+	defer handler.serialLock.Unlock()
 	if err := handler.ChatStream.Send(msg); err != nil {
 		chaincodeLogger.Error(fmt.Sprintf("[%s]Error sending %s: %s", shortuuid(msg.Uuid), msg.Type.String(), err))
 		return fmt.Errorf("Error sending %s: %s", msg.Type.String(), err)


### PR DESCRIPTION
Use a separate lock for protecting grpc sends instead of reusing global handler lock.
## Description

Chaincode and shim use locks for two purposes - protect handler state and protecting grpc sends. Using the same lock for both creates a problem when the grpc channel is full and the send blocks on the receiver to drain. Overloading a lock could cause a deadlock across the grpc connection where the receiver in turn is blocked waiting for the lock taken by the blocked sender.

To emphasize, this would happen only when the channel buffers are full - such as when doing 1000's of queries concurrently. In the reported test (and the subsequent recreate) this occurs when sending when 2000+ concurrent queries to a chaincode.
## Motivation and Context

Use of a separate lock for protecting grpc sends allows concurrent requests to be processed without fear of deadlock. 

Fixes #1627
## How Has This Been Tested?

Modified TestExecuteQuery to do upto 10000 concurrent queries. While even 2000+ queries failed without the fix 10000 queries succeeded in every attempt.

A test case was NOT created for the following reasons
- The problem manifests only in high stress situation.  Currently there is no process for adding long running stress unit or behave tests
- Current tests provide code coverage for the changes
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
