### PR TITLE
remove anyTransaction field and dropped Generic event type

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -56,7 +56,6 @@ func (a *Adapter) Recv(msg *ehpb.Event) (bool, error) {
 	//fmt.Printf("Adapter received %+v\n", msg.Event)
 	switch x := msg.Event.(type) {
 	case *ehpb.Event_Block:
-	case *ehpb.Event_Generic:
 	case *ehpb.Event_ChaincodeEvent:
 	case nil:
 		// The field is not set.
@@ -88,11 +87,6 @@ func createTestBlock() *ehpb.Event {
 
 func createTestChaincodeEvent(tid string, typ string) *ehpb.Event {
 	emsg := producer.CreateChaincodeEvent(&ehpb.ChaincodeEvent{ChaincodeID: tid, EventName: typ})
-	return emsg
-}
-
-func createTestGenericEvent() *ehpb.Event {
-	emsg := producer.CreateGenericEvent(&ehpb.Generic{EventType: "uuid#ccEventName", Payload: []byte("event data")})
 	return emsg
 }
 
@@ -179,7 +173,6 @@ func BenchmarkMessages(b *testing.B) {
 
 	for i := 0; i < numMessages; i++ {
 		go func() {
-			//emsg := createTestGenericEvent()
 			//emsg := createTestBlock()
 			emsg := createTestChaincodeEvent("0xffffffff", "event1")
 			if err = producer.Send(emsg); err != nil {

--- a/events/producer/eventhelper.go
+++ b/events/producer/eventhelper.go
@@ -25,12 +25,7 @@ func CreateBlockEvent(te *ehpb.Block) *ehpb.Event {
 	return &ehpb.Event{&ehpb.Event_Block{Block: te}}
 }
 
-//CreateGenericEvent creates a Event from a Generic
-func CreateGenericEvent(te *ehpb.Generic) *ehpb.Event {
-	return &ehpb.Event{&ehpb.Event_Generic{Generic: te}}
-}
-
-//CreateChaincodeEvent creates a Event from a Generic
+//CreateChaincodeEvent creates a Event from a ChaincodeEvent
 func CreateChaincodeEvent(te *ehpb.ChaincodeEvent) *ehpb.Event {
 	return &ehpb.Event{&ehpb.Event_ChaincodeEvent{ChaincodeEvent: te}}
 }

--- a/events/producer/register_internal_events.go
+++ b/events/producer/register_internal_events.go
@@ -26,11 +26,10 @@ import (
 )
 
 //----Event Types -----
-const (
+/*const (
 	RegisterType = "register"
 	BlockType    = "block"
-	GenericType  = "generic"
-)
+) */
 
 func getMessageType(e *pb.Event) pb.EventType {
 	switch e.Event.(type) {
@@ -38,8 +37,6 @@ func getMessageType(e *pb.Event) pb.EventType {
 		return pb.EventType_REGISTER
 	case *pb.Event_Block:
 		return pb.EventType_BLOCK
-	case *pb.Event_Generic:
-		return pb.EventType_GENERIC
 	case *pb.Event_ChaincodeEvent:
 		return pb.EventType_CHAINCODE
 	default:

--- a/protos/api.pb.go
+++ b/protos/api.pb.go
@@ -36,7 +36,6 @@ It has these top-level messages:
 	ChaincodeReg
 	Interest
 	Register
-	Generic
 	Event
 	Transaction
 	TransactionBlock

--- a/protos/events.pb.go
+++ b/protos/events.pb.go
@@ -23,21 +23,18 @@ type EventType int32
 const (
 	EventType_REGISTER  EventType = 0
 	EventType_BLOCK     EventType = 1
-	EventType_GENERIC   EventType = 2
-	EventType_CHAINCODE EventType = 3
+	EventType_CHAINCODE EventType = 2
 )
 
 var EventType_name = map[int32]string{
 	0: "REGISTER",
 	1: "BLOCK",
-	2: "GENERIC",
-	3: "CHAINCODE",
+	2: "CHAINCODE",
 }
 var EventType_value = map[string]int32{
 	"REGISTER":  0,
 	"BLOCK":     1,
-	"GENERIC":   2,
-	"CHAINCODE": 3,
+	"CHAINCODE": 2,
 }
 
 func (x EventType) String() string {
@@ -47,9 +44,8 @@ func (x EventType) String() string {
 // ChaincodeReg is used for registering chaincode Interests
 // when EventType is CHAINCODE
 type ChaincodeReg struct {
-	ChaincodeID    string `protobuf:"bytes,1,opt,name=chaincodeID" json:"chaincodeID,omitempty"`
-	EventName      string `protobuf:"bytes,2,opt,name=eventName" json:"eventName,omitempty"`
-	AnyTransaction bool   `protobuf:"varint,3,opt,name=anyTransaction" json:"anyTransaction,omitempty"`
+	ChaincodeID string `protobuf:"bytes,1,opt,name=chaincodeID" json:"chaincodeID,omitempty"`
+	EventName   string `protobuf:"bytes,2,opt,name=eventName" json:"eventName,omitempty"`
 }
 
 func (m *ChaincodeReg) Reset()         { *m = ChaincodeReg{} }
@@ -153,18 +149,6 @@ func (m *Register) GetEvents() []*Interest {
 	return nil
 }
 
-// ---------- producer events ---------
-// Generic is used for encoding payload as JSON or raw bytes
-// string type - "generic"
-type Generic struct {
-	EventType string `protobuf:"bytes,1,opt,name=eventType" json:"eventType,omitempty"`
-	Payload   []byte `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
-}
-
-func (m *Generic) Reset()         { *m = Generic{} }
-func (m *Generic) String() string { return proto.CompactTextString(m) }
-func (*Generic) ProtoMessage()    {}
-
 // Event is used by
 //  - consumers (adapters) to send Register
 //  - producer to advertise supported types and events
@@ -172,7 +156,6 @@ type Event struct {
 	// Types that are valid to be assigned to Event:
 	//	*Event_Register
 	//	*Event_Block
-	//	*Event_Generic
 	//	*Event_ChaincodeEvent
 	Event isEvent_Event `protobuf_oneof:"Event"`
 }
@@ -191,16 +174,12 @@ type Event_Register struct {
 type Event_Block struct {
 	Block *Block `protobuf:"bytes,2,opt,name=block,oneof"`
 }
-type Event_Generic struct {
-	Generic *Generic `protobuf:"bytes,3,opt,name=generic,oneof"`
-}
 type Event_ChaincodeEvent struct {
-	ChaincodeEvent *ChaincodeEvent `protobuf:"bytes,4,opt,name=chaincodeEvent,oneof"`
+	ChaincodeEvent *ChaincodeEvent `protobuf:"bytes,3,opt,name=chaincodeEvent,oneof"`
 }
 
 func (*Event_Register) isEvent_Event()       {}
 func (*Event_Block) isEvent_Event()          {}
-func (*Event_Generic) isEvent_Event()        {}
 func (*Event_ChaincodeEvent) isEvent_Event() {}
 
 func (m *Event) GetEvent() isEvent_Event {
@@ -224,13 +203,6 @@ func (m *Event) GetBlock() *Block {
 	return nil
 }
 
-func (m *Event) GetGeneric() *Generic {
-	if x, ok := m.GetEvent().(*Event_Generic); ok {
-		return x.Generic
-	}
-	return nil
-}
-
 func (m *Event) GetChaincodeEvent() *ChaincodeEvent {
 	if x, ok := m.GetEvent().(*Event_ChaincodeEvent); ok {
 		return x.ChaincodeEvent
@@ -243,7 +215,6 @@ func (*Event) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, 
 	return _Event_OneofMarshaler, _Event_OneofUnmarshaler, []interface{}{
 		(*Event_Register)(nil),
 		(*Event_Block)(nil),
-		(*Event_Generic)(nil),
 		(*Event_ChaincodeEvent)(nil),
 	}
 }
@@ -262,13 +233,8 @@ func _Event_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 		if err := b.EncodeMessage(x.Block); err != nil {
 			return err
 		}
-	case *Event_Generic:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Generic); err != nil {
-			return err
-		}
 	case *Event_ChaincodeEvent:
-		b.EncodeVarint(4<<3 | proto.WireBytes)
+		b.EncodeVarint(3<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.ChaincodeEvent); err != nil {
 			return err
 		}
@@ -298,15 +264,7 @@ func _Event_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) 
 		err := b.DecodeMessage(msg)
 		m.Event = &Event_Block{msg}
 		return true, err
-	case 3: // Event.generic
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Generic)
-		err := b.DecodeMessage(msg)
-		m.Event = &Event_Generic{msg}
-		return true, err
-	case 4: // Event.chaincodeEvent
+	case 3: // Event.chaincodeEvent
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}

--- a/protos/events.proto
+++ b/protos/events.proto
@@ -27,8 +27,7 @@ package protos;
 enum EventType {
         REGISTER = 0;
         BLOCK = 1;
-	GENERIC = 2;
-	CHAINCODE = 3;
+	CHAINCODE = 2;
 }
 
 //ChaincodeReg is used for registering chaincode Interests
@@ -36,7 +35,6 @@ enum EventType {
 message ChaincodeReg {
     string chaincodeID = 1;
     string eventName = 2;
-    bool anyTransaction = 3;
 }
 
 message Interest {
@@ -57,14 +55,6 @@ message Register {
     repeated Interest events = 1;
 }
 
-//---------- producer events ---------
-//Generic is used for encoding payload as JSON or raw bytes
-//string type - "generic"
-message Generic {
-    string eventType = 1;
-    bytes payload = 2;
-}
-
 //Event is used by
 //  - consumers (adapters) to send Register
 //  - producer to advertise supported types and events
@@ -77,8 +67,7 @@ message Event {
 
         //producer events
         Block block = 2;
-        Generic generic = 3;
-        ChaincodeEvent chaincodeEvent = 4;
+        ChaincodeEvent chaincodeEvent = 3;
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

anyTransaction was put in yesterday's PR, it should have been removed
Generic transaction type was never allowed as a client registration type and its functionality (it was intended to encode payload field to json vs protobuf) has been verified to be redundant to jsonpb. Clients may convert protobuf payload to json using jsonpb.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

reduces complexity

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #
No open issue
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

reran events unit test cases

<!--- If this PR does not contain a new test case, explain why. -->

minor cleanup - no new functionality
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Patrick Mullaney pmullaney@lseg.com
