### PR TITLE
Correctly order PBFT requests on resubmission

### DIFF
--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -215,13 +215,17 @@ func (h *Helper) CommitTxBatch(id interface{}, metadata []byte) (*pb.Block, erro
 	}
 
 	size := ledger.GetBlockchainSize()
-	h.curBatch = nil     // TODO, remove after issue 579
-	h.curBatchErrs = nil // TODO, remove after issue 579
+	defer func() {
+		h.curBatch = nil     // TODO, remove after issue 579
+		h.curBatchErrs = nil // TODO, remove after issue 579
+	}()
 
 	block, err := ledger.GetBlockByNumber(size - 1)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get the block at the head of the chain: %v", err)
 	}
+
+	logger.Debug("Committed block with %d transactions, intended to include %d", len(block.Transactions), len(h.curBatch))
 
 	return block, nil
 }

--- a/consensus/obcpbft/events/events.go
+++ b/consensus/obcpbft/events/events.go
@@ -105,7 +105,7 @@ func (em *managerImpl) Queue() chan<- Event {
 	return em.events
 }
 
-// sendEvent performs the event loop on a receiver to completion
+// SendEvent performs the event loop on a receiver to completion
 func SendEvent(receiver Receiver, event Event) {
 	next := event
 	for {

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -793,6 +793,61 @@ func TestSendQueueThrottling(t *testing.T) {
 	}
 }
 
+// Test for issue #1091
+// Once the primary ran out of sequence numbers, it would queue requests into a map, and resubmit them in arbitrary order
+// This is incorrect, they need to be resubmitted in the order of their timestamps
+func TestSendQueueOrdering(t *testing.T) {
+	prePreparesSent := 0
+
+	mock := &omniProto{}
+	instance := newPbftCore(0, loadConfig(), mock, &inertTimerFactory{})
+	instance.f = 1
+	instance.K = 2
+	instance.L = 100
+	lastTime := &gp.Timestamp{Seconds: 0, Nanos: 0}
+
+	instance.consumer = &omniProto{
+		validateImpl: func(p []byte) error { return nil },
+		broadcastImpl: func(p []byte) {
+			msg := &Message{}
+			err := proto.Unmarshal(p, msg)
+			if err != nil {
+				t.Fatalf("Error unmarshaling payload")
+				return
+			}
+			prePrep := msg.GetPrePrepare()
+			if prePrep == nil {
+				// not a preprepare, ignoring
+				return
+			}
+			req := prePrep.Request
+			if lastTime.Seconds > req.Timestamp.Seconds {
+				t.Fatalf("Did not arrive in order, got %d after %d", req.Timestamp.Seconds, lastTime.Seconds)
+			}
+			lastTime = req.Timestamp
+
+			// As each pre-prepare is sent, delete it from the outstanding requests, like it executed
+			delete(instance.outstandingReqs, prePrep.RequestDigest)
+			prePreparesSent++
+		},
+	}
+	defer instance.close()
+
+	for j := 1; j <= 100; j++ {
+		events.SendEvent(instance, &Request{
+			Timestamp: &gp.Timestamp{Seconds: int64(j), Nanos: 0},
+			Payload:   []byte(fmt.Sprintf("%d", j)),
+		})
+	}
+
+	instance.moveWatermarks(50)
+
+	expected := 100
+	if prePreparesSent != expected {
+		t.Fatalf("Expected to send only %d pre-prepares, but got %d messages", expected, prePreparesSent)
+	}
+}
+
 // From issue #687
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}


### PR DESCRIPTION
## Description

This changeset causes the resubmission of requests to occur in order by timestamp, rather than randomly in map order.

This changeset also includes a couple minor lint fixes and some enhanced debugging.
## Motivation and Context

Once PBFT runs out of sequence numbers, it simply starts queueing requests into a map.  After more sequence numbers become available as the watermarks move, the requests are resubmitted for ordering.  The previous implementation naively resubmitted them in the order in which they emerged from iterating over the map.  This caused an interaction with the custody deduplication mechanism in batch which expects for requests to arrive for execution in the same order that the batch primary submits them to PBFT for ordering (by timestamp).

This would result in later requests being executed before earlier, and consequently, when earlier requests would be scheduled for execution, they would be pruned as 'stale', producing empty blocks.

Fixes the empty block problem from #1091 (which is only half of #1091)
## How Has This Been Tested?

A new test has been added and verified to fail under the old behavior, but to pass under this PR.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
