### PR TITLE
Fix reset for event timers in consensus

### DIFF
--- a/consensus/obcpbft/events/events.go
+++ b/consensus/obcpbft/events/events.go
@@ -254,12 +254,12 @@ func (et *timerImpl) loop() {
 			eventDestChan = nil
 		case <-et.stopChan:
 			if et.timerChan == nil && eventDestChan == nil {
-				logger.Warning("Attempting to stop an unfired idle timer")
+				logger.Debug("Attempting to stop an unfired idle timer")
 			}
 			et.timerChan = nil
-			logger.Debug("Stopping timer for")
+			logger.Debug("Stopping timer")
 			if eventDestChan != nil {
-				logger.Debug("Timer for cleared pending event")
+				logger.Debug("Timer cleared pending event")
 			}
 			eventDestChan = nil
 			event = nil

--- a/consensus/obcpbft/events/events.go
+++ b/consensus/obcpbft/events/events.go
@@ -210,7 +210,7 @@ func (et *timerImpl) SoftReset(timeout time.Duration, event Event) {
 	et.startChan <- &timerStart{
 		duration: timeout,
 		event:    event,
-		hard:     true,
+		hard:     false,
 	}
 }
 
@@ -219,7 +219,7 @@ func (et *timerImpl) Reset(timeout time.Duration, event Event) {
 	et.startChan <- &timerStart{
 		duration: timeout,
 		event:    event,
-		hard:     false,
+		hard:     true,
 	}
 }
 

--- a/consensus/obcpbft/events/events_test.go
+++ b/consensus/obcpbft/events/events_test.go
@@ -22,7 +22,9 @@ import (
 )
 
 // mockEventID is equivalent to MIN_INT to prevent collisions
-type mockEvent struct{}
+type mockEvent struct {
+	info string
+}
 
 type mockReceiver struct {
 	processEventImpl func(event Event) Event
@@ -76,8 +78,8 @@ func TestEventTimerHardReset(t *testing.T) {
 	})
 	timer := newTimerImpl(mr)
 	defer timer.Halt()
-	me1 := &mockEvent{}
-	me2 := &mockEvent{}
+	me1 := &mockEvent{"one"}
+	me2 := &mockEvent{"two"}
 	timer.Reset(time.Millisecond, me1)
 	timer.Reset(time.Millisecond, me2)
 
@@ -87,7 +89,7 @@ func TestEventTimerHardReset(t *testing.T) {
 	select {
 	case e := <-events:
 		if e != me2 {
-			t.Fatalf("Received wrong output from event timer")
+			t.Fatalf("Received wrong output (%v) from event timer", e)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for event to fire")
@@ -103,8 +105,8 @@ func TestEventTimerSoftReset(t *testing.T) {
 	})
 	timer := newTimerImpl(mr)
 	defer timer.Halt()
-	me1 := &mockEvent{}
-	me2 := &mockEvent{}
+	me1 := &mockEvent{"one"}
+	me2 := &mockEvent{"two"}
 	timer.SoftReset(time.Millisecond, me1)
 	timer.SoftReset(time.Millisecond, me2)
 
@@ -114,7 +116,7 @@ func TestEventTimerSoftReset(t *testing.T) {
 	select {
 	case e := <-events:
 		if e != me1 {
-			t.Fatalf("Received wrong output from event timer")
+			t.Fatalf("Received wrong output (%v) from event timer", e)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for event to fire")

--- a/consensus/obcpbft/events/events_test.go
+++ b/consensus/obcpbft/events/events_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 )
 
-// mockEventID is equivalent to MIN_INT to prevent collisions
 type mockEvent struct {
 	info string
 }


### PR DESCRIPTION
## Description

For the event timers in consensus, `Reset()` should reset an existing timer to a new timeout and clear out any pending events, while `SoftReset()` should reset the timer only if it's not already running. Right now, their functionality is the opposite.
## Motivation and Context

This change is needed to deliver the expected functionality for the two methods.
## How Has This Been Tested?

I have modified the existing unit tests in the `events` package by adding a field to the `mockEvent` struct. This makes detection of such errors possible.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Kostas Christidis kchristidis@us.ibm.com
