### PR TITLE
create a chaincode image if not found

### DIFF
--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 
 	"github.com/hyperledger/fabric/core/container"
+	"github.com/hyperledger/fabric/core/container/ccintf"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/system_chaincode"
@@ -409,7 +410,7 @@ func checkFinalState(uuid string, chaincodeID string) error {
 }
 
 // Invoke chaincode_example02
-func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args []string) error {
+func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args []string, destroyImage bool) error {
 
 	f := "init"
 	argsDeploy := []string{"a", "100", "b", "200"}
@@ -421,6 +422,17 @@ func invokeExample02Transaction(ctxt context.Context, cID *pb.ChaincodeID, args 
 	}
 
 	time.Sleep(time.Second)
+
+	if destroyImage {
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		dir := container.DestroyImageReq{CCID: ccintf.CCID{ChaincodeSpec: spec, NetworkID: GetChain(DefaultChain).peerNetworkID, PeerID: GetChain(DefaultChain).peerID}, Force: true, NoPrune: true}
+
+		_, err = container.VMCProcess(ctxt, container.DOCKER, dir)
+		if err != nil {
+			err = fmt.Errorf("Error destroying image: %s", err)
+			return err
+		}
+	}
 
 	f = "invoke"
 	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
@@ -485,7 +497,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 	chaincodeID := &pb.ChaincodeID{Path: url}
 
 	args := []string{"a", "b", "10"}
-	err = invokeExample02Transaction(ctxt, chaincodeID, args)
+	err = invokeExample02Transaction(ctxt, chaincodeID, args, true)
 	if err != nil {
 		t.Fail()
 		t.Logf("Error invoking transaction: %s", err)
@@ -667,7 +679,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 
 	//FAIL, FAIL!
 	args := []string{"x", "-1"}
-	err = invokeExample02Transaction(ctxt, chaincodeID, args)
+	err = invokeExample02Transaction(ctxt, chaincodeID, args, false)
 
 	//this HAS to fail with expectedDeltaStringPrefix
 	if err != nil {
@@ -1311,7 +1323,6 @@ func TestChaincodeQueryChaincodeWithSec(t *testing.T) {
 	finitMemSrvc(memSrvcLis)
 	finitPeer(peerLis)
 }
-
 func TestMain(m *testing.M) {
 	SetupTestConfig()
 	os.Exit(m.Run())

--- a/core/container/controller.go
+++ b/core/container/controller.go
@@ -31,8 +31,9 @@ import (
 //abstract virtual image for supporting arbitrary virual machines
 type vm interface {
 	Deploy(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error
-	Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool) error
+	Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error
 	Stop(ctxt context.Context, ccid ccintf.CCID, timeout uint, dontkill bool, dontremove bool) error
+	Destroy(ctxt context.Context, ccid ccintf.CCID, force bool, noprune bool) error
 	GetVMName(ccID ccintf.CCID) (string, error)
 }
 
@@ -162,6 +163,7 @@ func (bp CreateImageReq) getCCID() ccintf.CCID {
 //StartImageReq - properties for starting a container.
 type StartImageReq struct {
 	ccintf.CCID
+	Reader       io.Reader
 	Args         []string
 	Env          []string
 	AttachStdin  bool
@@ -171,7 +173,7 @@ type StartImageReq struct {
 func (si StartImageReq) do(ctxt context.Context, v vm) VMCResp {
 	var resp VMCResp
 
-	if err := v.Start(ctxt, si.CCID, si.Args, si.Env, si.AttachStdin, si.AttachStdout); err != nil {
+	if err := v.Start(ctxt, si.CCID, si.Args, si.Env, si.AttachStdin, si.AttachStdout, si.Reader); err != nil {
 		resp = VMCResp{Err: err}
 	} else {
 		resp = VMCResp{}
@@ -208,6 +210,30 @@ func (si StopImageReq) do(ctxt context.Context, v vm) VMCResp {
 
 func (si StopImageReq) getCCID() ccintf.CCID {
 	return si.CCID
+}
+
+//DestroyImageReq - properties for stopping a container.
+type DestroyImageReq struct {
+	ccintf.CCID
+	Timeout uint
+	Force   bool
+	NoPrune bool
+}
+
+func (di DestroyImageReq) do(ctxt context.Context, v vm) VMCResp {
+	var resp VMCResp
+
+	if err := v.Destroy(ctxt, di.CCID, di.Force, di.NoPrune); err != nil {
+		resp = VMCResp{Err: err}
+	} else {
+		resp = VMCResp{}
+	}
+
+	return resp
+}
+
+func (di DestroyImageReq) getCCID() ccintf.CCID {
+	return di.CCID
 }
 
 //VMCProcess should be used as follows

--- a/core/container/inproccontroller/inproccontroller.go
+++ b/core/container/inproccontroller/inproccontroller.go
@@ -143,7 +143,7 @@ func (ipc *inprocContainer) launchInProc(ctxt context.Context, id string, args [
 }
 
 //Start starts a previously registered system codechain
-func (vm *InprocVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool) error {
+func (vm *InprocVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string, env []string, attachstdin bool, attachstdout bool, reader io.Reader) error {
 	path := ccid.ChaincodeSpec.ChaincodeID.Path
 
 	ipctemplate := typeRegistry[path]
@@ -206,6 +206,12 @@ func (vm *InprocVM) Stop(ctxt context.Context, ccid ccintf.CCID, timeout uint, d
 
 	delete(instRegistry, ccid.ChaincodeSpec.ChaincodeID.Name)
 	//TODO stop
+	return nil
+}
+
+//Destroy destroys an image
+func (vm *InprocVM) Destroy(ctxt context.Context, ccid ccintf.CCID, force bool, noprune bool) error {
+	//not implemented
 	return nil
 }
 


### PR DESCRIPTION
Pass the chaincode docker targz extracted from deploy transaction to launch of chaincode. The targz will be used to create the image if not found.
## Description

We have the targz at hand already quite conveniently. The "Start" interface is modified to take this is as a parameter. If the start of a container fails with ErrNoSuchImage, the targz is ued to create the image and retry start. As this happens under the aegis of "Start" it is atomic to the "Start" operation.
## Motivation and Context

There are few legitimate situations where a deployed chaincode's image is not found
- a peer that is catching up
- docker error conditions

The image is created on demand only when an invoke or query is issued against the chaincode. Note that this has no adverse performance effect under "normal" conditions.

Fixes #1603 
## How Has This Been Tested?

Introduced a "Destroy" command to the VM just so we could destroy an image for testing. Used this in an existing "ExecuteInvokeTransaction" test case as opposed to introducing a new test case (the chaincode test suite is quite long already). The test case deploys a chaincode, stops the container, deletes the image and then attempts to invoke. The invoke will cause the image to be created first.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
