### PR TITLE
Multi rootnode support

### DIFF
--- a/core/discovery.go
+++ b/core/discovery.go
@@ -16,9 +16,34 @@ limitations under the License.
 
 package core
 
-import "github.com/spf13/viper"
+import (
+	"math/rand"
+	"strings"
+	"time"
+)
 
-// GetRootNode place holder function for providing a boostrap address for a Validating Peer.
-func GetRootNode() (string, error) {
-	return viper.GetString("peer.discovery.rootnode"), nil
+// StaticDiscovery is an implementation of Discovery
+type StaticDiscovery struct {
+	rootNodes []string
+	random    *rand.Rand
+}
+
+// NewStaticDiscovery is a constructor of a Discovery implementation
+// Accepts as a parameter the root node configuration, which is a single node,
+// or a comma separated list of nodes with no spaces
+func NewStaticDiscovery(rootNodesString string) *StaticDiscovery {
+	sd := StaticDiscovery{}
+	sd.rootNodes = strings.Split(rootNodesString, ",")
+	sd.random = rand.New(rand.NewSource(time.Now().Unix()))
+	return &sd
+}
+
+// GetRandomNode returns a random root node out of the nodes the discovery was initialized with
+func (sd *StaticDiscovery) GetRandomNode() string {
+	return sd.rootNodes[sd.random.Intn(len(sd.rootNodes))]
+}
+
+// GetRootNodes returns an array of all the nodes it was initialized with
+func (sd *StaticDiscovery) GetRootNodes() []string {
+	return append([]string{}, sd.rootNodes...)
 }

--- a/core/discovery_test.go
+++ b/core/discovery_test.go
@@ -16,14 +16,81 @@ limitations under the License.
 
 package core
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestDiscovery_GetRootNode(t *testing.T) {
-	rootNode, err := GetRootNode()
-	if err != nil {
-		t.Fail()
-		t.Logf("Error getting rootnode:  %s", err)
+	d "github.com/hyperledger/fabric/discovery"
+)
+
+func TestDiscovery_GetEmptyRootNode(t *testing.T) {
+	assertRandomRootNode(t, "", NewStaticDiscovery(""))
+}
+
+func TestDiscovery_GetEmptyRootNodes(t *testing.T) {
+	discovery := NewStaticDiscovery("")
+	rootNodes := discovery.GetRootNodes()
+	if size := len(rootNodes); size != 1 || rootNodes[0] != "" {
+		t.Fatalf("Needed input is not ['']")
 	}
-	t.Logf("RootNode value: %s", rootNode)
+}
 
+func TestDiscovery_GetSinglePeer(t *testing.T) {
+	assertRandomRootNode(t, "someHost", NewStaticDiscovery("someHost"))
+}
+
+func TestDiscovery_GetAllPeers(t *testing.T) {
+	s := "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"
+	discovery := NewStaticDiscovery(s)
+	rootNodes := discovery.GetRootNodes()
+
+	expectedArrSize := strings.Count(s, ",") + 1
+	if len(rootNodes) != expectedArrSize {
+		t.Fatalf("Rootnodes length should have been %d but is %d", expectedArrSize, len(rootNodes))
+		return
+	}
+
+	for _, rootNode := range rootNodes {
+		if !strings.Contains(s, rootNode) {
+			t.Fatalf("%s is not a rootNode of [%s]", rootNode, s)
+		}
+	}
+}
+
+func TestDiscovery_GetMulti(t *testing.T) {
+	assertRootNodeRandomValues(t, []string{"a", "b", "c", "d", "e"}, NewStaticDiscovery("a,b,c,d,e"))
+}
+
+func assertRandomRootNode(t *testing.T, expected string, discovery d.Discovery) {
+	rootNode := discovery.GetRandomNode()
+
+	if rootNode != expected {
+		t.Fatalf("RootNode's value should be '%s'", expected)
+	}
+}
+
+func assertRootNodeRandomValues(t *testing.T, expected []string, discovery d.Discovery) {
+	rootNode := discovery.GetRandomNode()
+
+	if !inArray(rootNode, expected) {
+		t.Fatalf("RootNode's value should be one of '%v'", expected)
+	}
+
+	// Now test that a random value is sometimes returned
+	for i := 0; i < 100; i++ {
+		if val := discovery.GetRandomNode(); rootNode != val {
+			return
+		}
+	}
+	t.Fatalf("returned value was always %s", rootNode)
+
+}
+
+func inArray(element string, array []string) bool {
+	for _, val := range array {
+		if val == element {
+			return true
+		}
+	}
+	return false
 }

--- a/core/peer/config.go
+++ b/core/peer/config.go
@@ -45,7 +45,6 @@ var configurationCached = false
 // getValidatorStreamAddress(), and getPeerEndpoint()
 var localAddress string
 var localAddressError error
-var validatorStreamAddress string
 var peerEndpoint *pb.PeerEndpoint
 var peerEndpointError error
 
@@ -83,17 +82,6 @@ func CacheConfiguration() (err error) {
 		return
 	}
 
-	// getValidatorStreamAddress returns the address to stream requests to
-	getValidatorStreamAddress := func() string {
-		localaddr, _ := getLocalAddress()
-		if viper.GetBool("peer.validator.enabled") { // in validator mode, send your own address
-			return localaddr
-		} else if valaddr := viper.GetString("peer.discovery.rootnode"); valaddr != "" {
-			return valaddr
-		}
-		return localaddr
-	}
-
 	// getPeerEndpoint returns the PeerEndpoint for this Peer instance.  Affected by env:peer.addressAutoDetect
 	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
 		var peerAddress string
@@ -112,7 +100,6 @@ func CacheConfiguration() (err error) {
 
 	localAddress, localAddressError = getLocalAddress()
 	peerEndpoint, peerEndpointError = getPeerEndpoint()
-	validatorStreamAddress = getValidatorStreamAddress()
 
 	syncStateSnapshotChannelSize = viper.GetInt("peer.sync.state.snapshot.channelSize")
 	syncStateDeltasChannelSize = viper.GetInt("peer.sync.state.deltas.channelSize")
@@ -148,14 +135,6 @@ func GetLocalAddress() (string, error) {
 	return localAddress, localAddressError
 }
 
-func getValidatorStreamAddress() string {
-	if !configurationCached {
-		cacheConfiguration()
-	}
-	return validatorStreamAddress
-}
-
-// GetPeerEndpoint returns the PeerEndpoint for this peer
 func GetPeerEndpoint() (*pb.PeerEndpoint, error) {
 	if !configurationCached {
 		cacheConfiguration()

--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 	"github.com/hyperledger/fabric/core/ledger/statemgmt/state"
 	"github.com/hyperledger/fabric/core/util"
+	"github.com/hyperledger/fabric/discovery"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -51,6 +52,8 @@ type Peer interface {
 type BlocksRetriever interface {
 	RequestBlocks(*pb.SyncBlockRange) (<-chan *pb.SyncBlocks, error)
 }
+
+type token struct{}
 
 // StateRetriever interface for retrieving state deltas, etc.
 type StateRetriever interface {
@@ -186,6 +189,7 @@ type PeerImpl struct {
 	secHelper      crypto.Peer
 	engine         Engine
 	isValidator    bool
+	discoverySvc   discovery.Discovery
 }
 
 // TransactionProccesor responsible for processing of Transactions
@@ -202,8 +206,11 @@ type Engine interface {
 }
 
 // NewPeerWithHandler returns a Peer which uses the supplied handler factory function for creating new handlers on new Chat service invocations.
-func NewPeerWithHandler(secHelperFunc func() crypto.Peer, handlerFact HandlerFactory) (*PeerImpl, error) {
+func NewPeerWithHandler(secHelperFunc func() crypto.Peer, handlerFact HandlerFactory, discInstance discovery.Discovery) (*PeerImpl, error) {
 	peer := new(PeerImpl)
+
+	peer.discoverySvc = discInstance
+
 	if handlerFact == nil {
 		return nil, errors.New("Cannot supply nil handler factory")
 	}
@@ -224,13 +231,17 @@ func NewPeerWithHandler(secHelperFunc func() crypto.Peer, handlerFact HandlerFac
 		return nil, fmt.Errorf("Error constructing NewPeerWithHandler: %s", err)
 	}
 	peer.ledgerWrapper = &ledgerWrapper{ledger: ledgerPtr}
-	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
+
+	peer.chatWithSomePeers(peer.discoverySvc.GetRootNodes())
 	return peer, nil
 }
 
-// NewPeerWithEngine returns a Peer which uses the supplied engine factory function for creating new peer engine and getting handler factory from it for creating new handlers on new Chat service invocations.
-func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactory) (peer *PeerImpl, err error) {
+// NewPeerWithEngine returns a Peer which uses the supplied handler factory function for creating new handlers on new Chat service invocations.
+func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactory, discInstance discovery.Discovery) (peer *PeerImpl, err error) {
 	peer = new(PeerImpl)
+
+	peer.discoverySvc = discInstance
+
 	peer.handlerMap = &handlerMap{m: make(map[pb.PeerID]MessageHandler)}
 
 	peer.isValidator = ValidatorEnabled()
@@ -258,9 +269,10 @@ func NewPeerWithEngine(secHelperFunc func() crypto.Peer, engFactory EngineFactor
 	if peer.handlerFactory == nil {
 		return nil, errors.New("Cannot supply nil handler factory")
 	}
-
-	go peer.chatWithPeer(viper.GetString("peer.discovery.rootnode"))
+	rootNodes := peer.discoverySvc.GetRootNodes()
+	peer.chatWithSomePeers(rootNodes)
 	return peer, nil
+
 }
 
 // Chat implementation of the the Chat bidi streaming RPC function
@@ -328,7 +340,7 @@ func (p *PeerImpl) PeersDiscovered(peersMessage *pb.PeersMessage) error {
 			// NOOP
 		} else if _, ok := p.handlerMap.m[*getHandlerKeyFromPeerEndpoint(peerEndpoint)]; ok == false {
 			// Start chat with Peer
-			go p.chatWithPeer(peerEndpoint.Address)
+			p.chatWithSomePeers([]string{peerEndpoint.Address})
 		}
 	}
 	return nil
@@ -494,18 +506,50 @@ func (p *PeerImpl) sendTransactionsToLocalEngine(transaction *pb.Transaction) *p
 	return response
 }
 
-func (p *PeerImpl) chatWithPeer(peerAddress string) error {
-	if len(peerAddress) == 0 {
-		peerLogger.Debug("Starting up the first peer")
-		return nil // nothing to do
+// chatWithSomePeers initiates chat with 1 or all peers according to whether the node is a validator or not
+func (p *PeerImpl) chatWithSomePeers(peers []string) {
+
+	peerCountToChatWith := 1
+
+	if p.isValidator {
+		peerCountToChatWith = len(peers)
 	}
+
+	chatTokens := make(chan token, peerCountToChatWith)
+	for _, rootNode := range peers {
+		if len(rootNode) == 0 {
+			peerLogger.Debug("Starting up the first peer")
+			return // nothing to do
+		}
+		// Skip ourselves
+		if pe, err := GetPeerEndpoint(); err == nil {
+			if rootNode == pe.Address {
+				peerLogger.Debug(fmt.Sprintf("Skipping my own address(%v)", rootNode))
+				continue
+			}
+		} else {
+			peerLogger.Error("Failed obtaining peer endpoint, %v", err)
+			return
+		}
+
+		go p.chatWithPeer(rootNode, chatTokens)
+	}
+}
+
+func (p *PeerImpl) chatWithPeer(peerAddress string, chatTokens chan token) error {
 	for {
 		time.Sleep(1 * time.Second)
+
+		// acquire token
+		chatTokens <- token{}
+
 		peerLogger.Debug("Initiating Chat with peer address: %s", peerAddress)
 		conn, err := NewPeerClientConnectionWithAddress(peerAddress)
 		if err != nil {
 			e := fmt.Errorf("Error creating connection to peer address=%s:  %s", peerAddress, err)
 			peerLogger.Error(e.Error())
+			// relinquish token
+			<-chatTokens
 			continue
 		}
 		serverClient := pb.NewPeerClient(conn)
@@ -514,9 +558,12 @@ func (p *PeerImpl) chatWithPeer(peerAddress string) error {
 		if err != nil {
 			e := fmt.Errorf("Error establishing chat with peer address=%s:  %s", peerAddress, err)
 			peerLogger.Error(fmt.Sprintf("%s", e.Error()))
+			// relinquish token
+			<-chatTokens
 			continue
 		}
 		peerLogger.Debug("Established Chat with peer address: %s", peerAddress)
+
 		err = p.handleChat(ctx, stream, true)
 		stream.CloseSend()
 		if err != nil {
@@ -561,7 +608,7 @@ func (p *PeerImpl) ExecuteTransaction(transaction *pb.Transaction) (response *pb
 	if p.isValidator {
 		response = p.sendTransactionsToLocalEngine(transaction)
 	} else {
-		peerAddress := getValidatorStreamAddress()
+		peerAddress := p.discoverySvc.GetRandomNode()
 		response = p.SendTransactionsToPeer(peerAddress, transaction)
 	}
 	return response

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,31 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package discovery
+
+// Discovery is the interface that consolidates bootstrap peer membership selection
+// and validating peer selection for non validating peers
+type Discovery interface {
+
+	// GetRootNode function for providing a random bootstrap address for a peer
+	GetRandomNode() string
+
+	// GetRootNode function for providing all bootstrap addresses for a peer
+	GetRootNodes() []string
+}

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -197,6 +197,7 @@ peer:
 
         # The root nodes are used for bootstrapping purposes, and generally
         # supplied through ENV variables
+        # It can be either a single host or a comma separated list of hosts.
         rootnode:
 
         # The duration of time between attempts to asks peers for their connected peers

--- a/peer/main.go
+++ b/peer/main.go
@@ -401,6 +401,7 @@ func serve(args []string) error {
 		viper.Set("ledger.blockchain.deploy-system-chaincode", "false")
 		viper.Set("validator.validity-period.verification", "false")
 	}
+
 	if err := peer.CacheConfiguration(); err != nil {
 		return err
 	}
@@ -458,6 +459,8 @@ func serve(args []string) error {
 
 	var peerServer *peer.PeerImpl
 
+	discInstance := core.NewStaticDiscovery(viper.GetString("peer.discovery.rootnode"))
+
 	//create the peerServer....
 	if peer.ValidatorEnabled() {
 		logger.Debug("Running as validating peer - making genesis block if needed")
@@ -466,10 +469,10 @@ func serve(args []string) error {
 			return makeGenesisError
 		}
 		logger.Debug("Running as validating peer - installing consensus %s", viper.GetString("peer.validator.consensus"))
-		peerServer, err = peer.NewPeerWithEngine(secHelperFunc, helper.GetEngine)
+		peerServer, err = peer.NewPeerWithEngine(secHelperFunc, helper.GetEngine, discInstance)
 	} else {
 		logger.Debug("Running as non-validating peer")
-		peerServer, err = peer.NewPeerWithHandler(secHelperFunc, peer.NewPeerHandler)
+		peerServer, err = peer.NewPeerWithHandler(secHelperFunc, peer.NewPeerHandler, discInstance)
 	}
 
 	if err != nil {
@@ -503,14 +506,11 @@ func serve(args []string) error {
 		go rest.StartOpenchainRESTServer(serverOpenchain, serverDevops)
 	}
 
-	rootNode, err := core.GetRootNode()
-	if err != nil {
-		grpclog.Fatalf("Failed to get peer.discovery.rootnode valey: %s", err)
-	}
+	rootNodes := discInstance.GetRootNodes()
 
-	logger.Info("Starting peer with id=%s, network id=%s, address=%s, discovery.rootnode=%s, validator=%v",
+	logger.Info("Starting peer with id=%s, network id=%s, address=%s, discovery.rootnode=[%v], validator=%v",
 		peerEndpoint.ID, viper.GetString("peer.networkId"),
-		peerEndpoint.Address, rootNode, peer.ValidatorEnabled())
+		peerEndpoint.Address, rootNodes, peer.ValidatorEnabled())
 
 	// Start the grpc server. Done in a goroutine so we can deploy the
 	// genesis block if needed.


### PR DESCRIPTION
Added support for multiple RootNodes (bootstrap peers)

Original discussion was [here](https://github.com/hyperledger/fabric/pull/1482)
## Description

All peers can now start with an array of root nodes instead of a single one, for example (from core.yaml): 

```
    discovery:

        # The root nodes are used for bootstrapping purposes, and generally
        # supplied through ENV variables
        # It can be either a single host or a comma separated list of hosts.
        rootnode: 172.17.0.2,172.17.0.3
```

This removes the SPOF of having a peer depend on a single root node for joining the cluster.
The method that supports this is GetRootNodes() // notice the plural form //
The original GetRootNode() method is not present anymore and instead is replaced by GetRandomNode() which returns a random root node. 
- In addition, NVP nodes now query a random validating peer out of the root node list instead of the same one each time
- In terms of discovery process, validating peers now connect to all root nodes at startup, and non-validating peers seek a servicing peer to connect to.
## How Has This Been Tested?

Ran 4 VPs and 1 NVP and invoked transactions through the VPs and NVP and ensured via reading the logs that NVP selects a random node each time, and VP calls itself and doesn't forward, and also ensured that membership view is full for all nodes via querying the REST endpoint /network/peers for all nodes. 
- Ran the unit tests (go test -timeout=20m $(go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/))
- Behave tests ran by Travis
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] I have run [gofmt](https://golang.org/cmd/gofmt/), and [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and have resolved all errors and warnings.
- [x] I updated the comments in the core.yaml file
- [x] I have added tests to cover my changes.  

Signed-off-by: Yacov Manevich yacov88m@gmail.com   
