### PR TITLE
Statetransfer full state block hole fix

### DIFF
--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -215,13 +215,17 @@ func (h *Helper) CommitTxBatch(id interface{}, metadata []byte) (*pb.Block, erro
 	}
 
 	size := ledger.GetBlockchainSize()
-	h.curBatch = nil     // TODO, remove after issue 579
-	h.curBatchErrs = nil // TODO, remove after issue 579
+	defer func() {
+		h.curBatch = nil     // TODO, remove after issue 579
+		h.curBatchErrs = nil // TODO, remove after issue 579
+	}()
 
 	block, err := ledger.GetBlockByNumber(size - 1)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get the block at the head of the chain: %v", err)
 	}
+
+	logger.Debug("Committed block with %d transactions, intended to include %d", len(block.Transactions), len(h.curBatch))
 
 	return block, nil
 }

--- a/consensus/obcpbft/events/events.go
+++ b/consensus/obcpbft/events/events.go
@@ -105,7 +105,7 @@ func (em *managerImpl) Queue() chan<- Event {
 	return em.events
 }
 
-// sendEvent performs the event loop on a receiver to completion
+// SendEvent performs the event loop on a receiver to completion
 func SendEvent(receiver Receiver, event Event) {
 	next := event
 	for {

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -793,6 +793,61 @@ func TestSendQueueThrottling(t *testing.T) {
 	}
 }
 
+// Test for issue #1091
+// Once the primary ran out of sequence numbers, it would queue requests into a map, and resubmit them in arbitrary order
+// This is incorrect, they need to be resubmitted in the order of their timestamps
+func TestSendQueueOrdering(t *testing.T) {
+	prePreparesSent := 0
+
+	mock := &omniProto{}
+	instance := newPbftCore(0, loadConfig(), mock, &inertTimerFactory{})
+	instance.f = 1
+	instance.K = 2
+	instance.L = 100
+	lastTime := &gp.Timestamp{Seconds: 0, Nanos: 0}
+
+	instance.consumer = &omniProto{
+		validateImpl: func(p []byte) error { return nil },
+		broadcastImpl: func(p []byte) {
+			msg := &Message{}
+			err := proto.Unmarshal(p, msg)
+			if err != nil {
+				t.Fatalf("Error unmarshaling payload")
+				return
+			}
+			prePrep := msg.GetPrePrepare()
+			if prePrep == nil {
+				// not a preprepare, ignoring
+				return
+			}
+			req := prePrep.Request
+			if lastTime.Seconds > req.Timestamp.Seconds {
+				t.Fatalf("Did not arrive in order, got %d after %d", req.Timestamp.Seconds, lastTime.Seconds)
+			}
+			lastTime = req.Timestamp
+
+			// As each pre-prepare is sent, delete it from the outstanding requests, like it executed
+			delete(instance.outstandingReqs, prePrep.RequestDigest)
+			prePreparesSent++
+		},
+	}
+	defer instance.close()
+
+	for j := 1; j <= 100; j++ {
+		events.SendEvent(instance, &Request{
+			Timestamp: &gp.Timestamp{Seconds: int64(j), Nanos: 0},
+			Payload:   []byte(fmt.Sprintf("%d", j)),
+		})
+	}
+
+	instance.moveWatermarks(50)
+
+	expected := 100
+	if prePreparesSent != expected {
+		t.Fatalf("Expected to send only %d pre-prepares, but got %d messages", expected, prePreparesSent)
+	}
+}
+
 // From issue #687
 func TestWitnessCheckpointOutOfBounds(t *testing.T) {
 	mock := &omniProto{}

--- a/core/peer/statetransfer/statetransfer_test.go
+++ b/core/peer/statetransfer/statetransfer_test.go
@@ -245,6 +245,17 @@ func TestCatchupWithoutDeltas(t *testing.T) {
 		t.Fatalf("State delta retrieval should not occur during this test")
 	}
 
+	select {
+	case <-sts.blockThreadIdleChan:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timed out waiting for block sync to complete")
+	}
+
+	for i := uint64(0); i <= 7; i++ {
+		if _, err := ml.GetBlockByNumber(i); err != nil {
+			t.Errorf("Expected block %d but got error %s", i, err)
+		}
+	}
 }
 
 func TestCatchupSyncBlocksErrors(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This PR builds on top of PR #1749 so please consider only the latest commit for code review.

This changeset causes state transfer to check for missing blocks after state transfer skips to a point in time via a state snapshot.
## Motivation and Context

Via #1091, the ledger reported `null` blocks on occasion.  After investigation, these seems to occur when there is a missing block in the ledger (this should be handled more cleanly by the REST API, but that is a separate issue).  These 'missing blocks' turn out to be caused by state transfer falling sufficiently behind, that is moves to a point in time in the future.  When this completes, state transfer was not filling in the missing blocks in the background (despite its design to do so).

This was caused by a relatively simple bug, where `break` was used inside a select statement, when it was intended to break from the enclosing for loop.  This bug has been fixed.

Additionally, there was some small logical inefficiencies which are addressed in this changeset.  Rather than retrieve blocks, then see if there are sufficient deltas to recover, this change now checks before the block retrieval.  Similarly the state is detected as invalid when comparing against the known state hash from a valid block, rather than explicitly invalidating it (as the update does).

Does not fix, but is relevant to #1091 
## How Has This Been Tested?

An existing test case has been enhanced to fail under the old behavior, and verifies that the entire chain is recovered after one of these 'skip' operations.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
