### PR TITLE
Add only successful TXs to the ledger

### DIFF
--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -177,10 +177,11 @@ func (h *Helper) ExecTxs(id interface{}, txs []*pb.Transaction) ([]byte, error) 
 	// cxt := context.WithValue(context.Background(), "security", h.coordinator.GetSecHelper())
 	// TODO return directly once underlying implementation no longer returns []error
 
-	res, txerrs, err := chaincode.ExecuteTransactions(context.Background(), chaincode.DefaultChain, txs)
-	h.curBatch = append(h.curBatch, txs...) // TODO, remove after issue 579
+	succeededTxs, res, txerrs, err := chaincode.ExecuteTransactions(context.Background(), chaincode.DefaultChain, txs)
 
-	//copy errs to results
+	h.curBatch = append(h.curBatch, succeededTxs...) // TODO, remove after issue 579
+
+	//copy errs to result
 	txresults := make([]*pb.TransactionResult, len(txerrs))
 
 	//process errors for each transaction


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR changes the system so it adds only successful TXs to the ledger. The TXs where chaincode execution was erroneous are not persisted.
## Description

See the summary.
## Motivation and Context

Writing erroneous TXs (where the chaincode execution resulted in an exception etc.) to the ledger makes it possible to flood the ledger easily. On the other hand, Bitcoin follows the same approach as this commit, it does not store unsuccessful transactions.
## How Has This Been Tested?

Unit tests were run.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Gabor Hosszu gabor@digitalasset.com
