### PR TITLE
Optionally generate invoke transaction ID from transaction content

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -315,6 +315,27 @@ Feature: lanching 3 peers
 
 #    @doNotDecompose
 #    @wip
+#    Arg[0] = a, base64 = 'YQ=='
+#    sha256 = 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'
+	Scenario: chaincode map single peer content generated UUID
+	    Given we compose "docker-compose-1.yml"
+	    When requesting "/chain" from "vp0"
+	    Then I should get a JSON response with "height" = "1"
+	    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/map" with ctor "init" to "vp0"
+	      ||
+              ||
+	    Then I should have received a chaincode name
+	    Then I wait up to "60" seconds for transaction to be committed to all peers
+
+        When I invoke chaincode "map" function name "put" on "vp0" with "sha256base64"
+	    | arg1  |arg2|
+            | YQ==  | 10 |
+	    Then I should have received a transactionID
+	    Then I wait up to "25" seconds for transaction to be committed to all peers
+	    Then I check the transaction ID if it is "ca978112-ca1b-bdca-fac2-31b39a23dc4d"
+
+#    @doNotDecompose
+#    @wip
 	Scenario: chaincode example 02 single peer
 	    Given we compose "docker-compose-1.yml"
 	    When requesting "/chain" from "vp0"

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -317,7 +317,7 @@ Feature: lanching 3 peers
 #    @wip
 #    Arg[0] = a, base64 = 'YQ=='
 #    sha256 = 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'
-	Scenario: chaincode map single peer content generated UUID
+	Scenario: chaincode map single peer content generated ID
 	    Given we compose "docker-compose-1.yml"
 	    When requesting "/chain" from "vp0"
 	    Then I should get a JSON response with "height" = "1"

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -204,10 +204,10 @@ def step_impl(context):
     else:
         fail('chaincodeSpec not in context')
 
-@when(u'I invoke chaincode "{chaincodeName}" function name "{functionName}" on "{containerName}" with "{uuidGenAlg}"')
-def step_impl(context, chaincodeName, functionName, containerName, uuidGenAlg):
+@when(u'I invoke chaincode "{chaincodeName}" function name "{functionName}" on "{containerName}" with "{idGenAlg}"')
+def step_impl(context, chaincodeName, functionName, containerName, idGenAlg):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
-    invokeChaincode(context, "invoke", functionName, containerName, uuidGenAlg)
+    invokeChaincode(context, "invoke", functionName, containerName, idGenAlg)
 
 @when(u'I invoke chaincode "{chaincodeName}" function name "{functionName}" on "{containerName}" "{times}" times')
 def step_impl(context, chaincodeName, functionName, containerName, times):
@@ -234,7 +234,7 @@ def step_impl(context, chaincodeName, functionName, containerName):
 def step_impl(context, chaincodeName, functionName, containerName):
     invokeChaincode(context, "query", functionName, containerName)
 
-def invokeChaincode(context, devopsFunc, functionName, containerName, uuidGenAlg=None):
+def invokeChaincode(context, devopsFunc, functionName, containerName, idGenAlg=None):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
     # Update hte chaincodeSpec ctorMsg for invoke
     args = []
@@ -248,8 +248,8 @@ def invokeChaincode(context, devopsFunc, functionName, containerName, uuidGenAlg
         "chaincodeSpec" : context.chaincodeSpec
     }
     ipAddress = bdd_test_util.ipFromContainerNamePart(containerName, context.compose_containers)
-    if uuidGenAlg is not None:
-	    chaincodeInvocationSpec['uuidGenerationAlg'] = uuidGenAlg
+    if idGenAlg is not None:
+	    chaincodeInvocationSpec['idGenerationAlg'] = idGenAlg
     request_url = buildUrl(context, ipAddress, "/devops/{0}".format(devopsFunc))
     print("{0} POSTing path = {1}".format(currentTime(), request_url))
 

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -204,6 +204,11 @@ def step_impl(context):
     else:
         fail('chaincodeSpec not in context')
 
+@when(u'I invoke chaincode "{chaincodeName}" function name "{functionName}" on "{containerName}" with "{uuidGenAlg}"')
+def step_impl(context, chaincodeName, functionName, containerName, uuidGenAlg):
+    assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
+    invokeChaincode(context, "invoke", functionName, containerName, uuidGenAlg)
+
 @when(u'I invoke chaincode "{chaincodeName}" function name "{functionName}" on "{containerName}" "{times}" times')
 def step_impl(context, chaincodeName, functionName, containerName, times):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
@@ -229,7 +234,7 @@ def step_impl(context, chaincodeName, functionName, containerName):
 def step_impl(context, chaincodeName, functionName, containerName):
     invokeChaincode(context, "query", functionName, containerName)
 
-def invokeChaincode(context, devopsFunc, functionName, containerName):
+def invokeChaincode(context, devopsFunc, functionName, containerName, uuidGenAlg=None):
     assert 'chaincodeSpec' in context, "chaincodeSpec not found in context"
     # Update hte chaincodeSpec ctorMsg for invoke
     args = []
@@ -243,6 +248,8 @@ def invokeChaincode(context, devopsFunc, functionName, containerName):
         "chaincodeSpec" : context.chaincodeSpec
     }
     ipAddress = bdd_test_util.ipFromContainerNamePart(containerName, context.compose_containers)
+    if uuidGenAlg is not None:
+	    chaincodeInvocationSpec['uuidGenerationAlg'] = uuidGenAlg
     request_url = buildUrl(context, ipAddress, "/devops/{0}".format(devopsFunc))
     print("{0} POSTing path = {1}".format(currentTime(), request_url))
 
@@ -328,6 +335,22 @@ def step_impl(context, seconds):
     print("Result of request to all peers = {0}".format(respMap))
     print("")
 
+@then(u'I check the transaction ID if it is "{tUUID}"')
+def step_impl(context, tUUID):
+    assert 'transactionID' in context, "transactionID not found in context"
+    assert context.transactionID == tUUID, "transactionID is not tUUID"
+
+def getContainerDataValuesFromContext(context, aliases, callback):
+    """Returns the IPAddress based upon a name part of the full container name"""
+    assert 'compose_containers' in context, "compose_containers not found in context"
+    values = []
+    containerNamePrefix = os.path.basename(os.getcwd()) + "_"
+    for namePart in aliases:
+        for containerData in context.compose_containers:
+            if containerData.containerName.startswith(containerNamePrefix + namePart):
+                values.append(callback(containerData))
+                break
+    return values
 
 @then(u'I wait up to "{seconds}" seconds for transaction to be committed to peers')
 def step_impl(context, seconds):
@@ -475,7 +498,7 @@ def step_impl(context, userName, secret):
         assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
         context.response = resp
         print("message = {0}".format(resp.json()))
-    
+
         # Create new User entry
         bdd_test_util.registerUser(context, secretMsg, containerData.composeService)
 

--- a/core/devops.go
+++ b/core/devops.go
@@ -19,6 +19,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
@@ -209,7 +210,18 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 	}
 
 	// Now create the Transactions message and send to Peer.
-	uuid := util.GenerateUUID()
+	var customUUIDgenAlg = strings.ToLower(chaincodeInvocationSpec.UuidGenerationAlg)
+	var uuid string
+	var generr error
+	if customUUIDgenAlg != "" {
+		uuid, generr = util.GenerateUUIDWithAlg(customUUIDgenAlg, chaincodeInvocationSpec.ChaincodeSpec.CtorMsg.Args[0])
+		if generr != nil {
+			return nil, generr
+		}
+	} else {
+		uuid = util.GenerateUUID()
+	}
+	devopsLogger.Info("Transaction ID: %v", uuid)
 	var transaction *pb.Transaction
 	var err error
 	var sec crypto.Client

--- a/core/devops.go
+++ b/core/devops.go
@@ -210,18 +210,18 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 	}
 
 	// Now create the Transactions message and send to Peer.
-	var customUUIDgenAlg = strings.ToLower(chaincodeInvocationSpec.UuidGenerationAlg)
-	var uuid string
+	var customIDgenAlg = strings.ToLower(chaincodeInvocationSpec.IdGenerationAlg)
+	var id string
 	var generr error
-	if customUUIDgenAlg != "" {
-		uuid, generr = util.GenerateUUIDWithAlg(customUUIDgenAlg, chaincodeInvocationSpec.ChaincodeSpec.CtorMsg.Args[0])
+	if customIDgenAlg != "" {
+		id, generr = util.GenerateIDWithAlg(customIDgenAlg, chaincodeInvocationSpec.ChaincodeSpec.CtorMsg.Args[0])
 		if generr != nil {
 			return nil, generr
 		}
 	} else {
-		uuid = util.GenerateUUID()
+		id = util.GenerateUUID()
 	}
-	devopsLogger.Info("Transaction ID: %v", uuid)
+	devopsLogger.Info("Transaction ID: %v", id)
 	var transaction *pb.Transaction
 	var err error
 	var sec crypto.Client
@@ -238,7 +238,7 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 		}
 	}
 
-	transaction, err = d.createExecTx(chaincodeInvocationSpec, attributes, uuid, invoke, sec)
+	transaction, err = d.createExecTx(chaincodeInvocationSpec, attributes, id, invoke, sec)
 	if err != nil {
 		return nil, err
 	}

--- a/core/util/utils.go
+++ b/core/util/utils.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"math/big"
@@ -27,6 +29,15 @@ import (
 
 	"golang.org/x/crypto/sha3"
 )
+
+type alg struct {
+	hashFun func([]byte) string
+	decoder func(string) ([]byte, error)
+}
+
+var availableUUIDgenAlgs = map[string]alg{
+	"sha256base64": alg{GenerateUUIDfromTxSHAHash, base64.StdEncoding.DecodeString},
+}
 
 // ComputeCryptoHash should be used in openchain code so that we can change the actual algo used for crypto-hash at one place
 func ComputeCryptoHash(data []byte) (hash []byte) {
@@ -62,7 +73,7 @@ func GenerateIntUUID() *big.Int {
 // GenerateUUID returns a UUID based on RFC 4122
 func GenerateUUID() string {
 	uuid := GenerateBytesUUID()
-	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:])
+	return uuidBytesToStr(uuid)
 }
 
 // CreateUtcTimestamp returns a google/protobuf/Timestamp in UTC
@@ -87,4 +98,28 @@ func GenerateHashFromSignature(path string, ctor string, args []string) []byte {
 	copy(b, cbytes)
 	hash := ComputeCryptoHash(b)
 	return hash
+}
+
+// GenerateUUIDfromTxSHAHash generates SHA256 hash using Tx payload, and uses its first
+// 128 bits as a UUID
+func GenerateUUIDfromTxSHAHash(txData []byte) string {
+	txHash := sha256.Sum256(txData)
+	return uuidBytesToStr(txHash[0:16])
+}
+
+// GenerateUUIDWithAlg generates a UUID using a custom algorithm
+func GenerateUUIDWithAlg(customUUIDgenAlg string, encodedPayload string) (string, error) {
+	var alg = availableUUIDgenAlgs[customUUIDgenAlg]
+	if alg.hashFun != nil && alg.decoder != nil {
+		var payload, err = alg.decoder(encodedPayload)
+		if err != nil {
+			return "", err
+		}
+		return alg.hashFun(payload), nil
+	}
+	return "", fmt.Errorf("Wrong UUID generation algorithm was given.")
+}
+
+func uuidBytesToStr(uuid []byte) string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:])
 }

--- a/core/util/utils.go
+++ b/core/util/utils.go
@@ -35,7 +35,7 @@ type alg struct {
 	decoder func(string) ([]byte, error)
 }
 
-var availableUUIDgenAlgs = map[string]alg{
+var availableIDgenAlgs = map[string]alg{
 	"sha256base64": alg{GenerateUUIDfromTxSHAHash, base64.StdEncoding.DecodeString},
 }
 
@@ -107,9 +107,9 @@ func GenerateUUIDfromTxSHAHash(txData []byte) string {
 	return uuidBytesToStr(txHash[0:16])
 }
 
-// GenerateUUIDWithAlg generates a UUID using a custom algorithm
-func GenerateUUIDWithAlg(customUUIDgenAlg string, encodedPayload string) (string, error) {
-	var alg = availableUUIDgenAlgs[customUUIDgenAlg]
+// GenerateIDWithAlg generates an ID using a custom algorithm
+func GenerateIDWithAlg(customIDgenAlg string, encodedPayload string) (string, error) {
+	var alg = availableIDgenAlgs[customIDgenAlg]
 	if alg.hashFun != nil && alg.decoder != nil {
 		var payload, err = alg.decoder(encodedPayload)
 		if err != nil {

--- a/peer/main.go
+++ b/peer/main.go
@@ -182,7 +182,7 @@ var (
 	chaincodeQueryRaw       bool
 	chaincodeQueryHex       bool
 	chaincodeAttributesJSON string
-	customUUIDGenAlg  string
+	customIDGenAlg          string
 )
 
 var chaincodeCmd = &cobra.Command{
@@ -298,7 +298,7 @@ func main() {
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodePath, "path", "p", undefinedParamValue, fmt.Sprintf("Path to %s", chainFuncName))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeName, "name", "n", undefinedParamValue, fmt.Sprintf("Name of the chaincode returned by the deploy transaction"))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeUsr, "username", "u", undefinedParamValue, fmt.Sprintf("Username for chaincode operations when security is enabled"))
-	chaincodeCmd.PersistentFlags().StringVarP(&customUUIDGenAlg, "tid", "t", undefinedParamValue, fmt.Sprintf("Name of a custom UUID generation algorithm (hashing and decoding) e.g. sha256base64"))
+	chaincodeCmd.PersistentFlags().StringVarP(&customIDGenAlg, "tid", "t", undefinedParamValue, fmt.Sprintf("Name of a custom ID generation algorithm (hashing and decoding) e.g. sha256base64"))
 
 	chaincodeQueryCmd.Flags().BoolVarP(&chaincodeQueryRaw, "raw", "r", false, "If true, output the query value as raw bytes, otherwise format as a printable string")
 	chaincodeQueryCmd.Flags().BoolVarP(&chaincodeQueryHex, "hex", "x", false, "If true, output the query value byte array in hexadecimal. Incompatible with --raw")
@@ -983,8 +983,8 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 
 	// Build the ChaincodeInvocationSpec message
 	invocation := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
-	if customUUIDGenAlg != undefinedParamValue {
-		invocation.UuidGenerationAlg = customUUIDGenAlg
+	if customIDGenAlg != undefinedParamValue {
+		invocation.IdGenerationAlg = customIDGenAlg
 	}
 
 	var resp *pb.Response

--- a/peer/main.go
+++ b/peer/main.go
@@ -182,6 +182,7 @@ var (
 	chaincodeQueryRaw       bool
 	chaincodeQueryHex       bool
 	chaincodeAttributesJSON string
+	customUUIDGenAlg  string
 )
 
 var chaincodeCmd = &cobra.Command{
@@ -297,6 +298,7 @@ func main() {
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodePath, "path", "p", undefinedParamValue, fmt.Sprintf("Path to %s", chainFuncName))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeName, "name", "n", undefinedParamValue, fmt.Sprintf("Name of the chaincode returned by the deploy transaction"))
 	chaincodeCmd.PersistentFlags().StringVarP(&chaincodeUsr, "username", "u", undefinedParamValue, fmt.Sprintf("Username for chaincode operations when security is enabled"))
+	chaincodeCmd.PersistentFlags().StringVarP(&customUUIDGenAlg, "tid", "t", undefinedParamValue, fmt.Sprintf("Name of a custom UUID generation algorithm (hashing and decoding) e.g. sha256base64"))
 
 	chaincodeQueryCmd.Flags().BoolVarP(&chaincodeQueryRaw, "raw", "r", false, "If true, output the query value as raw bytes, otherwise format as a printable string")
 	chaincodeQueryCmd.Flags().BoolVarP(&chaincodeQueryHex, "hex", "x", false, "If true, output the query value byte array in hexadecimal. Incompatible with --raw")
@@ -981,6 +983,9 @@ func chaincodeInvokeOrQuery(cmd *cobra.Command, args []string, invoke bool) (err
 
 	// Build the ChaincodeInvocationSpec message
 	invocation := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
+	if customUUIDGenAlg != undefinedParamValue {
+		invocation.UuidGenerationAlg = customUUIDGenAlg
+	}
 
 	var resp *pb.Response
 	if invoke {

--- a/protos/api.pb.go
+++ b/protos/api.pb.go
@@ -36,8 +36,8 @@ It has these top-level messages:
 	ExecuteWithBinding
 	SigmaOutput
 	BuildResult
-	ChaincodeReg
 	TransactionRequest
+	ChaincodeReg
 	Interest
 	Register
 	Event

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -251,6 +251,15 @@ func (m *ChaincodeDeploymentSpec) GetEffectiveDate() *google_protobuf.Timestamp 
 // Carries the chaincode function and its arguments.
 type ChaincodeInvocationSpec struct {
 	ChaincodeSpec *ChaincodeSpec `protobuf:"bytes,1,opt,name=chaincodeSpec" json:"chaincodeSpec,omitempty"`
+	// ChaincodeInput message = 2;
+	// This field can contain a user-specified UUID generation algorithm
+	// If supplied, this will be used to generate a UUID
+	// If not supplied (left empty), a random UUID will be generated
+	// The algorithm consists of two parts:
+	//  1, a hash function
+	//  2, a decoding used to decode user (string) input to bytes
+	// Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
+	UuidGenerationAlg string `protobuf:"bytes,2,opt,name=uuidGenerationAlg" json:"uuidGenerationAlg,omitempty"`
 }
 
 func (m *ChaincodeInvocationSpec) Reset()         { *m = ChaincodeInvocationSpec{} }

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -251,15 +251,14 @@ func (m *ChaincodeDeploymentSpec) GetEffectiveDate() *google_protobuf.Timestamp 
 // Carries the chaincode function and its arguments.
 type ChaincodeInvocationSpec struct {
 	ChaincodeSpec *ChaincodeSpec `protobuf:"bytes,1,opt,name=chaincodeSpec" json:"chaincodeSpec,omitempty"`
-	// ChaincodeInput message = 2;
-	// This field can contain a user-specified UUID generation algorithm
-	// If supplied, this will be used to generate a UUID
+	// This field can contain a user-specified ID generation algorithm
+	// If supplied, this will be used to generate a ID
 	// If not supplied (left empty), a random UUID will be generated
 	// The algorithm consists of two parts:
 	//  1, a hash function
 	//  2, a decoding used to decode user (string) input to bytes
-	// Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
-	UuidGenerationAlg string `protobuf:"bytes,2,opt,name=uuidGenerationAlg" json:"uuidGenerationAlg,omitempty"`
+	// Currently, SHA256 with BASE64 is supported (e.g. idGenerationAlg='sha256base64')
+	IdGenerationAlg string `protobuf:"bytes,2,opt,name=idGenerationAlg" json:"idGenerationAlg,omitempty"`
 }
 
 func (m *ChaincodeInvocationSpec) Reset()         { *m = ChaincodeInvocationSpec{} }

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -95,8 +95,14 @@ message ChaincodeDeploymentSpec {
 message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
-    //ChaincodeInput message = 2;
-
+    // This field can contain a user-specified UUID generation algorithm
+    // If supplied, this will be used to generate a UUID
+    // If not supplied (left empty), a random UUID will be generated
+    // The algorithm consists of two parts:
+    //  1, a hash function
+    //  2, a decoding used to decode user (string) input to bytes
+    // Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
+    string uuidGenerationAlg = 2;
 }
 
 // This structure contain transaction data that we send to the chaincode

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -95,14 +95,14 @@ message ChaincodeDeploymentSpec {
 message ChaincodeInvocationSpec {
 
     ChaincodeSpec chaincodeSpec = 1;
-    // This field can contain a user-specified UUID generation algorithm
-    // If supplied, this will be used to generate a UUID
+    // This field can contain a user-specified ID generation algorithm
+    // If supplied, this will be used to generate a ID
     // If not supplied (left empty), a random UUID will be generated
     // The algorithm consists of two parts:
     //  1, a hash function
     //  2, a decoding used to decode user (string) input to bytes
-    // Currently, SHA256 with BASE64 is supported (e.g. uuidGenerationAlg='sha256base64')
-    string uuidGenerationAlg = 2;
+    // Currently, SHA256 with BASE64 is supported (e.g. idGenerationAlg='sha256base64')
+    string idGenerationAlg = 2;
 }
 
 // This structure contain transaction data that we send to the chaincode


### PR DESCRIPTION
Optionally generate invoke transaction ID  from transaction content
## Description

Adds a -tid options to CLI that determines the transaction id derivation algorithm. 
Adds uuidGenerationAlg to ChaincodeInvocationSpec with same meaning and content option. 

Currently supported derivation algorithm is `sha256base64`,  that means transaction is assumed to be encoded as a base64 string and will be hashed with sha256, then first 128 bits will be formatted like an RFC 4122 UUID to identify the transaction
## Motivation and Context

If UUID is derived from transaction content, then it is already known by the ledger client application, that is able to track it from construction to storage into the ledger. If UUID was assigned by the ledger (as is now) then a client would have to find the transaction in the block chain by comparing its content with content that it sent in. Deriving transaction id from content with a cryptographic hash practically ensures that ID will be unique, no other transaction with any different content will have the same ID. A limit of the approach is that identical invoke would receive same ID, which is however easy to avoid by the creator of the transaction. It is questionable if identical invokes should be processed at all since if they are allowed then trivial transaction replay attack can be executed on the ledger.
## How Has This Been Tested?

unit tests were run
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [ ] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Tamas Blummer tamas@digitalasset.com
