### PR TITLE
fixes #1299 by removing instance of multiplication by time.Millisecond

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -114,7 +114,7 @@ func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEn
 
 	s.userRunsCC = userrunsCC
 
-	s.ccStartupTimeout = ccstartuptimeout * time.Millisecond
+	s.ccStartupTimeout = ccstartuptimeout
 
 	//TODO I'm not sure if this needs to be on a per chain basis... too lowel and just needs to be a global default ?
 	s.chaincodeInstallPath = viper.GetString("chaincode.installpath")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Removed redundant multiplication of timeout setting 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

There is a parameter in core.yaml ( `chaincode.startuptimeout` ) which ends up being accidentally multiplied by `time.Millisecond` in two places (once in the peer on startup and later in the chaincode_support module).  This results in a startup timeout of 277h46m40s rather than the intended 1s

Fixes #1299
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

No new test case added as the current tests still pass.  We have also been patching the code we use to run the Bluemix service for months as well and know this change works.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Gari Singh gari.r.singh@gmail.com
