### PR TITLE
code coverage for go unit-tests using -cover flag

### DIFF
--- a/scripts/goUnitTests.sh
+++ b/scripts/goUnitTests.sh
@@ -16,4 +16,4 @@ trap cleanup 0
 echo "DONE!"
 
 echo "Running tests..."
-go test -timeout=20m $PKGS
+go test -cover -timeout=20m $PKGS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Updated go unit-test command with `-cover` flag (this provides coverage report to all the unit-tests performing with `go test -cover -timeout=20m $PKGS` command)
## Description

<!--- Describe your changes in detail. -->

Provides code coverage report to all the fabric unit-tests.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Tested this change in inside vagrant and Travis environments.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: thoomu@us.ibm.com
