### PR TITLE
Remove hacky sendViewChangedEvent

### DIFF
--- a/consensus/obcpbft/events_test.go
+++ b/consensus/obcpbft/events_test.go
@@ -36,9 +36,11 @@ func (mr *mockReceiver) processEvent(event interface{}) interface{} {
 }
 
 func newMockManager(processEvent func(event interface{}) interface{}) eventManager {
-	return newEventManagerImpl(&mockReceiver{
+	manager := newEventManagerImpl()
+	manager.setReceiver(&mockReceiver{
 		processEventImpl: processEvent,
 	})
+	return manager
 }
 
 // Starts an event timer, waits for the event to be delivered

--- a/consensus/obcpbft/fuzz_test.go
+++ b/consensus/obcpbft/fuzz_test.go
@@ -60,13 +60,13 @@ func TestFuzz(t *testing.T) {
 	logging.SetBackend(logging.InitForTesting(logging.ERROR))
 
 	mock := newFuzzMock()
-	primary := newPbftCore(0, loadConfig(), mock)
-	primary.manager.start()
+	primary, pmanager := createRunningPbftWithManager(0, loadConfig(), mock)
 	defer primary.close()
+	defer pmanager.halt()
 	mock = newFuzzMock()
-	backup := newPbftCore(1, loadConfig(), mock)
-	backup.manager.start()
+	backup, bmanager := createRunningPbftWithManager(1, loadConfig(), mock)
 	defer backup.close()
+	defer bmanager.halt()
 
 	f := fuzz.New()
 
@@ -95,8 +95,8 @@ func TestFuzz(t *testing.T) {
 			senderID = nv.ReplicaId
 		}
 
-		primary.manager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
-		backup.manager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
+		pmanager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
+		bmanager.queue() <- &pbftMessageEvent{msg: msg, sender: senderID}
 	}
 
 	logging.Reset()
@@ -162,7 +162,7 @@ func TestMinimalFuzz(t *testing.T) {
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
 		for _, ep := range net.endpoints {
-			ep.(*pbftEndpoint).pbft.manager.queue() <- &pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
+			ep.(*pbftEndpoint).manager.queue() <- &pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 		}
 		if err != nil {
 			t.Fatalf("Request failed: %s", err)

--- a/consensus/obcpbft/legacyshim.go
+++ b/consensus/obcpbft/legacyshim.go
@@ -31,20 +31,30 @@ import (
 	"github.com/spf13/viper"
 )
 
+type legacyInnerStack interface {
+	innerStack
+	viewChange(curView uint64)
+}
+
 type legacyGenericShim struct {
 	*obcGeneric
-	pbft legacyPbftShim
+	pbft *legacyPbftShim
 }
 
 type legacyPbftShim struct {
 	*pbftCore
-	manager eventManager // Used to give the pbft core work
+	consumer legacyInnerStack
+	manager  eventManager // Used to give the pbft core work
 }
 
-func (shim *legacyGenericShim) init(id uint64, config *viper.Viper, consumer innerStack) {
-	shim.pbft.manager = newEventManagerImpl()
+func (shim *legacyGenericShim) init(id uint64, config *viper.Viper, consumer legacyInnerStack) {
+	shim.pbft = &legacyPbftShim{
+		manager:  newEventManagerImpl(),
+		consumer: consumer,
+	}
 	shim.pbft.pbftCore = newPbftCore(id, config, consumer, newEventTimerFactoryImpl(shim.pbft.manager))
 	shim.pbft.manager.setReceiver(shim.pbft)
+	logger.Debug("Replica %d Consumer is %p", shim.pbft.id, shim.pbft.consumer)
 	shim.pbft.manager.start()
 	logger.Debug("Replica %d legacyGenericShim now initialized: %v", id, shim)
 }
@@ -60,13 +70,25 @@ func (shim *legacyGenericShim) getManager() eventManager {
 	return shim.pbft.manager
 }
 
+// processEvent intercepts the events bound for PBFT to implement the legacy innerStack methods
+func (instance *legacyPbftShim) processEvent(e interface{}) interface{} {
+	switch e.(type) {
+	case viewChangedEvent:
+		logger.Debug("ASDF Replica %d Consumer is %p", instance.id, instance.consumer)
+		instance.consumer.viewChange(instance.view)
+	default:
+		return instance.pbftCore.processEvent(e)
+	}
+	return nil
+}
+
 // execDone is an event telling us that the last execution has completed
-func (instance legacyPbftShim) execDone() {
+func (instance *legacyPbftShim) execDone() {
 	instance.manager.queue() <- execDoneEvent{}
 }
 
 // stateUpdated is an event telling us that the application fast-forwarded its state
-func (instance legacyPbftShim) stateUpdated(seqNo uint64, id []byte) {
+func (instance *legacyPbftShim) stateUpdated(seqNo uint64, id []byte) {
 	logger.Debug("Replica %d queueing message that it has caught up via state transfer", instance.id)
 	instance.manager.queue() <- stateUpdatedEvent{
 		seqNo: seqNo,
@@ -75,7 +97,7 @@ func (instance legacyPbftShim) stateUpdated(seqNo uint64, id []byte) {
 }
 
 // stateUpdating is an event telling us that the application is fast-forwarding its state
-func (instance legacyPbftShim) stateUpdating(seqNo uint64, id []byte) {
+func (instance *legacyPbftShim) stateUpdating(seqNo uint64, id []byte) {
 	logger.Debug("Replica %d queueing message that state transfer has been initiated", instance.id)
 	instance.manager.queue() <- stateUpdatingEvent{
 		seqNo: seqNo,
@@ -84,7 +106,7 @@ func (instance legacyPbftShim) stateUpdating(seqNo uint64, id []byte) {
 }
 
 // handle new consensus requests
-func (instance legacyPbftShim) request(msgPayload []byte, senderID uint64) error {
+func (instance *legacyPbftShim) request(msgPayload []byte, senderID uint64) error {
 	msg := &Message{&Message_Request{&Request{Payload: msgPayload,
 		ReplicaId: senderID}}}
 	instance.manager.queue() <- pbftMessageEvent{
@@ -95,7 +117,7 @@ func (instance legacyPbftShim) request(msgPayload []byte, senderID uint64) error
 }
 
 // handle internal consensus messages
-func (instance legacyPbftShim) receive(msgPayload []byte, senderID uint64) error {
+func (instance *legacyPbftShim) receive(msgPayload []byte, senderID uint64) error {
 	msg := &Message{}
 	err := proto.Unmarshal(msgPayload, msg)
 	if err != nil {
@@ -111,7 +133,7 @@ func (instance legacyPbftShim) receive(msgPayload []byte, senderID uint64) error
 }
 
 // TODO, this should not return an error
-func (instance legacyPbftShim) recvMsgSync(msg *Message, senderID uint64) (err error) {
+func (instance *legacyPbftShim) recvMsgSync(msg *Message, senderID uint64) (err error) {
 	instance.manager.queue() <- pbftMessageEvent{
 		msg:    msg,
 		sender: senderID,
@@ -121,6 +143,6 @@ func (instance legacyPbftShim) recvMsgSync(msg *Message, senderID uint64) (err e
 
 // Allows the caller to inject work onto the main thread
 // This is useful when the caller wants to safely manipulate PBFT state
-func (instance legacyPbftShim) inject(work func()) {
+func (instance *legacyPbftShim) inject(work func()) {
 	instance.manager.queue() <- workEvent(work)
 }

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -52,7 +52,7 @@ func (ce *consumerEndpoint) isBusy() bool {
 	}
 
 	select {
-	case ce.consumer.getPBFTCore().manager.queue() <- nil:
+	case ce.consumer.getManager().queue() <- nil:
 		ce.net.debugMsg("Reporting busy because pbft not idle\n")
 	default:
 		return true
@@ -102,6 +102,7 @@ type pbftConsumer interface {
 	innerStack
 	consensus.Consenter
 	getPBFTCore() *pbftCore
+	getManager() eventManager // TODO, remove, this is a temporary measure
 	Close()
 	idleChannel() <-chan struct{}
 }

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -125,10 +125,10 @@ func (op *obcBatch) submitToLeader(req *Request) event {
 	leader := op.pbft.primary(op.pbft.view)
 	if leader == op.pbft.id && op.pbft.activeView {
 		return op.leaderProcReq(req)
-	} else {
-		op.unicastMsg(&BatchMessage{&BatchMessage_Request{req}}, leader)
-		return nil
 	}
+
+	op.unicastMsg(&BatchMessage{&BatchMessage_Request{req}}, leader)
+	return nil
 }
 
 func (op *obcBatch) broadcastMsg(msg *BatchMessage) {
@@ -364,9 +364,9 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 		logger.Debug("Batch replica %d received complaint %s", op.pbft.id, hash)
 
 		return op.submitToLeader(complaint)
-	} else {
-		logger.Error("Unknown request: %+v", batchMsg)
 	}
+
+	logger.Error("Unknown request: %+v", batchMsg)
 
 	return nil
 }

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -240,10 +240,6 @@ func (op *obcBatch) executeImpl(seqNo uint64, raw []byte) {
 	op.pbft.execDoneSync()
 }
 
-func (op *obcBatch) viewChange(curView uint64) {
-	// TODO, remove
-}
-
 // =============================================================================
 // functions specific to batch mode
 // =============================================================================

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -40,6 +40,8 @@ type obcBatch struct {
 	batchTimeout     time.Duration
 	inViewChange     bool
 
+	manager eventManager // TODO, remove eventually, the event manager
+
 	incomingChan chan *batchMessage // Queues messages for processing by main thread
 	idleChan     chan struct{}      // Idle channel, to be removed
 
@@ -76,13 +78,14 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 
 	logger.Debug("Replica %d obtaining startup information", id)
 
-	op.pbft = newPbftCore(id, config, op)
-	op.pbft.manager = newEventManagerImpl(op) // TODO, this is hacky, eventually rip it out
-	etf := newEventTimerFactoryImpl(op.pbft.manager)
+	op.manager = newEventManagerImpl() // TODO, this is hacky, eventually rip it out
+	op.manager.setReceiver(op)
+	etf := newEventTimerFactoryImpl(op.manager)
+	op.pbft = newPbftCore(id, config, op, etf)
 	op.pbft.newViewTimer.halt()
 	op.pbft.newViewTimer = etf.createTimer()
-	op.pbft.manager.start()
-	op.externalEventReceiver.manager = op.pbft.manager
+	op.manager.start()
+	op.externalEventReceiver.manager = op.manager
 
 	op.batchSize = config.GetInt("general.batchSize")
 	op.batchStore = nil
@@ -107,7 +110,7 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 // Complain is necessary to implement complaintHandler
 func (op *obcBatch) Complain(hash string, req *Request, primaryFail bool) {
 	c := complaintEvent{hash, req, primaryFail}
-	op.pbft.manager.queue() <- c
+	op.manager.queue() <- c
 }
 
 // Close tells us to release resources we are holding
@@ -117,13 +120,14 @@ func (op *obcBatch) Close() {
 	op.pbft.close()
 }
 
-func (op *obcBatch) submitToLeader(req *Request) {
+func (op *obcBatch) submitToLeader(req *Request) event {
 	// submit to current leader
 	leader := op.pbft.primary(op.pbft.view)
 	if leader == op.pbft.id && op.pbft.activeView {
-		op.leaderProcReq(req)
+		return op.leaderProcReq(req)
 	} else {
 		op.unicastMsg(&BatchMessage{&BatchMessage_Request{req}}, leader)
+		return nil
 	}
 }
 
@@ -190,7 +194,7 @@ func (op *obcBatch) validate(txRaw []byte) error {
 
 // execute an opaque request which corresponds to an OBC Transaction
 func (op *obcBatch) execute(seqNo uint64, raw []byte) {
-	op.pbft.manager.queue() <- batchExecEvent{
+	op.manager.queue() <- batchExecEvent{
 		seqNo: seqNo,
 		raw:   raw,
 	}
@@ -244,7 +248,7 @@ func (op *obcBatch) viewChange(curView uint64) {
 // functions specific to batch mode
 // =============================================================================
 
-func (op *obcBatch) leaderProcReq(req *Request) error {
+func (op *obcBatch) leaderProcReq(req *Request) event {
 	// XXX check req sig
 
 	if !op.deduplicator.Request(req) {
@@ -263,13 +267,13 @@ func (op *obcBatch) leaderProcReq(req *Request) error {
 	}
 
 	if len(op.batchStore) >= op.batchSize {
-		op.sendBatch()
+		return op.sendBatch()
 	}
 
 	return nil
 }
 
-func (op *obcBatch) sendBatch() error {
+func (op *obcBatch) sendBatch() event {
 	op.stopBatchTimer()
 
 	reqBlock := &RequestBlock{op.batchStore}
@@ -277,16 +281,16 @@ func (op *obcBatch) sendBatch() error {
 
 	reqsPacked, err := proto.Marshal(reqBlock)
 	if err != nil {
-		err = fmt.Errorf("Unable to pack block for new batch request")
-		logger.Error(err.Error())
-		return err
+		logger.Error("Unable to pack block for new batch request")
+		return nil
 	}
 
 	// process internally
 	logger.Info("Creating batch with %d requests", len(reqBlock.Requests))
-	op.pbft.requestSync(reqsPacked, op.pbft.id)
-
-	return nil
+	return pbftMessageEvent{
+		msg:    &Message{&Message_Request{&Request{Payload: reqsPacked, ReplicaId: op.pbft.id}}},
+		sender: op.pbft.id,
+	}
 }
 
 func (op *obcBatch) txToReq(tx []byte) *Request {
@@ -303,40 +307,47 @@ func (op *obcBatch) txToReq(tx []byte) *Request {
 	return req
 }
 
-func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
+func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) event {
 	if ocMsg.Type == pb.Message_CHAIN_TRANSACTION {
 		req := op.txToReq(ocMsg.Payload)
 		hash := op.complainer.Custody(req)
 
 		logger.Info("Batch replica %d received new consensus request: %s", op.pbft.id, hash)
 
-		op.submitToLeader(req)
-		return nil
+		return op.submitToLeader(req)
 	}
 
 	if ocMsg.Type != pb.Message_CONSENSUS {
-		return fmt.Errorf("Unexpected message type: %s", ocMsg.Type)
+		logger.Error("Unexpected message type: %s", ocMsg.Type)
+		return nil
 	}
 
 	batchMsg := &BatchMessage{}
 	err := proto.Unmarshal(ocMsg.Payload, batchMsg)
 	if err != nil {
-		return err
+		logger.Error("Error unmarshaling message: %s", err)
+		return nil
 	}
 
 	if req := batchMsg.GetRequest(); req != nil {
 		if (op.pbft.primary(op.pbft.view) == op.pbft.id) && op.pbft.activeView {
-			err := op.leaderProcReq(req)
-			if err != nil {
-				return err
-			}
+			return op.leaderProcReq(req)
 		}
 	} else if pbftMsg := batchMsg.GetPbftMessage(); pbftMsg != nil {
 		senderID, err := getValidatorID(senderHandle) // who sent this?
 		if err != nil {
 			panic("Cannot map sender's PeerID to a valid replica ID")
 		}
-		op.pbft.receiveSync(pbftMsg, senderID)
+		msg := &Message{}
+		err = proto.Unmarshal(pbftMsg, msg)
+		if err != nil {
+			logger.Error("Error unpacking payload from message: %s", err)
+			return nil
+		}
+		return pbftMessageEvent{
+			msg:    msg,
+			sender: senderID,
+		}
 	} else if complaint := batchMsg.GetComplaint(); complaint != nil {
 		if op.pbft.primary(op.pbft.view) == op.pbft.id && op.pbft.activeView {
 			return op.leaderProcReq(complaint)
@@ -352,10 +363,9 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 		hash := op.complainer.Complaint(complaint)
 		logger.Debug("Batch replica %d received complaint %s", op.pbft.id, hash)
 
-		op.submitToLeader(complaint)
+		return op.submitToLeader(complaint)
 	} else {
-		err = fmt.Errorf("Unknown request: %+v", batchMsg)
-		logger.Error(err.Error())
+		logger.Error("Unknown request: %+v", batchMsg)
 	}
 
 	return nil
@@ -366,13 +376,13 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 // this request raced with a later one and lost, then we need to
 // repackage this request's payload into a new request and resubmit
 // it.
-func (op *obcBatch) resubmitStaleRequest(c complaintEvent) {
+func (op *obcBatch) resubmitStaleRequest(c complaintEvent) event {
 	oldReq := c.req.(*Request)
 
 	if !op.complainer.InCustody(oldReq) {
 		logger.Debug("Batch replica %d custody expired for stale request: %s",
 			op.pbft.id, c.hash)
-		return
+		return nil
 	}
 
 	newReq := op.txToReq(oldReq.Payload)
@@ -381,7 +391,7 @@ func (op *obcBatch) resubmitStaleRequest(c complaintEvent) {
 		op.pbft.id, hashReq(oldReq), hashReq(newReq))
 	op.complainer.Success(oldReq)
 	op.complainer.Custody(newReq)
-	op.submitToLeader(newReq)
+	return op.submitToLeader(newReq)
 }
 
 // allow the primary to send a batch when the timer expires
@@ -390,14 +400,11 @@ func (op *obcBatch) processEvent(event interface{}) interface{} {
 	switch et := event.(type) {
 	case batchMessageEvent:
 		ocMsg := et
-		if err := op.processMessage(ocMsg.msg, ocMsg.sender); nil != err {
-			logger.Error("Error processing message: %v", err)
-		}
-		return nil
+		return op.processMessage(ocMsg.msg, ocMsg.sender)
 	case batchTimerEvent:
 		logger.Info("Replica %d batch timer expired", op.pbft.id)
 		if op.pbft.activeView && (len(op.batchStore) > 0) {
-			op.sendBatch()
+			return op.sendBatch()
 		}
 	case viewChangedEvent:
 		// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
@@ -415,7 +422,7 @@ func (op *obcBatch) processEvent(event interface{}) interface{} {
 		op.complainer.Restart()
 		for _, pair := range op.complainer.CustodyElements() {
 			logger.Info("Replica %d resubmitting request under custody: %s", op.pbft.id, pair.Hash)
-			op.submitToLeader(pair.Request)
+			return op.submitToLeader(pair.Request)
 		}
 	case batchExecEvent:
 		execInfo := et
@@ -474,4 +481,9 @@ func (op *obcBatch) wrapMessage(msgPayload []byte) *pb.Message {
 // Retrieve the idle channel, only used for testing
 func (op *obcBatch) idleChannel() <-chan struct{} {
 	return op.idleChan
+}
+
+// TODO, temporary
+func (op *obcBatch) getManager() eventManager {
+	return op.manager
 }

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -186,13 +186,13 @@ func TestBatchStaleCustody(t *testing.T) {
 	req1 := createOcMsgWithChainTx(1)
 	op.RecvMsg(req1, &pb.PeerID{})
 	op.RecvMsg(createOcMsgWithChainTx(2), &pb.PeerID{})
-	op.pbft.manager.queue() <- nil
+	op.manager.queue() <- nil
 	op.pbft.currentExec = new(uint64) // so that pbft.execDone doesn't get unhappy
 	*op.pbft.currentExec = 1
 	rblock2raw, _ := proto.Marshal(&RequestBlock{[]*Request{reqs[1]}})
 	op.executeImpl(1, rblock2raw)
 	time.Sleep(500 * time.Millisecond)
-	op.pbft.manager.queue() <- nil
+	op.manager.queue() <- nil
 	if len(reqs) != 3 || !reflect.DeepEqual(reqs[2].Payload, req1.Payload) {
 		t.Error("expected resubmitted request")
 	}

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -37,16 +37,14 @@ type obcClassic struct {
 func newObcClassic(id uint64, config *viper.Viper, stack consensus.Stack) *obcClassic {
 	op := &obcClassic{
 		legacyGenericShim: legacyGenericShim{
-			obcGeneric: obcGeneric{stack: stack},
+			obcGeneric: &obcGeneric{stack: stack},
 		},
 	}
 
 	op.persistForward.persistor = stack
 
 	logger.Debug("Replica %d obtaining startup information", id)
-
-	op.pbft = legacyPbftShim{newPbftCore(id, config, op)}
-	op.pbft.manager.start()
+	op.legacyGenericShim.init(id, config, op)
 
 	op.idleChan = make(chan struct{})
 	close(op.idleChan)
@@ -82,11 +80,6 @@ func (op *obcClassic) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error 
 	op.pbft.receive(ocMsg.Payload, senderID)
 
 	return nil
-}
-
-// Close tells us to release resources we are holding
-func (op *obcClassic) Close() {
-	op.pbft.close()
 }
 
 // =============================================================================

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -75,7 +75,7 @@ type msgWithSender struct {
 func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSieve {
 	op := &obcSieve{
 		legacyGenericShim: legacyGenericShim{
-			obcGeneric: obcGeneric{stack: stack},
+			obcGeneric: &obcGeneric{stack: stack},
 		},
 		id: id,
 	}
@@ -84,8 +84,7 @@ func newObcSieve(id uint64, config *viper.Viper, stack consensus.Stack) *obcSiev
 
 	op.restoreBlockNumber()
 
-	op.pbft = legacyPbftShim{newPbftCore(id, config, op)}
-	op.pbft.manager.start()
+	op.legacyGenericShim.init(id, config, op)
 	op.complainer = newComplainer(op, op.pbft.requestTimeout, op.pbft.requestTimeout)
 	op.deduplicator = newDeduplicator()
 
@@ -209,7 +208,7 @@ func (op *obcSieve) RecvMsg(ocMsg *pb.Message, senderHandle *pb.PeerID) error {
 // Close tells us to release resources we are holding
 func (op *obcSieve) Close() {
 	op.complainer.Stop()
-	op.pbft.close()
+	op.legacyGenericShim.Close()
 }
 
 // called by pbft-core to multicast a message to all replicas

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -61,7 +61,6 @@ type innerStack interface {
 	getLastSeqNo() (uint64, error)
 	skipTo(seqNo uint64, snapshotID []byte, peers []uint64)
 	validate(txRaw []byte) error
-	viewChange(curView uint64)
 
 	sign(msg []byte) ([]byte, error)
 	verify(senderID uint64, signature []byte, message []byte) error
@@ -357,7 +356,7 @@ func (instance *pbftCore) processEvent(e interface{}) interface{} {
 
 		return instance.processNewView()
 	case viewChangedEvent:
-		instance.consumer.viewChange(instance.view)
+		// No-op, processed by plugins if needed
 	default:
 		logger.Warning("Replica %d received an unknown message type %T", instance.id, et)
 	}

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -27,8 +27,9 @@ import (
 
 type pbftEndpoint struct {
 	*testEndpoint
-	pbft *pbftCore
-	sc   *simpleConsumer
+	pbft    *pbftCore
+	sc      *simpleConsumer
+	manager eventManager
 }
 
 func (pe *pbftEndpoint) deliver(msgPayload []byte, senderHandle *pb.PeerID) {
@@ -39,7 +40,7 @@ func (pe *pbftEndpoint) deliver(msgPayload []byte, senderHandle *pb.PeerID) {
 		panic("Told deliver something which did not unmarshal")
 	}
 
-	pe.pbft.manager.queue() <- &pbftMessage{msg: msg, sender: senderID}
+	pe.manager.queue() <- &pbftMessage{msg: msg, sender: senderID}
 }
 
 func (pe *pbftEndpoint) stop() {
@@ -56,7 +57,7 @@ func (pe *pbftEndpoint) isBusy() bool {
 	// channel, the send blocks until the thread has picked up the new work, still
 	// this will be removed pending the transition to an externally driven state machine
 	select {
-	case pe.pbft.manager.queue() <- nil:
+	case pe.manager.queue() <- nil:
 	default:
 		pe.net.debugMsg("TEST: Returning as busy no reply on idleChan\n")
 		return true
@@ -125,7 +126,7 @@ func (sc *simpleConsumer) execute(seqNo uint64, tx []byte) {
 	sc.lastExecution = tx
 	sc.executions++
 	sc.lastSeqNo = seqNo
-	go sc.pe.pbft.execDone()
+	sc.pe.manager.queue() <- execDoneEvent{}
 }
 
 func (sc *simpleConsumer) getState() []byte {
@@ -150,15 +151,17 @@ func makePBFTNetwork(N int, config *viper.Viper) *pbftNetwork {
 		tep := makeTestEndpoint(id, net)
 		pe := &pbftEndpoint{
 			testEndpoint: tep,
+			manager:      newEventManagerImpl(),
 		}
 
 		pe.sc = &simpleConsumer{
 			pe: pe,
 		}
 
-		pe.pbft = newPbftCore(id, config, pe.sc)
+		pe.pbft = newPbftCore(id, config, pe.sc, newEventTimerFactoryImpl(pe.manager))
+		pe.manager.setReceiver(pe.pbft)
 
-		pe.pbft.manager.start()
+		pe.manager.start()
 
 		return pe
 

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -408,7 +408,7 @@ func TestViewChangeWatermarksMovement(t *testing.T) {
 		ReplicaId: 1,
 	}
 
-	if nil != instance.processNewView() {
+	if _, ok := instance.processNewView().(viewChangedEvent); !ok {
 		t.Fatalf("Failed to successfully process new view")
 	}
 
@@ -1288,7 +1288,7 @@ func TestNetworkNullRequests(t *testing.T) {
 	net.pbftEndpoints[0].manager.queue() <- msg
 
 	go net.processContinually()
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	for _, pep := range net.pbftEndpoints {
 		if pep.sc.executions != 1 {

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -72,7 +72,7 @@ func TestMaliciousPrePrepare(t *testing.T) {
 			t.Fatalf("Expected to ignore malicious pre-prepare")
 		},
 	}
-	instance := newPbftCore(1, loadConfig(), mock)
+	instance := newPbftCore(1, loadConfig(), mock, &inertTimerFactory{})
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -95,7 +95,7 @@ func TestWrongReplicaID(t *testing.T) {
 			return nil
 		},
 	}
-	instance := newPbftCore(1, loadConfig(), mock)
+	instance := newPbftCore(1, loadConfig(), mock, &inertTimerFactory{})
 
 	chainTxMsg := createOcMsgWithChainTx(1)
 	req := &Request{
@@ -124,7 +124,7 @@ func TestIncompletePayload(t *testing.T) {
 			return nil
 		},
 	}
-	instance := newPbftCore(1, loadConfig(), mock)
+	instance := newPbftCore(1, loadConfig(), mock, &inertTimerFactory{})
 	defer instance.close()
 	instance.replicaCount = 5
 
@@ -147,7 +147,7 @@ func TestNetwork(t *testing.T) {
 	net := makePBFTNetwork(validatorCount, nil)
 
 	msg := createPbftRequestWithChainTx(1, uint64(generateBroadcaster(validatorCount)))
-	net.pbftEndpoints[0].pbft.manager.queue() <- msg
+	net.pbftEndpoints[0].manager.queue() <- msg
 
 	err := net.process()
 	if err != nil {
@@ -197,7 +197,7 @@ func TestCheckpoint(t *testing.T) {
 			t.Fatalf("Failed to marshal TX block: %s", err)
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
-		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
+		net.pbftEndpoints[0].manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 
 		net.process()
 	}
@@ -272,7 +272,7 @@ func TestLostPrePrepare(t *testing.T) {
 		ReplicaId: uint64(generateBroadcaster(validatorCount)),
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- (req)
+	net.pbftEndpoints[0].manager.queue() <- (req)
 
 	// clear all messages sent by primary
 	msg := <-net.msgs
@@ -285,7 +285,7 @@ func TestLostPrePrepare(t *testing.T) {
 
 	// deliver pre-prepare to subset of replicas
 	for _, pep := range net.pbftEndpoints[1 : len(net.pbftEndpoints)-1] {
-		pep.pbft.manager.queue() <- prePrep.GetPrePrepare()
+		pep.manager.queue() <- prePrep.GetPrePrepare()
 	}
 
 	err = net.process()
@@ -330,15 +330,15 @@ func TestInconsistentPrePrepare(t *testing.T) {
 		return preprep
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- makePP(1).Request
+	net.pbftEndpoints[0].manager.queue() <- makePP(1).Request
 
 	// clear all messages sent by primary
 	net.clearMessages()
 
 	// replace with fake messages
-	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(1)
-	net.pbftEndpoints[2].pbft.manager.queue() <- makePP(2)
-	net.pbftEndpoints[3].pbft.manager.queue() <- makePP(3)
+	net.pbftEndpoints[1].manager.queue() <- makePP(1)
+	net.pbftEndpoints[2].manager.queue() <- makePP(2)
+	net.pbftEndpoints[3].manager.queue() <- makePP(3)
 
 	net.process()
 
@@ -358,8 +358,7 @@ func TestViewChangeWatermarksMovement(t *testing.T) {
 			t.Fatalf("Should not have attempted to initiate state transfer")
 		},
 		broadcastImpl: func(b []byte) {},
-	})
-	instance.manager.start()
+	}, &inertTimerFactory{})
 	instance.activeView = false
 	instance.view = 1
 	instance.lastExec = 10
@@ -490,7 +489,7 @@ func TestViewChange(t *testing.T) {
 			t.Fatalf("Failed to marshal TX block: %s", err)
 		}
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
-		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
+		net.pbftEndpoints[0].manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 		if err != nil {
 			t.Fatalf("Request failed: %s", err)
 		}
@@ -555,15 +554,15 @@ func TestInconsistentDataViewChange(t *testing.T) {
 		return preprep
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- makePP(0).Request
+	net.pbftEndpoints[0].manager.queue() <- makePP(0).Request
 
 	// clear all messages sent by primary
 	net.clearMessages()
 
 	// replace with fake messages
-	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(1)
-	net.pbftEndpoints[2].pbft.manager.queue() <- makePP(1)
-	net.pbftEndpoints[3].pbft.manager.queue() <- makePP(0)
+	net.pbftEndpoints[1].manager.queue() <- makePP(1)
+	net.pbftEndpoints[2].manager.queue() <- makePP(1)
+	net.pbftEndpoints[3].manager.queue() <- makePP(0)
 
 	err := net.process()
 	if err != nil {
@@ -615,14 +614,14 @@ func TestViewChangeWithStateTransfer(t *testing.T) {
 
 	// Have primary advance the sequence number past a checkpoint for replicas 0,1,2
 	for i := int64(1); i <= 3; i++ {
-		net.pbftEndpoints[0].pbft.manager.queue() <- makePP(i).Request
+		net.pbftEndpoints[0].manager.queue() <- makePP(i).Request
 
 		// clear all messages sent by primary
 		net.clearMessages()
 
-		net.pbftEndpoints[0].pbft.manager.queue() <- makePP(i)
-		net.pbftEndpoints[1].pbft.manager.queue() <- makePP(i)
-		net.pbftEndpoints[2].pbft.manager.queue() <- makePP(i)
+		net.pbftEndpoints[0].manager.queue() <- makePP(i)
+		net.pbftEndpoints[1].manager.queue() <- makePP(i)
+		net.pbftEndpoints[2].manager.queue() <- makePP(i)
 
 		err = net.process()
 		if err != nil {
@@ -643,7 +642,7 @@ func TestViewChangeWithStateTransfer(t *testing.T) {
 
 	fmt.Println("Done with stage 3")
 
-	net.pbftEndpoints[1].pbft.manager.queue() <- makePP(5).Request
+	net.pbftEndpoints[1].manager.queue() <- makePP(5).Request
 	err = net.process()
 	if err != nil {
 		t.Fatalf("Processing failed: %s", err)
@@ -684,7 +683,7 @@ func TestNewViewTimeout(t *testing.T) {
 
 	// This will eventually trigger 1's request timeout
 	// We check that one single timed out replica will not keep trying to change views by itself
-	net.pbftEndpoints[1].pbft.manager.queue() <- req
+	net.pbftEndpoints[1].manager.queue() <- req
 	fmt.Println("Debug: Sleeping 1")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 1")
@@ -695,7 +694,7 @@ func TestNewViewTimeout(t *testing.T) {
 	// However, 2 does not know about the missing request, and therefore the request will not be
 	// pre-prepared and finally executed.
 	replica1Disabled = true
-	net.pbftEndpoints[3].pbft.manager.queue() <- req
+	net.pbftEndpoints[3].manager.queue() <- req
 	fmt.Println("Debug: Sleeping 2")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 2")
@@ -703,7 +702,7 @@ func TestNewViewTimeout(t *testing.T) {
 	// So far, we are in view 2, and replica 1 and 3 (who got the request) in view change to view 3.
 	// Submitting the request to 0 will eventually trigger its view-change timeout, which will make
 	// all replicas move to view 3 and finally process the request.
-	net.pbftEndpoints[0].pbft.manager.queue() <- req
+	net.pbftEndpoints[0].manager.queue() <- req
 	fmt.Println("Debug: Sleeping 3")
 	time.Sleep(5 * millisUntilTimeout * time.Millisecond)
 	fmt.Println("Debug: Waking 3")
@@ -737,7 +736,7 @@ func TestViewChangeUpdateSeqNo(t *testing.T) {
 	broadcaster := uint64(generateBroadcaster(validatorCount))
 
 	req := createPbftRequestWithChainTx(1, broadcaster)
-	net.pbftEndpoints[0].pbft.manager.queue() <- req
+	net.pbftEndpoints[0].manager.queue() <- req
 	time.Sleep(5 * millisUntilTimeout)
 	// Now we all have executed seqNo 100.  After triggering a
 	// view change, the new primary should pick up right after
@@ -748,7 +747,7 @@ func TestViewChangeUpdateSeqNo(t *testing.T) {
 	time.Sleep(5 * millisUntilTimeout)
 
 	req = createPbftRequestWithChainTx(2, broadcaster)
-	net.pbftEndpoints[1].pbft.manager.queue() <- req
+	net.pbftEndpoints[1].manager.queue() <- req
 	time.Sleep(5 * millisUntilTimeout)
 
 	net.stop()
@@ -768,7 +767,7 @@ func TestSendQueueThrottling(t *testing.T) {
 	prePreparesSent := 0
 
 	mock := &omniProto{}
-	instance := newPbftCore(0, loadConfig(), mock)
+	instance := newPbftCore(0, loadConfig(), mock, &inertTimerFactory{})
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -796,7 +795,7 @@ func TestSendQueueThrottling(t *testing.T) {
 // From issue #687
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}
-	instance := newPbftCore(1, loadConfig(), mock)
+	instance := newPbftCore(1, loadConfig(), mock, &inertTimerFactory{})
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -821,7 +820,7 @@ func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 // From issue #687
 func TestWitnessFallBehindMissingPrePrepare(t *testing.T) {
 	mock := &omniProto{}
-	instance := newPbftCore(1, loadConfig(), mock)
+	instance := newPbftCore(1, loadConfig(), mock, &inertTimerFactory{})
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -856,7 +855,7 @@ func TestFallBehind(t *testing.T) {
 
 		msg := &Message{&Message_Request{&Request{Payload: txPacked, ReplicaId: uint64(generateBroadcaster(validatorCount))}}}
 
-		net.pbftEndpoints[0].pbft.manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
+		net.pbftEndpoints[0].manager.queue() <- pbftMessageEvent{msg: msg, sender: msg.GetRequest().ReplicaId}
 
 		if skipThree {
 			// Send the request for consensus to everone but replica 3
@@ -927,7 +926,7 @@ func TestPbftF0(t *testing.T) {
 
 	pep0 := net.pbftEndpoints[0]
 
-	pep0.pbft.manager.queue() <- req
+	pep0.manager.queue() <- req
 
 	err := net.process()
 	if err != nil {
@@ -960,8 +959,8 @@ func TestRequestTimerDuringViewChange(t *testing.T) {
 			t.Errorf("Should not send the view change message during a view change")
 		},
 	}
-	instance := newPbftCore(1, loadConfig(), mock)
-	instance.manager.start()
+	instance, manager := createRunningPbftWithManager(1, loadConfig(), mock)
+	defer manager.halt()
 	instance.f = 1
 	instance.K = 2
 	instance.L = 4
@@ -979,7 +978,7 @@ func TestRequestTimerDuringViewChange(t *testing.T) {
 		ReplicaId: 1, // Not the primary
 	}
 
-	instance.manager.queue() <- req
+	manager.queue() <- req
 
 	time.Sleep(100 * time.Millisecond)
 }
@@ -1008,21 +1007,21 @@ func TestReplicaCrash1(t *testing.T) {
 		}
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- mkreq(1)
+	net.pbftEndpoints[0].manager.queue() <- mkreq(1)
 	net.process()
 
 	for id := 0; id < 2; id++ {
 		pe := net.pbftEndpoints[id]
-		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc)
-		pe.pbft.manager.start()
+		pe.pbft = newPbftCore(uint64(id), loadConfig(), pe.sc, newEventTimerFactoryImpl(pe.manager))
+		pe.manager.setReceiver(pe.pbft)
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.K = 2
 		pe.pbft.L = 2 * pe.pbft.K
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- mkreq(2)
-	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(3))
+	net.pbftEndpoints[0].manager.queue() <- mkreq(2)
+	net.pbftEndpoints[0].manager.queue() <- (mkreq(3))
 	net.process()
 
 	for _, pep := range net.pbftEndpoints {
@@ -1082,15 +1081,15 @@ func TestReplicaCrash2(t *testing.T) {
 		}
 	}
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(1))
+	net.pbftEndpoints[0].manager.queue() <- (mkreq(1))
 	net.process()
 
 	logger.Info("stopping filtering")
 	filterMsg = false
 	primary := net.pbftEndpoints[0].pbft.primary(net.pbftEndpoints[0].pbft.view)
-	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(2))
-	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(3))
-	net.pbftEndpoints[primary].pbft.manager.queue() <- (mkreq(4))
+	net.pbftEndpoints[primary].manager.queue() <- (mkreq(2))
+	net.pbftEndpoints[primary].manager.queue() <- (mkreq(3))
+	net.pbftEndpoints[primary].manager.queue() <- (mkreq(4))
 	go net.processContinually()
 	time.Sleep(5 * time.Second)
 
@@ -1144,7 +1143,7 @@ func TestReplicaCrash3(t *testing.T) {
 	}
 
 	for i := int64(1); i <= 8; i++ {
-		net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(i))
+		net.pbftEndpoints[0].manager.queue() <- (mkreq(i))
 	}
 	net.process() // vp0,1,2 should have a stable checkpoint for seqNo 8
 
@@ -1153,8 +1152,9 @@ func TestReplicaCrash3(t *testing.T) {
 		pe := net.pbftEndpoints[id]
 		config := loadConfig()
 		config.Set("general.K", "2")
-		pe.pbft = newPbftCore(uint64(id), config, pe.sc)
-		pe.pbft.manager.start()
+		pe.pbft.close()
+		pe.pbft = newPbftCore(uint64(id), config, pe.sc, newEventTimerFactoryImpl(pe.manager))
+		pe.manager.setReceiver(pe.pbft)
 		pe.pbft.N = 4
 		pe.pbft.f = (4 - 1) / 3
 		pe.pbft.requestTimeout = 200 * time.Millisecond
@@ -1165,7 +1165,7 @@ func TestReplicaCrash3(t *testing.T) {
 
 	// Because vp2 is 'offline', and vp3 is still at the genesis block, the network needs to make a view change
 
-	net.pbftEndpoints[0].pbft.manager.queue() <- (mkreq(9))
+	net.pbftEndpoints[0].manager.queue() <- (mkreq(9))
 	net.process()
 
 	// Now vp0,1,3 should be in sync with 9 executions in view 1, and vp2 should be at 8 executions in view 0
@@ -1226,7 +1226,7 @@ func TestReplicaPersistQSet(t *testing.T) {
 			return r, nil
 		},
 	}
-	p := newPbftCore(1, loadConfig(), stack)
+	p := newPbftCore(1, loadConfig(), stack, &inertTimerFactory{})
 	req := &Request{
 		Timestamp: &gp.Timestamp{Seconds: 1, Nanos: 0},
 		Payload:   []byte("foo"),
@@ -1241,7 +1241,7 @@ func TestReplicaPersistQSet(t *testing.T) {
 	})
 	p.close()
 
-	p = newPbftCore(1, loadConfig(), stack)
+	p = newPbftCore(1, loadConfig(), stack, &inertTimerFactory{})
 	if !p.prePrepared(hashReq(req), 0, 1) {
 		t.Errorf("did not restore qset properly")
 	}
@@ -1259,7 +1259,7 @@ func TestReplicaPersistDelete(t *testing.T) {
 			delete(persist, key)
 		},
 	}
-	p := newPbftCore(1, loadConfig(), stack)
+	p := newPbftCore(1, loadConfig(), stack, &inertTimerFactory{})
 	p.reqStore["a"] = &Request{}
 	p.persistRequest("a")
 	if len(persist) != 1 {
@@ -1272,7 +1272,7 @@ func TestReplicaPersistDelete(t *testing.T) {
 }
 
 func TestNilCurrentExec(t *testing.T) {
-	p := newPbftCore(1, loadConfig(), &omniProto{})
+	p := newPbftCore(1, loadConfig(), &omniProto{}, &inertTimerFactory{})
 	p.execDoneSync() // Per issue 1538, this would cause a Nil pointer dereference
 }
 
@@ -1285,7 +1285,7 @@ func TestNetworkNullRequests(t *testing.T) {
 	defer net.stop()
 
 	msg := createPbftRequestWithChainTx(1, 0)
-	net.pbftEndpoints[0].pbft.manager.queue() <- msg
+	net.pbftEndpoints[0].manager.queue() <- msg
 
 	go net.processContinually()
 	time.Sleep(2 * time.Second)
@@ -1314,7 +1314,7 @@ func TestNetworkNullRequestMissing(t *testing.T) {
 	net.pbftEndpoints[0].pbft.nullRequestTimeout = 0
 
 	msg := createPbftRequestWithChainTx(1, 0)
-	net.pbftEndpoints[0].pbft.manager.queue() <- msg
+	net.pbftEndpoints[0].manager.queue() <- msg
 
 	go net.processContinually()
 	time.Sleep(3 * time.Second) // Bumped from 2 to 3 seconds because of sporadic CI failures
@@ -1345,7 +1345,7 @@ func TestNetworkPeriodicViewChange(t *testing.T) {
 	for n := 1; n < 6; n++ {
 		msg := createPbftRequestWithChainTx(int64(n), 0)
 		for _, pe := range net.pbftEndpoints {
-			pe.pbft.manager.queue() <- msg
+			pe.manager.queue() <- msg
 		}
 		net.process()
 	}
@@ -1376,7 +1376,7 @@ func TestNetworkPeriodicViewChangeMissing(t *testing.T) {
 	for n := 1; n < 3; n++ {
 		msg := createPbftRequestWithChainTx(int64(n), 0)
 		for _, pe := range net.pbftEndpoints {
-			pe.pbft.manager.queue() <- msg
+			pe.manager.queue() <- msg
 		}
 		net.process()
 	}

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -438,7 +438,7 @@ func (instance *pbftCore) processNewView2(nv *NewView) error {
 
 	logger.Debug("Replica %d done cleaning view change artifacts, calling into consumer", instance.id)
 
-	instance.manager.inject(viewChangedEvent{})
+	instance.sendViewChangedEvent = true
 
 	return nil
 }


### PR DESCRIPTION
## Description

This is a follow up to PR #1675.  It removes the hacky mechanism for generating `viewChangedEvent` events introduced, and causes the view change code to pass back the events directly.  It moves the old `innerStack` `viewChange` method into the legacy structures.
## Motivation and Context

This is one in the long series of PRs trying to turn PBFT into more of a simple state machine, by removing the threading, and causing all state changes to be event driven.

The old code was pushing execution into the plugin layer directly by sending the thread into the plugin code.  This changeset removes this tight coupling via the `viewChange()` method by removing it from the `innerStack` interface and into the `legacyInnerStack` interface.  It also removes the `viewChange` empty implementation from `obc-batch.go` as it now consumes only the event.
## How Has This Been Tested?

This has been tested locally via the unit tests.  The remainder should be covered by CI. As this is code restructuring, with no new function, no new tests are required.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
