### PR TITLE
Move pbft batch execution off main thread

### DIFF
--- a/consensus/obcpbft/events.go
+++ b/consensus/obcpbft/events.go
@@ -303,9 +303,6 @@ type viewChangedEvent struct{}
 // complaintEvent is sent when custody has a complaint
 type complaintEvent custodyInfo
 
-// batchExecEvent is sent when a batch execution should take place
-type batchExecEvent execInfo
-
 // returnRequestEvent is sent by pbft when we are forwarded a request
 type returnRequestEvent *Request
 

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -190,7 +190,7 @@ func TestBatchStaleCustody(t *testing.T) {
 	op.pbft.currentExec = new(uint64) // so that pbft.execDone doesn't get unhappy
 	*op.pbft.currentExec = 1
 	rblock2raw, _ := proto.Marshal(&RequestBlock{[]*Request{reqs[1]}})
-	op.executeImpl(1, rblock2raw)
+	op.manager.queue() <- workEvent(func() { op.execute(1, rblock2raw) })
 	time.Sleep(500 * time.Millisecond)
 	op.manager.queue() <- nil
 	if len(reqs) != 3 || !reflect.DeepEqual(reqs[2].Payload, req1.Payload) {

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -129,23 +129,25 @@ func (op *obcClassic) validate(txRaw []byte) error {
 
 // execute an opaque request which corresponds to an OBC Transaction
 func (op *obcClassic) execute(seqNo uint64, txRaw []byte) {
-	tx := &pb.Transaction{}
-	err := proto.Unmarshal(txRaw, tx)
-	if err != nil {
-		logger.Error("Unable to unmarshal transaction: %v", err)
-		return
-	}
+	go func() {
+		tx := &pb.Transaction{}
+		err := proto.Unmarshal(txRaw, tx)
+		if err != nil {
+			logger.Error("Unable to unmarshal transaction: %v", err)
+			return
+		}
 
-	meta, _ := proto.Marshal(&Metadata{seqNo})
+		meta, _ := proto.Marshal(&Metadata{seqNo})
 
-	id := []byte("foo")
-	op.stack.BeginTxBatch(id)
-	result, err := op.stack.ExecTxs(id, []*pb.Transaction{tx})
-	_ = err    // XXX what to do on error?
-	_ = result // XXX what to do with the result?
-	_, err = op.stack.CommitTxBatch(id, meta)
+		id := []byte("foo")
+		op.stack.BeginTxBatch(id)
+		result, err := op.stack.ExecTxs(id, []*pb.Transaction{tx})
+		_ = err    // XXX what to do on error?
+		_ = result // XXX what to do with the result?
+		_, err = op.stack.CommitTxBatch(id, meta)
 
-	op.pbft.execDone()
+		op.pbft.execDone()
+	}()
 }
 
 // called when a view-change happened in the underlying PBFT

--- a/consensus/obcpbft/obc-sieve.go
+++ b/consensus/obcpbft/obc-sieve.go
@@ -650,11 +650,13 @@ func (op *obcSieve) main() {
 // called by pbft-core to execute an opaque request,
 // which is a totally-ordered `Decision`
 func (op *obcSieve) execute(seqNo uint64, raw []byte) {
-	op.executeChan <- &pbftExecute{
-		seqNo: seqNo,
-		txRaw: raw,
-	}
-	logger.Debug("Sieve replica %d successfully sent transaction for sequence number %d", op.id, seqNo)
+	go func() {
+		op.executeChan <- &pbftExecute{
+			seqNo: seqNo,
+			txRaw: raw,
+		}
+		logger.Debug("Sieve replica %d successfully sent transaction for sequence number %d", op.id, seqNo)
+	}()
 }
 
 func (op *obcSieve) executeImpl(seqNo uint64, raw []byte) {

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -880,10 +880,8 @@ func (instance *pbftCore) executeOne(idx msgID) bool {
 		logger.Info("Replica %d executing/committing request for view=%d/seqNo=%d and digest %s",
 			instance.id, idx.v, idx.n, digest)
 
-		// asynchronously execute
-		go func() {
-			instance.consumer.execute(idx.n, req.Payload)
-		}()
+		// synchronously execute, it is the other side's responsibility to execute in the background if needed
+		instance.consumer.execute(idx.n, req.Payload)
 	}
 	return true
 }

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -126,7 +126,7 @@ func (sc *simpleConsumer) execute(seqNo uint64, tx []byte) {
 	sc.lastExecution = tx
 	sc.executions++
 	sc.lastSeqNo = seqNo
-	sc.pe.manager.queue() <- execDoneEvent{}
+	go func() { sc.pe.manager.queue() <- execDoneEvent{} }()
 }
 
 func (sc *simpleConsumer) getState() []byte {


### PR DESCRIPTION
## Description

This changeset moves the actual fabric execution off of the main event thread and onto its own thread so that PBFT can continue to process messages while execution is being performed.

Note that this is only a single commit stacked on top of PR #1689 so please review only the diff for the latest commit when considering this PR (assuming #1689 is likely to be merged in the near future).
## Motivation and Context

The execution of certain transactions, in particular chaincode deploy transactions, can take relatively long amounts of time (multiple seconds).  If the main event thread which is responsible for processing new messages blocks while executing transactions, the message queues can fill up, and messages might be discarded.  Although it's unclear if this is the root of the problem witnessed in #1701, discarding messages unnecessarily can cause thrashing in the system, and seriously degrade the PBFT's performance.

As a brief history of this code path for context in those wishing to understand this changeset:
1. The slowness of deploy transactions introduced the necessity that they execute on their own thread, so executions were performed on their own go routine.
2. In order to detect when requests were being censored, a complaints mechanism was introduced, which required hooking into the execution path to remove transactions from custody as they were processed.
3. Race conditions were encountered between the execution go routine and the event routine as they both attempted to concurrently modify the same data structures.
4. To eliminate the race, the execution go routine queued an event for the main event go routine to perform the execution, which returns us to the original problem from (1).

The solution was to eliminate the execution go routine from PBFT core, and have it call into the plugin synchronously.  This allows the plugin to manipulate the custody data structure safely in a non-concurrent way, then spawn the go routine itself which performs the actual execution, and queues an execution completed event once done.
## How Has This Been Tested?

This changeset changes only the execution flow, not the actual executed code, so existing tests should be sufficient.  This has been tested locally with unit tests, and CI will cover the remainder.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
