### PR TITLE
Transaction response not passed along to 'complete' event callback

### DIFF
--- a/sdk/node/src/hlc.ts
+++ b/sdk/node/src/hlc.ts
@@ -1428,7 +1428,7 @@ export class Peer {
                             eventEmitter.emit('error', 'the response is missing the transaction UUID');
                         } else {
                             eventEmitter.emit('submitted', response.msg);
-                            self.waitToComplete(eventEmitter);
+                            self.waitToComplete(eventEmitter, response.msg);
                         }
                     } else {
                         // Deploy completed with status "FAILURE" or "UNDEFINED"
@@ -1439,7 +1439,7 @@ export class Peer {
                     if (response.status === "SUCCESS") {
                         // Invoke transaction has been submitted
                         eventEmitter.emit('submitted', response.msg);
-                        self.waitToComplete(eventEmitter);
+                        self.waitToComplete(eventEmitter, response.msg);
                     } else {
                         // Invoke completed with status "FAILURE" or "UNDEFINED"
                         eventEmitter.emit('error', response.msg);
@@ -1466,11 +1466,11 @@ export class Peer {
      * This is a temporary hack until event notification is implemented.
      * TODO: implement this appropriately.
      */
-    private waitToComplete(eventEmitter:events.EventEmitter): void {
+    private waitToComplete(eventEmitter:events.EventEmitter, rmsg:Buffer): void {
         debug("waiting 5 seconds before emitting complete event");
         var emitComplete = function() {
             debug("emitting completion event");
-            eventEmitter.emit('complete');
+            eventEmitter.emit('complete',rmsg);
         };
         setTimeout(emitComplete,5000);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Transaction response not passed along to 'complete' event callback
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Spontaneous fix
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Running test/unit/chain-tests.js
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [n/a] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Thomas Eirich eir@zurich.ibm.com
