### PR TITLE
Bump null request timeout to fix sporadic CI failures

### DIFF
--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -352,7 +352,7 @@ func (op *obcSieve) processRequest() {
 
 func (op *obcSieve) recvExecute(exec *Execute) {
 	if !(exec.View >= op.epoch && exec.BlockNumber > op.blockNumber && op.pbft.primary(exec.View) == exec.ReplicaId) {
-		logger.Debug("Invalid execute from %d", exec.ReplicaId)
+		logger.Debug("Replica %d got invalid execute from %d for view %d and block %d", op.pbft.id, exec.ReplicaId, exec.View, exec.BlockNumber)
 		return
 	}
 

--- a/consensus/obcpbft/obc-sieve_test.go
+++ b/consensus/obcpbft/obc-sieve_test.go
@@ -98,8 +98,8 @@ func TestSieveNoDecision(t *testing.T) {
 	validatorCount := 4
 	net := makeConsumerNetwork(validatorCount, obcSieveHelper, func(ce *consumerEndpoint) {
 		ce.consumer.(*obcSieve).pbft.requestTimeout = 400 * time.Millisecond
-		ce.consumer.(*obcSieve).pbft.newViewTimeout = 800 * time.Millisecond
-		ce.consumer.(*obcSieve).pbft.lastNewViewTimeout = 800 * time.Millisecond
+		ce.consumer.(*obcSieve).pbft.newViewTimeout = 1200 * time.Millisecond
+		ce.consumer.(*obcSieve).pbft.lastNewViewTimeout = 1200 * time.Millisecond
 	})
 	// net.debug = true // Enable for debug
 	net.testnet.filterFn = func(src int, dst int, raw []byte) []byte {
@@ -121,9 +121,9 @@ func TestSieveNoDecision(t *testing.T) {
 	net.endpoints[1].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(1), broadcaster)
 
 	go net.processContinually()
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 	net.endpoints[3].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(2), broadcaster)
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 	net.stop()
 
 	for _, ep := range net.endpoints {

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1336,7 +1336,7 @@ func TestNetworkNullRequestMissing(t *testing.T) {
 	net.pbftEndpoints[0].pbft.manager.queue() <- msg
 
 	go net.processContinually()
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second) // Bumped from 2 to 3 seconds because of sporadic CI failures
 
 	for _, pep := range net.pbftEndpoints {
 		if pep.sc.executions != 1 {


### PR DESCRIPTION
## Description

This is a very simple change which increases the timeout for the `TestNetworkNullRequestMissing` test which has been periodically failing via CI.
## Motivation and Context

There periodic CI failures appear to be simply because the test has not executed quickly enough.  There is no harm (other than lengthening the test runs) of waiting longer for this, so this simple fix adds 50% more time (1 second) to the wait.

Ultimately, as we transition the PBFT tests to use deterministic timers, these sleeps will be removed, but in an effort to help CI now, this fix is needed.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
