### PR TITLE
Fixes #1626. Simplify build behind proxy server

### DIFF
--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -70,7 +70,8 @@ esac
 apt-get install -y linux-image-extra-$(uname -r) apparmor docker-engine
 
 # Configure docker
-echo "DOCKER_OPTS=\"-s=${DOCKER_STORAGE_BACKEND_STRING} -r=true --api-cors-header='*' -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock ${DOCKER_OPTS}\"" > /etc/default/docker
+DOCKER_OPTS="-s=${DOCKER_STORAGE_BACKEND_STRING} -r=true --api-cors-header='*' -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock ${DOCKER_OPTS}"
+sed -i.bak '/^DOCKER_OPTS=/{h;s|=.*|=\"'"${DOCKER_OPTS}"'\"|};${x;/^$/{s||DOCKER_OPTS=\"'"${DOCKER_OPTS}"'\"|;H};x}' /etc/default/docker
 
 service docker restart
 usermod -a -G docker vagrant # Add vagrant user to the docker group

--- a/scripts/provision/docker.sh
+++ b/scripts/provision/docker.sh
@@ -99,6 +99,12 @@ COPY scripts $REMOTESCRIPTS
 RUN $REMOTESCRIPTS/common.sh
 EOF
 
-docker build -t $NAME:latest $TMP
+[ ! -z "$http_proxy" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg http_proxy=$http_proxy"
+[ ! -z "$https_proxy" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg https_proxy=$https_proxy"
+[ ! -z "$HTTP_PROXY" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg HTTP_PROXY=$HTTP_PROXY"
+[ ! -z "$HTTPS_PROXY" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg HTTPS_PROXY=$HTTPS_PROXY"
+[ ! -z "$no_proxy" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg no_proxy=$no_proxy"
+[ ! -z "$NO_PROXY" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg NO_PROXY=$NO_PROXY"
+docker build $DOCKER_ARGS_PROXY -t $NAME:latest $TMP
 
 rm -rf $TMP


### PR DESCRIPTION
Simplify running devenv on host behind proxy server.
## Description
1. /etc/default/docker file was always overwritten by static content. However, if you try to run vagrant up behind proxy, vagrant will set up env. variables which in turn are placed into /etc/default/docker file and shall be preserved.
2. Pass proxy env. variables into docker build command for the same purpose.
## Motivation and Context

Fixes #1626. Actually, the fix is a partial, as docker being installed on a provision step, vagrant don't set proxy env. variables for it and thus it is required to execute vagrant provision after the first failure on vagrant up step.
## How Has This Been Tested?

Tested vagrant up on host behind proxy and on host directly connected to the Internet.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Mikhail Kulinich tysonite@gmail.com
