### PR TITLE
unit tests housekeeping for consensus/helper and core/util

### DIFF
--- a/consensus/helper/engine_test.go
+++ b/consensus/helper/engine_test.go
@@ -14,30 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package helper
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestQueue(t *testing.T) {
-	q := NewQueue()
-	q.Push("first")
-	q.Push("second")
-	q.Push("third")
-	t.Logf("Size: %d\n", q.Size())
-	head := q.Peek()
-	if head != "first" {
-		t.Fatalf("head is not correct. Expected \"first\", got %v", head)
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 2 {
-		t.Fatalf("Wrong queue size != 2: %d", q.Size())
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 0 {
-		t.Fatalf("Wrong queue size != 0: %d", q.Size())
-	}
-
+func TestEngine(t *testing.T) {
+	t.Skip("Engine functions already tested in other consensus components")
 }

--- a/consensus/helper/handler_test.go
+++ b/consensus/helper/handler_test.go
@@ -14,30 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package helper
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestQueue(t *testing.T) {
-	q := NewQueue()
-	q.Push("first")
-	q.Push("second")
-	q.Push("third")
-	t.Logf("Size: %d\n", q.Size())
-	head := q.Peek()
-	if head != "first" {
-		t.Fatalf("head is not correct. Expected \"first\", got %v", head)
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 2 {
-		t.Fatalf("Wrong queue size != 2: %d", q.Size())
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 0 {
-		t.Fatalf("Wrong queue size != 0: %d", q.Size())
-	}
-
+func TestHandler(t *testing.T) {
+	t.Skip("Handler functions already tested in other consensus components")
 }

--- a/consensus/helper/helper_test.go
+++ b/consensus/helper/helper_test.go
@@ -14,30 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package helper
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestQueue(t *testing.T) {
-	q := NewQueue()
-	q.Push("first")
-	q.Push("second")
-	q.Push("third")
-	t.Logf("Size: %d\n", q.Size())
-	head := q.Peek()
-	if head != "first" {
-		t.Fatalf("head is not correct. Expected \"first\", got %v", head)
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 2 {
-		t.Fatalf("Wrong queue size != 2: %d", q.Size())
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 0 {
-		t.Fatalf("Wrong queue size != 0: %d", q.Size())
-	}
-
+func TestHelper(t *testing.T) {
+	t.Skip("Helper functions already tested in other consensus components")
 }

--- a/consensus/helper/persist/persist_test.go
+++ b/consensus/helper/persist/persist_test.go
@@ -14,30 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package persist
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestQueue(t *testing.T) {
-	q := NewQueue()
-	q.Push("first")
-	q.Push("second")
-	q.Push("third")
-	t.Logf("Size: %d\n", q.Size())
-	head := q.Peek()
-	if head != "first" {
-		t.Fatalf("head is not correct. Expected \"first\", got %v", head)
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 2 {
-		t.Fatalf("Wrong queue size != 2: %d", q.Size())
-	}
-	t.Logf("Pop: %v\n", q.Pop())
-	t.Logf("Pop: %v\n", q.Pop())
-	if q.Size() != 0 {
-		t.Fatalf("Wrong queue size != 0: %d", q.Size())
-	}
-
+func TestPersist(t *testing.T) {
+	t.Skip("Persist functions already tested in other consensus components")
 }

--- a/core/util/utils_test.go
+++ b/core/util/utils_test.go
@@ -42,9 +42,28 @@ func TestUUIDGeneration(t *testing.T) {
 	}
 }
 
+func TestIntUUIDGeneration(t *testing.T) {
+	uuid := GenerateIntUUID()
+
+	uuid2 := GenerateIntUUID()
+	if uuid == uuid2 {
+		t.Fatalf("Two UUIDs are equal. This should never occur")
+	}
+}
 func TestTimestamp(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		t.Logf("timestamp now: %v", CreateUtcTimestamp())
 		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func TestGenerateHashFromSignature(t *testing.T) {
+	if bytes.Compare(GenerateHashFromSignature("aPath", "aCtor", []string{"1", "2"}),
+		GenerateHashFromSignature("aPath", "aCtor", []string{"1", "2"})) != 0 {
+		t.Fatalf("Expected hashes to match, but they did not match")
+	}
+	if bytes.Compare(GenerateHashFromSignature("aPath", "aCtor", []string{"1", "2"}),
+		GenerateHashFromSignature("bPath", "bCtor", []string{"3", "4"})) == 0 {
+		t.Fatalf("Expected hashes to be different, but they match")
 	}
 }


### PR DESCRIPTION
## Description

Explicit indicate that consensus/helper and consensus/persist are unit-tested by the testcases in other consensus components

Add more unit tests for core/util
## Motivation and Context

part of test coverage hackathon June 3
## How Has This Been Tested?

Automatically run as part of `make unit-test`
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Tuan Dang tdang@us.ibm.com
