### PR TITLE
Add executor service

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -81,6 +81,8 @@ type LegacyExecutor interface {
 // The problem with invoking the calls directly above, is that they must be coordinated
 // with state transfer, to eliminate possible races and ledger corruption
 type Executor interface {
+	Start()                                                                     // Bring up the resources needed to use this interface
+	Halt()                                                                      // Tear down the resources needed to use this interface
 	Execute(tag interface{}, txs []*pb.Transaction)                             // Executes a set of transactions, this may be called in succession
 	Commit(tag interface{}, metadata []byte)                                    // Commits whatever transactions have been executed
 	Rollback(tag interface{})                                                   // Rolls back whatever transactions have been executed

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -68,7 +68,7 @@ type ReadOnlyLedger interface {
 	GetBlockHeadMetadata() ([]byte, error)
 }
 
-// Executor is used to invoke transactions, potentially modifying the backing ledger
+// LegacyExecutor is used to invoke transactions, potentially modifying the backing ledger
 type LegacyExecutor interface {
 	BeginTxBatch(id interface{}) error
 	ExecTxs(id interface{}, txs []*pb.Transaction) ([]byte, error)
@@ -77,7 +77,7 @@ type LegacyExecutor interface {
 	PreviewCommitTxBatch(id interface{}, metadata []byte) ([]byte, error)
 }
 
-// NewExecutor is intended to eventually supplant the old Executor interface
+// Executor is intended to eventually supplant the old Executor interface
 // The problem with invoking the calls directly above, is that they must be coordinated
 // with state transfer, to eliminate possible races and ledger corruption
 type Executor interface {
@@ -89,8 +89,8 @@ type Executor interface {
 
 // LedgerManager is used to manipulate the state of the ledger
 type LedgerManager interface {
-	InvalidateState()                                 // Invalidate informs the ledger that it is out of date and should reject queries
-	ValidateState()                                   // Validate informs the ledger that it is back up to date and should resume replying to queries
+	InvalidateState() // Invalidate informs the ledger that it is out of date and should reject queries
+	ValidateState()   // Validate informs the ledger that it is back up to date and should resume replying to queries
 }
 
 // StatePersistor is used to store consensus state which should survive a process crash

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -20,12 +20,19 @@ import (
 	pb "github.com/hyperledger/fabric/protos"
 )
 
+// ExecutionConsumer allows callbacks from asycnhronous execution and statetransfer
+type ExecutionConsumer interface {
+	Executed(tag interface{})                                // Called whenever Execute completes
+	Committed(tag interface{}, target *pb.BlockchainInfo)    // Called whenever Commit completes
+	RolledBack(tag interface{})                              // Called whenever a Rollback completes
+	StateUpdated(tag interface{}, target *pb.BlockchainInfo) // Called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
+}
+
 // Consenter is used to receive messages from the network
 // Every consensus plugin needs to implement this interface
 type Consenter interface {
 	RecvMsg(msg *pb.Message, senderHandle *pb.PeerID) error // Called serially with incoming messages from gRPC
-	StateUpdated(tag uint64, id []byte)                     // Called when state transfer completes, serial with StateUpdating
-	StateUpdating(tag uint64, id []byte)                    // Called when SkipTo causes state transfer to start serial with StateUpdated
+	ExecutionConsumer
 }
 
 // Inquirer is used to retrieve info about the validating network
@@ -56,12 +63,13 @@ type SecurityUtils interface {
 type ReadOnlyLedger interface {
 	GetBlock(id uint64) (block *pb.Block, err error)
 	GetBlockchainSize() uint64
+	GetBlockchainInfo() *pb.BlockchainInfo
 	GetBlockchainInfoBlob() []byte
 	GetBlockHeadMetadata() ([]byte, error)
 }
 
 // Executor is used to invoke transactions, potentially modifying the backing ledger
-type Executor interface {
+type LegacyExecutor interface {
 	BeginTxBatch(id interface{}) error
 	ExecTxs(id interface{}, txs []*pb.Transaction) ([]byte, error)
 	CommitTxBatch(id interface{}, metadata []byte) (*pb.Block, error)
@@ -69,9 +77,18 @@ type Executor interface {
 	PreviewCommitTxBatch(id interface{}, metadata []byte) ([]byte, error)
 }
 
+// NewExecutor is intended to eventually supplant the old Executor interface
+// The problem with invoking the calls directly above, is that they must be coordinated
+// with state transfer, to eliminate possible races and ledger corruption
+type Executor interface {
+	Execute(tag interface{}, txs []*pb.Transaction)                             // Executes a set of transactions, this may be called in succession
+	Commit(tag interface{}, metadata []byte)                                    // Commits whatever transactions have been executed
+	Rollback(tag interface{})                                                   // Rolls back whatever transactions have been executed
+	UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) // Attempts to synchronize state to a particular target, implicitly calls rollback if needed
+}
+
 // LedgerManager is used to manipulate the state of the ledger
 type LedgerManager interface {
-	SkipTo(tag uint64, id []byte, peers []*pb.PeerID) // SkipTo tells state transfer to bring the ledger to a particular state, it should generally be preceeded/proceeded by Invalidate/Validate
 	InvalidateState()                                 // Invalidate informs the ledger that it is out of date and should reject queries
 	ValidateState()                                   // Validate informs the ledger that it is back up to date and should resume replying to queries
 }
@@ -89,6 +106,7 @@ type Stack interface {
 	NetworkStack
 	SecurityUtils
 	Executor
+	LegacyExecutor
 	LedgerManager
 	ReadOnlyLedger
 	StatePersistor

--- a/consensus/executor/executor.go
+++ b/consensus/executor/executor.go
@@ -1,0 +1,220 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric/consensus"
+	"github.com/hyperledger/fabric/consensus/obcpbft/events"
+	"github.com/hyperledger/fabric/core/peer/statetransfer"
+	pb "github.com/hyperledger/fabric/protos"
+
+	"github.com/op/go-logging"
+)
+
+var logger *logging.Logger // package-level logger
+
+func init() {
+	logger = logging.MustGetLogger("consensus/executor")
+}
+
+// PartialStack contains the ledger features required by the executor.Coordinator
+type PartialStack interface {
+	consensus.LegacyExecutor
+	GetBlockchainInfo() *pb.BlockchainInfo
+}
+
+type coordinatorImpl struct {
+	manager         events.Manager              // Maintains event thread and sends events to the coordinator
+	rawExecutor     PartialStack                // Does the real interaction with the ledger
+	consumer        consensus.ExecutionConsumer // The consumer of this coordinator which receives the callbacks
+	stc             statetransfer.Coordinator   // State transfer instance
+	batchInProgress bool                        // Are we mid execution batch
+	skipInProgress  bool                        // Are we mid state transfer
+}
+
+// NewCoordinatorImpl creates a new executor.Coordinator
+func NewImpl(consumer consensus.ExecutionConsumer, rawExecutor PartialStack, stps statetransfer.PartialStack) consensus.Executor {
+	co := &coordinatorImpl{
+		rawExecutor: rawExecutor,
+		consumer:    consumer,
+		stc:         statetransfer.NewCoordinatorImpl(stps),
+		manager:     events.NewManagerImpl(),
+	}
+	co.manager.SetReceiver(co)
+	return co
+}
+
+// ProcessEvent is the main event loop for the executor.Coordinator
+func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
+	switch et := event.(type) {
+	case executeEvent:
+		if logger.IsEnabledFor(logging.DEBUG) {
+			if logger.IsEnabledFor(logging.DEBUG) {
+				logger.Debug("Executor is processing an executeEvent")
+			}
+		}
+		if co.skipInProgress {
+			logger.Error("FATAL programming error, attempted to execute a transaction during state transfer")
+			return nil
+		}
+
+		if !co.batchInProgress {
+			if logger.IsEnabledFor(logging.DEBUG) {
+				logger.Debug("Starting new transaction batch")
+			}
+			co.batchInProgress = true
+			err := co.rawExecutor.BeginTxBatch(co)
+			_ = err // TODO This should probably panic, see issue 752
+		}
+
+		co.rawExecutor.ExecTxs(co, et.txs)
+
+		co.consumer.Executed(et.tag)
+	case commitEvent:
+		if logger.IsEnabledFor(logging.DEBUG) {
+			logger.Debug("Executor is processing an commitEvent")
+		}
+		if co.skipInProgress {
+			logger.Error("Likely FATAL programming error, attempted to commit a transaction batch during state transfer")
+			return nil
+		}
+
+		if !co.batchInProgress {
+			logger.Error("Likely FATAL programming error, attemted to commit a transaction batch when one does not exist")
+			return nil
+		}
+
+		_, err := co.rawExecutor.CommitTxBatch(co, et.metadata)
+		_ = err // TODO This should probably panic, see issue 752
+
+		co.batchInProgress = false
+
+		info := co.rawExecutor.GetBlockchainInfo()
+
+		co.consumer.Committed(et.tag, info)
+	case rollbackEvent:
+		if logger.IsEnabledFor(logging.DEBUG) {
+			logger.Debug("Executor is processing an rollbackEvent")
+		}
+		if co.skipInProgress {
+			logger.Error("Programming error, attempted to rollback a transaction batch during state transfer")
+			return nil
+		}
+
+		if !co.batchInProgress {
+			logger.Error("Programming error, attempted to rollback a transaction batch which had not started")
+			return nil
+		}
+
+		err := co.rawExecutor.RollbackTxBatch(co)
+		_ = err // TODO This should probably panic, see issue 752
+
+		co.batchInProgress = false
+
+		co.consumer.RolledBack(et.tag)
+	case stateUpdateEvent:
+		if logger.IsEnabledFor(logging.DEBUG) {
+			logger.Debug("Executor is processing an stateUpdateEvent")
+		}
+		if co.batchInProgress {
+			err := co.rawExecutor.RollbackTxBatch(co)
+			_ = err // TODO This should probably panic, see issue 752
+		}
+
+		co.skipInProgress = true
+
+		info := et.blockchainInfo
+		for {
+			err, recoverable := co.stc.SyncToTarget(info.Height-1, info.CurrentBlockHash, et.peers)
+			if err == nil {
+				co.skipInProgress = false
+				co.consumer.StateUpdated(et.tag, info)
+				return nil
+			}
+			if !recoverable {
+				if logger.IsEnabledFor(logging.DEBUG) {
+					logger.Debug("State transfer failed irrecoverably, calling back to consumer: %s", err)
+				}
+				co.consumer.StateUpdated(et.tag, nil)
+				return nil
+			}
+			logger.Warning("State transfer did not complete successfully but is recoverable, trying again: %s", err)
+			et.peers = nil // Broaden the peers included in recover to all connected
+		}
+	default:
+		logger.Error(fmt.Sprintf("Unknown event type %s", et))
+	}
+
+	return nil
+}
+
+// Commit commits whatever outstanding requests have been executed, it is an error to call this without pending executions
+func (co *coordinatorImpl) Commit(tag interface{}, metadata []byte) {
+	co.manager.Queue() <- commitEvent{tag, metadata}
+}
+
+// Execute adds additional executions to the current batch
+func (co *coordinatorImpl) Execute(tag interface{}, txs []*pb.Transaction) {
+	co.manager.Queue() <- executeEvent{tag, txs}
+}
+
+// Rollback rolls back the executions from the current batch
+func (co *coordinatorImpl) Rollback(tag interface{}) {
+	co.manager.Queue() <- rollbackEvent{tag}
+}
+
+// UpdateState uses the state transfer subsystem to attempt to progress to a target
+func (co *coordinatorImpl) UpdateState(tag interface{}, info *pb.BlockchainInfo, peers []*pb.PeerID) {
+	co.manager.Queue() <- stateUpdateEvent{tag, info, peers}
+}
+
+// Start must be called before utilizing the Coordinator
+func (co *coordinatorImpl) Start() {
+	co.stc.Start()
+	co.manager.Start()
+}
+
+// Halt should be called to clean up resources allocated by the Coordinator
+func (co *coordinatorImpl) Halt() {
+	co.stc.Stop()
+	co.manager.Halt()
+}
+
+// Event types
+
+type executeEvent struct {
+	tag interface{}
+	txs []*pb.Transaction
+}
+
+// Note, this cannot be a simple type alias, in case tag is nil
+type rollbackEvent struct {
+	tag interface{}
+}
+
+type commitEvent struct {
+	tag      interface{}
+	metadata []byte
+}
+
+type stateUpdateEvent struct {
+	tag            interface{}
+	blockchainInfo *pb.BlockchainInfo
+	peers          []*pb.PeerID
+}

--- a/consensus/executor/executor.go
+++ b/consensus/executor/executor.go
@@ -64,20 +64,14 @@ func NewImpl(consumer consensus.ExecutionConsumer, rawExecutor PartialStack, stp
 func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 	switch et := event.(type) {
 	case executeEvent:
-		if logger.IsEnabledFor(logging.DEBUG) {
-			if logger.IsEnabledFor(logging.DEBUG) {
-				logger.Debug("Executor is processing an executeEvent")
-			}
-		}
+		logger.Debug("Executor is processing an executeEvent")
 		if co.skipInProgress {
 			logger.Error("FATAL programming error, attempted to execute a transaction during state transfer")
 			return nil
 		}
 
 		if !co.batchInProgress {
-			if logger.IsEnabledFor(logging.DEBUG) {
-				logger.Debug("Starting new transaction batch")
-			}
+			logger.Debug("Starting new transaction batch")
 			co.batchInProgress = true
 			err := co.rawExecutor.BeginTxBatch(co)
 			_ = err // TODO This should probably panic, see issue 752
@@ -87,9 +81,7 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 
 		co.consumer.Executed(et.tag)
 	case commitEvent:
-		if logger.IsEnabledFor(logging.DEBUG) {
-			logger.Debug("Executor is processing an commitEvent")
-		}
+		logger.Debug("Executor is processing an commitEvent")
 		if co.skipInProgress {
 			logger.Error("Likely FATAL programming error, attempted to commit a transaction batch during state transfer")
 			return nil
@@ -109,9 +101,7 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 
 		co.consumer.Committed(et.tag, info)
 	case rollbackEvent:
-		if logger.IsEnabledFor(logging.DEBUG) {
-			logger.Debug("Executor is processing an rollbackEvent")
-		}
+		logger.Debug("Executor is processing an rollbackEvent")
 		if co.skipInProgress {
 			logger.Error("Programming error, attempted to rollback a transaction batch during state transfer")
 			return nil
@@ -129,9 +119,7 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 
 		co.consumer.RolledBack(et.tag)
 	case stateUpdateEvent:
-		if logger.IsEnabledFor(logging.DEBUG) {
-			logger.Debug("Executor is processing an stateUpdateEvent")
-		}
+		logger.Debug("Executor is processing an stateUpdateEvent")
 		if co.batchInProgress {
 			err := co.rawExecutor.RollbackTxBatch(co)
 			_ = err // TODO This should probably panic, see issue 752
@@ -148,9 +136,7 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 				return nil
 			}
 			if !recoverable {
-				if logger.IsEnabledFor(logging.DEBUG) {
-					logger.Debug("State transfer failed irrecoverably, calling back to consumer: %s", err)
-				}
+				logger.Warning("State transfer failed irrecoverably, calling back to consumer: %s", err)
 				co.consumer.StateUpdated(et.tag, nil)
 				return nil
 			}

--- a/consensus/executor/executor_test.go
+++ b/consensus/executor/executor_test.go
@@ -1,0 +1,522 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric/consensus/obcpbft/events"
+
+	pb "github.com/hyperledger/fabric/protos"
+
+	"github.com/op/go-logging"
+)
+
+func init() {
+	logging.SetLevel(logging.DEBUG, "")
+}
+
+// -------------------------
+//
+// Mock consumer
+//
+// -------------------------
+
+type mockConsumer struct {
+	ExecutedImpl     func(tag interface{})                            // Called whenever Execute completes
+	CommittedImpl    func(tag interface{}, target *pb.BlockchainInfo) // Called whenever Commit completes
+	RolledBackImpl   func(tag interface{})                            // Called whenever a Rollback completes
+	StateUpdatedImpl func(tag interface{}, target *pb.BlockchainInfo) // Called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
+}
+
+func (mock *mockConsumer) Executed(tag interface{}) {
+	if mock.ExecutedImpl != nil {
+		mock.ExecutedImpl(tag)
+	}
+}
+
+func (mock *mockConsumer) Committed(tag interface{}, target *pb.BlockchainInfo) {
+	if mock.CommittedImpl != nil {
+		mock.CommittedImpl(tag, target)
+	}
+}
+
+func (mock *mockConsumer) RolledBack(tag interface{}) {
+	if mock.RolledBackImpl != nil {
+		mock.RolledBackImpl(tag)
+	}
+}
+
+func (mock *mockConsumer) StateUpdated(tag interface{}, target *pb.BlockchainInfo) {
+	if mock.StateUpdatedImpl != nil {
+		mock.StateUpdatedImpl(tag, target)
+	}
+}
+
+// -------------------------
+//
+// Mock rawExecutor
+//
+// -------------------------
+
+type mockRawExecutor struct {
+	t           *testing.T
+	curBatch    interface{}
+	curTxs      []*pb.Transaction
+	commitCount uint64
+}
+
+func (mock *mockRawExecutor) BeginTxBatch(id interface{}) error {
+	if mock.curBatch != nil {
+		e := fmt.Errorf("Attempted to start a new batch without stopping the other")
+		mock.t.Fatal(e)
+		return e
+	}
+	mock.curBatch = id
+	return nil
+}
+
+func (mock *mockRawExecutor) ExecTxs(id interface{}, txs []*pb.Transaction) ([]byte, error) {
+	if mock.curBatch != id {
+		e := fmt.Errorf("Attempted to exec on a different batch")
+		mock.t.Fatal(e)
+		return nil, e
+	}
+	mock.curTxs = append(mock.curTxs, txs...)
+	return nil, nil
+}
+
+func (mock *mockRawExecutor) CommitTxBatch(id interface{}, meta []byte) (*pb.Block, error) {
+	if mock.curBatch != id {
+		e := fmt.Errorf("Attempted to commit a batch which doesn't exist")
+		mock.t.Fatal(e)
+		return nil, e
+	}
+	mock.commitCount++
+	return nil, nil
+}
+
+func (mock *mockRawExecutor) RollbackTxBatch(id interface{}) error {
+	if mock.curBatch == nil {
+		e := fmt.Errorf("Attempted to rollback a batch which doesn't exist")
+		mock.t.Fatal(e)
+		return e
+	}
+
+	mock.curTxs = nil
+	mock.curBatch = nil
+
+	return nil
+}
+
+func (mock *mockRawExecutor) PreviewCommitTxBatch(id interface{}, meta []byte) ([]byte, error) {
+	if mock.curBatch != nil {
+		e := fmt.Errorf("Attempted to preview a batch which doesn't exist")
+		mock.t.Fatal(e)
+		return nil, e
+	}
+
+	return nil, nil
+}
+
+func (mock *mockRawExecutor) GetBlockchainInfo() *pb.BlockchainInfo {
+	return &pb.BlockchainInfo{
+		Height:            mock.commitCount,
+		CurrentBlockHash:  []byte(fmt.Sprintf("%d", mock.commitCount)),
+		PreviousBlockHash: []byte(fmt.Sprintf("%d", mock.commitCount-1)),
+	}
+}
+
+// -------------------------
+//
+// Mock stateTransfer
+//
+// -------------------------
+
+type mockStateTransfer struct {
+	StartImpl        func()
+	StopImpl         func()
+	SyncToTargetImpl func(blockNumber uint64, blockHash []byte, peerIDs []*pb.PeerID) (error, bool)
+}
+
+func (mock *mockStateTransfer) Start() {}
+func (mock *mockStateTransfer) Stop()  {}
+
+func (mock *mockStateTransfer) SyncToTarget(blockNumber uint64, blockHash []byte, peerIDs []*pb.PeerID) (error, bool) {
+	if mock.SyncToTargetImpl != nil {
+		return mock.SyncToTargetImpl(blockNumber, blockHash, peerIDs)
+	}
+	return nil, false
+}
+
+// -------------------------
+//
+// Mock event manager
+//
+// -------------------------
+
+type mockEventManager struct {
+	target          events.Receiver
+	bufferedChannel chan events.Event // This is buffered so that queueing never blocks
+}
+
+func (mock *mockEventManager) Start() {}
+
+func (mock *mockEventManager) Halt() {}
+
+func (mock *mockEventManager) Inject(event events.Event) {}
+
+func (mock *mockEventManager) SetReceiver(receiver events.Receiver) {
+	mock.target = receiver
+}
+
+func (mock *mockEventManager) Queue() chan<- events.Event {
+	return mock.bufferedChannel
+}
+
+func (mock *mockEventManager) process() {
+	for {
+		select {
+		case ev := <-mock.bufferedChannel:
+			events.SendEvent(mock.target, ev)
+		default:
+			return
+		}
+	}
+}
+
+// -------------------------
+//
+// Util functions
+//
+// -------------------------
+
+func newMocks(t *testing.T) (*coordinatorImpl, *mockConsumer, *mockRawExecutor, *mockStateTransfer, *mockEventManager) {
+	mc := &mockConsumer{}
+	mre := &mockRawExecutor{t: t}
+	mst := &mockStateTransfer{}
+	mev := &mockEventManager{bufferedChannel: make(chan events.Event, 100)}
+	co := &coordinatorImpl{
+		consumer:    mc,
+		rawExecutor: mre,
+		stc:         mst,
+		manager:     mev,
+	}
+	mev.target = co
+	return co, mc, mre, mst, mev
+}
+
+// -------------------------
+//
+// Actual Tests
+//
+// -------------------------
+
+// TestNormalExecutes executes 50 transactions, then commits, ensuring that the callbacks are called appropriately
+func TestNormalExecutes(t *testing.T) {
+	co, mc, _, _, mev := newMocks(t)
+
+	times := uint64(50)
+
+	id := struct{}{}
+	testTxs := []*pb.Transaction{&pb.Transaction{}, &pb.Transaction{}, &pb.Transaction{}}
+
+	executed := uint64(0)
+	mc.ExecutedImpl = func(tag interface{}) {
+		if tag != id {
+			t.Fatalf("Executed got wrong ID")
+		}
+		executed++
+	}
+
+	committed := false
+	mc.CommittedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if tag != id {
+			t.Fatalf("Committed got wrong ID")
+		}
+		committed = true
+		if info.Height != 1 {
+			t.Fatalf("Blockchain info should have returned height of %d, returned %d", 1, info.Height)
+		}
+	}
+
+	for i := uint64(0); i < times; i++ {
+		co.Execute(id, testTxs)
+	}
+
+	co.Commit(id, nil)
+	mev.process()
+
+	if executed != times {
+		t.Fatalf("Should have executed %d times but executed %d times", times, executed)
+	}
+
+	if !committed {
+		t.Fatalf("Should have committed")
+	}
+}
+
+// TestRollbackExecutes executes 5 transactions, then rolls back, executes 5 more and commits, ensuring that the callbacks are called appropriately
+func TestRollbackExecutes(t *testing.T) {
+	co, mc, _, _, mev := newMocks(t)
+
+	times := uint64(5)
+
+	id := struct{}{}
+	testTxs := []*pb.Transaction{&pb.Transaction{}, &pb.Transaction{}, &pb.Transaction{}}
+
+	executed := uint64(0)
+	mc.ExecutedImpl = func(tag interface{}) {
+		if tag != id {
+			t.Fatalf("Executed got wrong ID")
+		}
+		executed++
+	}
+
+	committed := false
+	mc.CommittedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if tag != id {
+			t.Fatalf("Committed got wrong ID")
+		}
+		committed = true
+		if info.Height != 1 {
+			t.Fatalf("Blockchain info should have returned height of %d, returned %d", 1, info.Height)
+		}
+	}
+
+	rolledBack := false
+	mc.RolledBackImpl = func(tag interface{}) {
+		if tag != id {
+			t.Fatalf("RolledBack got wrong ID")
+		}
+		rolledBack = true
+	}
+
+	for i := uint64(0); i < times; i++ {
+		co.Execute(id, testTxs)
+	}
+
+	co.Rollback(id)
+	mev.process()
+
+	if !rolledBack {
+		t.Fatalf("Should have rolled back")
+	}
+
+	for i := uint64(0); i < times; i++ {
+		co.Execute(id, testTxs)
+	}
+	co.Commit(id, nil)
+	mev.process()
+
+	if executed != 2*times {
+		t.Fatalf("Should have executed %d times but executed %d times", 2*times, executed)
+	}
+
+	if !committed {
+		t.Fatalf("Should have committed")
+	}
+}
+
+// TestEmptyCommit attempts to commit without executing any transactions, this is considered a fatal error and no callback should occur
+func TestEmptyCommit(t *testing.T) {
+	co, mc, _, _, mev := newMocks(t)
+
+	mc.CommittedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		t.Fatalf("Should not have committed")
+	}
+
+	co.Commit(nil, nil)
+	mev.process()
+}
+
+// TestEmptyRollback attempts a rollback without executing any transactions, this is considered an error and no callback should occur
+func TestEmptyRollback(t *testing.T) {
+	co, mc, _, _, mev := newMocks(t)
+
+	mc.RolledBackImpl = func(tag interface{}) {
+		t.Fatalf("Should not have committed")
+	}
+
+	co.Rollback(nil)
+	mev.process()
+}
+
+// TestNormalStateTransfer attempts a simple state transfer request with 10 recoverable failures
+func TestNormalStateTransfer(t *testing.T) {
+	co, mc, _, mst, mev := newMocks(t)
+	//co, mc, mre, mst, mev := newMocks(t)
+
+	id := struct{}{}
+	blockNumber := uint64(2389)
+	blockHash := []byte("BlockHash")
+
+	stateUpdated := false
+	mc.StateUpdatedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if id != tag {
+			t.Fatalf("Incorrect tag received")
+		}
+		if stateUpdated {
+			t.Fatalf("State should only be updated once")
+		}
+		if info.Height != blockNumber+1 {
+			t.Fatalf("Final height should have been %d", blockNumber+1)
+		}
+		if !bytes.Equal(info.CurrentBlockHash, blockHash) {
+			t.Fatalf("Final height should have been %d", blockNumber+1)
+		}
+		stateUpdated = true
+	}
+
+	count := 0
+	mst.SyncToTargetImpl = func(bn uint64, bh []byte, ps []*pb.PeerID) (error, bool) {
+		count++
+		if count <= 10 {
+			return fmt.Errorf("Transient state transfer error"), true
+		}
+
+		return nil, true
+	}
+
+	co.UpdateState(id, &pb.BlockchainInfo{Height: blockNumber + 1, CurrentBlockHash: blockHash}, nil)
+	mev.process()
+
+	if !stateUpdated {
+		t.Fatalf("State should have been updated")
+	}
+}
+
+// TestFailingStateTransfer attempts a failing simple state transfer request with 10 recoverable failures, then a fatal error, then a success
+func TestFailingStateTransfer(t *testing.T) {
+	co, mc, _, mst, mev := newMocks(t)
+	//co, mc, mre, mst, mev := newMocks(t)
+
+	id := struct{}{}
+	blockNumber1 := uint64(1)
+	blockHash1 := []byte("BlockHash1")
+	blockNumber2 := uint64(2)
+	blockHash2 := []byte("BlockHash2")
+
+	stateUpdated := false
+	mc.StateUpdatedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if id != tag {
+			t.Fatalf("Incorrect tag received")
+		}
+		if stateUpdated {
+			t.Fatalf("State should only be updated once")
+		}
+		if info == nil {
+			return
+		}
+		if info.Height != blockNumber2+1 {
+			t.Fatalf("Final height should have been %d", blockNumber2+1)
+		}
+		if !bytes.Equal(info.CurrentBlockHash, blockHash2) {
+			t.Fatalf("Final height should have been %d", blockNumber2+1)
+		}
+		stateUpdated = true
+	}
+
+	count := 0
+	mst.SyncToTargetImpl = func(bn uint64, bh []byte, ps []*pb.PeerID) (error, bool) {
+		count++
+		if count <= 10 {
+			return fmt.Errorf("Transient state transfer error"), true
+		}
+
+		if bn == blockNumber1 {
+			return fmt.Errorf("Irrecoverable state transfer error"), false
+		}
+
+		return nil, true
+	}
+
+	co.UpdateState(id, &pb.BlockchainInfo{Height: blockNumber1 + 1, CurrentBlockHash: blockHash1}, nil)
+	mev.process()
+
+	if stateUpdated {
+		t.Fatalf("State should not have been updated")
+	}
+
+	co.UpdateState(id, &pb.BlockchainInfo{Height: blockNumber2 + 1, CurrentBlockHash: blockHash2}, nil)
+	mev.process()
+
+	if !stateUpdated {
+		t.Fatalf("State should have been updated")
+	}
+}
+
+// TestExecuteAfterStateTransfer attempts an execute and commit after a simple state transfer request
+func TestExecuteAfterStateTransfer(t *testing.T) {
+	co, mc, _, _, mev := newMocks(t)
+	testTxs := []*pb.Transaction{&pb.Transaction{}, &pb.Transaction{}, &pb.Transaction{}}
+
+	id := struct{}{}
+	blockNumber := uint64(2389)
+	blockHash := []byte("BlockHash")
+
+	stateTransferred := false
+	mc.StateUpdatedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if nil == info {
+			t.Fatalf("State transfer should have succeeded")
+		}
+		stateTransferred = true
+	}
+
+	executed := false
+	mc.ExecutedImpl = func(tag interface{}) {
+		executed = true
+	}
+
+	co.UpdateState(id, &pb.BlockchainInfo{Height: blockNumber + 1, CurrentBlockHash: blockHash}, nil)
+	co.Execute(id, testTxs)
+	mev.process()
+
+	if !executed {
+		t.Fatalf("Execution should have occurred")
+	}
+}
+
+// TestExecuteDuringStateTransfer attempts a state transfer which fails, then an execute which should not be performed
+func TestExecuteDuringStateTransfer(t *testing.T) {
+	co, mc, mre, mst, mev := newMocks(t)
+	testTxs := []*pb.Transaction{&pb.Transaction{}, &pb.Transaction{}, &pb.Transaction{}}
+
+	id := struct{}{}
+	blockNumber := uint64(2389)
+	blockHash := []byte("BlockHash")
+
+	mc.StateUpdatedImpl = func(tag interface{}, info *pb.BlockchainInfo) {
+		if info != nil {
+			t.Fatalf("State transfer should not succeed")
+		}
+	}
+
+	mst.SyncToTargetImpl = func(bn uint64, bh []byte, ps []*pb.PeerID) (error, bool) {
+		return fmt.Errorf("Irrecoverable error"), false
+	}
+
+	co.UpdateState(id, &pb.BlockchainInfo{Height: blockNumber + 1, CurrentBlockHash: blockHash}, nil)
+	co.Execute(id, testTxs)
+	mev.process()
+
+	if mre.curBatch != nil {
+		t.Fatalf("Execution should not have executed beginning a new batch")
+	}
+}

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/hyperledger/fabric/consensus"
+	"github.com/hyperledger/fabric/consensus/executor"
 	"github.com/hyperledger/fabric/consensus/helper/persist"
 	"github.com/hyperledger/fabric/core/chaincode"
 	crypto "github.com/hyperledger/fabric/core/crypto"
@@ -45,7 +46,7 @@ type Helper struct {
 	persist.Helper
 	stateTransfering bool // Whether state transfer is active
 
-	sts *statetransfer.StateTransferState
+	executor executor.Coordinator
 }
 
 // NewHelper constructs the consensus helper object
@@ -56,7 +57,8 @@ func NewHelper(mhc peer.MessageHandlerCoordinator) *Helper {
 		secHelper:   mhc.GetSecHelper(),
 		valid:       true, // Assume our state is consistent until we are told otherwise, TODO: revisit
 	}
-	h.sts = statetransfer.NewStateTransferState(mhc)
+	h.executor = executor.NewImpl(h, h, mhc)
+	h.executor.Start()
 	return h
 }
 
@@ -370,5 +372,53 @@ func (h *Helper) Errored(bn uint64, bh []byte, pids []*pb.PeerID, m interface{},
 		logger.Warningf("state transfer reported error for block %d, seqNo %d: %s", bn, seqNo, e)
 	} else {
 		logger.Warningf("state transfer reported error for block %d, %s", bn, e)
+	}
+}
+
+// Executes a set of transactions, this may be called in succession
+func (h *Helper) Execute(tag interface{}, txs []*pb.Transaction) {
+	h.executor.Execute(tag, txs)
+}
+
+// Commits whatever transactions have been executed
+func (h *Helper) Commit(tag interface{}, metadata []byte) {
+	h.executor.Commit(tag, metadata)
+}
+
+// Rolls back whatever transactions have been executed
+func (h *Helper) Rollback(tag interface{}) {
+	h.executor.Rollback(tag)
+}
+
+// Attempts to synchronize state to a particular target, implicitly calls rollback if needed
+func (h *Helper) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
+	h.executor.UpdateState(tag, target, peers)
+}
+
+// Called whenever Execute completes
+func (h *Helper) Executed(tag interface{}) {
+	if h.c != nil {
+		h.c.Executed(tag)
+	}
+}
+
+// Called whenever Commit completes
+func (h *Helper) Committed(tag interface{}, target *pb.BlockchainInfo) {
+	if h.c != nil {
+		h.c.Committed(tag, target)
+	}
+}
+
+// Called whenever a Rollback completes
+func (h *Helper) RolledBack(tag interface{}) {
+	if h.c != nil {
+		h.c.RolledBack(tag)
+	}
+}
+
+// Called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
+func (h *Helper) StateUpdated(tag interface{}, target *pb.BlockchainInfo) {
+	if h.c != nil {
+		h.c.StateUpdated(tag, target)
 	}
 }

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -30,7 +30,6 @@ import (
 	crypto "github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/peer"
-	"github.com/hyperledger/fabric/core/peer/statetransfer"
 	pb "github.com/hyperledger/fabric/protos"
 )
 
@@ -46,7 +45,7 @@ type Helper struct {
 	persist.Helper
 	stateTransfering bool // Whether state transfer is active
 
-	executor executor.Coordinator
+	executor consensus.Executor
 }
 
 // NewHelper constructs the consensus helper object
@@ -288,6 +287,13 @@ func (h *Helper) GetBlockchainSize() uint64 {
 	return h.coordinator.GetBlockchainSize()
 }
 
+// GetBlockchainInfo gets the ledger's BlockchainInfo
+func (h *Helper) GetBlockchainInfo() *pb.BlockchainInfo {
+	ledger, _ := ledger.GetLedger()
+	info, _ := ledger.GetBlockchainInfo()
+	return info
+}
+
 // GetBlockchainInfoBlob marshals a ledger's BlockchainInfo into a protobuf
 func (h *Helper) GetBlockchainInfoBlob() []byte {
 	ledger, _ := ledger.GetLedger()
@@ -310,40 +316,6 @@ func (h *Helper) GetBlockHeadMetadata() ([]byte, error) {
 	return block.ConsensusMetadata, nil
 }
 
-// SkipTo is invoked to tell state transfer of a possible sync target, if state transfer is not already executing, it is initiated
-func (h *Helper) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
-	if h.valid {
-		logger.Warning("State transfer is being called for, but the state has not been invalidated")
-	}
-
-	// This looks racey, but this should always be called in a serial fashion so it should not be, also this will be removed when the executor is introduced
-	// This is just a temporary hack to enable legacy-like behavior until the executor is finished
-	if !h.stateTransfering {
-		h.stateTransfering = true
-		info := &pb.BlockchainInfo{}
-		proto.Unmarshal(id, info)
-		go func() {
-			h.Initiated(info.Height-1, info.CurrentBlockHash, peers, tag)
-
-			for {
-				err, recoverable := h.sts.SyncToTarget(info.Height-1, info.CurrentBlockHash, peers)
-				if err != nil {
-					h.Errored(info.Height-1, info.CurrentBlockHash, peers, tag, err)
-				}
-				if !recoverable {
-					break
-				}
-				if err != nil {
-					h.Completed(info.Height-1, info.CurrentBlockHash, peers, tag)
-					break
-				}
-			}
-			h.stateTransfering = false
-
-		}()
-	}
-}
-
 // InvalidateState is invoked to tell us that consensus realizes the ledger is out of sync
 func (h *Helper) InvalidateState() {
 	logger.Debug("Invalidating the current state")
@@ -354,25 +326,6 @@ func (h *Helper) InvalidateState() {
 func (h *Helper) ValidateState() {
 	logger.Debug("Validating the current state")
 	h.valid = true
-}
-
-// Initiated is called when state transfer is kicked off, this occurs if SkipTo is invoked while statetransfer is not currently running
-func (h *Helper) Initiated(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}) {
-	h.consenter.StateUpdating(m.(uint64), bh)
-}
-
-// Completed is called when state transfer finishes moving the state to some point added via SkipTo
-func (h *Helper) Completed(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}) {
-	h.consenter.StateUpdated(m.(uint64), bh)
-}
-
-// Errored is called when state transfer encounters an error, this is not necessarily fatal
-func (h *Helper) Errored(bn uint64, bh []byte, pids []*pb.PeerID, m interface{}, e error) {
-	if seqNo, ok := m.(uint64); !ok {
-		logger.Warningf("state transfer reported error for block %d, seqNo %d: %s", bn, seqNo, e)
-	} else {
-		logger.Warningf("state transfer reported error for block %d, %s", bn, e)
-	}
 }
 
 // Execute will execute a set of transactions, this may be called in succession
@@ -392,33 +345,43 @@ func (h *Helper) Rollback(tag interface{}) {
 
 // UpdateState attempts to synchronize state to a particular target, implicitly calls rollback if needed
 func (h *Helper) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
+	if h.valid {
+		logger.Warning("State transfer is being called for, but the state has not been invalidated")
+	}
+
 	h.executor.UpdateState(tag, target, peers)
 }
 
 // Executed is called whenever Execute completes
 func (h *Helper) Executed(tag interface{}) {
-	if h.c != nil {
-		h.c.Executed(tag)
+	if h.consenter != nil {
+		h.consenter.Executed(tag)
 	}
 }
 
 // Committed is called whenever Commit completes
 func (h *Helper) Committed(tag interface{}, target *pb.BlockchainInfo) {
-	if h.c != nil {
-		h.c.Committed(tag, target)
+	if h.consenter != nil {
+		h.consenter.Committed(tag, target)
 	}
 }
 
 // RolledBack is called whenever a Rollback completes
 func (h *Helper) RolledBack(tag interface{}) {
-	if h.c != nil {
-		h.c.RolledBack(tag)
+	if h.consenter != nil {
+		h.consenter.RolledBack(tag)
 	}
 }
 
 // StateUpdated is called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
 func (h *Helper) StateUpdated(tag interface{}, target *pb.BlockchainInfo) {
-	if h.c != nil {
-		h.c.StateUpdated(tag, target)
+	if h.consenter != nil {
+		h.consenter.StateUpdated(tag, target)
 	}
 }
+
+// Start his is a byproduct of the consensus API needing some cleaning, for now it's a no-op
+func (h *Helper) Start() {}
+
+// Halt is a byproduct of the consensus API needing some cleaning, for now it's a no-op
+func (h *Helper) Halt() {}

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -375,48 +375,48 @@ func (h *Helper) Errored(bn uint64, bh []byte, pids []*pb.PeerID, m interface{},
 	}
 }
 
-// Executes a set of transactions, this may be called in succession
+// Execute will execute a set of transactions, this may be called in succession
 func (h *Helper) Execute(tag interface{}, txs []*pb.Transaction) {
 	h.executor.Execute(tag, txs)
 }
 
-// Commits whatever transactions have been executed
+// Commit will commit whatever transactions have been executed
 func (h *Helper) Commit(tag interface{}, metadata []byte) {
 	h.executor.Commit(tag, metadata)
 }
 
-// Rolls back whatever transactions have been executed
+// Rollback will roll back whatever transactions have been executed
 func (h *Helper) Rollback(tag interface{}) {
 	h.executor.Rollback(tag)
 }
 
-// Attempts to synchronize state to a particular target, implicitly calls rollback if needed
+// UpdateState attempts to synchronize state to a particular target, implicitly calls rollback if needed
 func (h *Helper) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
 	h.executor.UpdateState(tag, target, peers)
 }
 
-// Called whenever Execute completes
+// Executed is called whenever Execute completes
 func (h *Helper) Executed(tag interface{}) {
 	if h.c != nil {
 		h.c.Executed(tag)
 	}
 }
 
-// Called whenever Commit completes
+// Committed is called whenever Commit completes
 func (h *Helper) Committed(tag interface{}, target *pb.BlockchainInfo) {
 	if h.c != nil {
 		h.c.Committed(tag, target)
 	}
 }
 
-// Called whenever a Rollback completes
+// RolledBack is called whenever a Rollback completes
 func (h *Helper) RolledBack(tag interface{}) {
 	if h.c != nil {
 		h.c.RolledBack(tag)
 	}
 }
 
-// Called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
+// StateUpdated is called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied
 func (h *Helper) StateUpdated(tag interface{}, target *pb.BlockchainInfo) {
 	if h.c != nil {
 		h.c.StateUpdated(tag, target)

--- a/consensus/noops/noops.go
+++ b/consensus/noops/noops.go
@@ -112,16 +112,6 @@ func (i *Noops) RecvMsg(msg *pb.Message, senderHandle *pb.PeerID) error {
 	return nil
 }
 
-// StateUpdating is called once state transfer is initiated, currently unused
-func (i *Noops) StateUpdating(seqNo uint64, id []byte) {
-	// ignored as it is never initiated
-}
-
-// StateUpdated is called once state transfer finishes, currently unused
-func (i *Noops) StateUpdated(seqNo uint64, id []byte) {
-	// ignored as it is never initiated
-}
-
 func (i *Noops) broadcastConsensusMsg(msg *pb.Message) error {
 	t := &pb.Transaction{}
 	if err := proto.Unmarshal(msg.Payload, t); err != nil {
@@ -302,4 +292,24 @@ func (i *Noops) notifyBlockAdded(block *pb.Block, delta *statemgmt.StateDelta) e
 		return fmt.Errorf("Failed to broadcast with errors: %v", errs)
 	}
 	return nil
+}
+
+// Executed is called whenever Execute completes, no-op for noops as it uses the legacy synchronous api
+func (i *Noops) Executed(tag interface{}) {
+	// Never called
+}
+
+// Committed is called whenever Commit completes, no-op for noops as it uses the legacy synchronous api
+func (i *Noops) Committed(tag interface{}, target *pb.BlockchainInfo) {
+	// Never called
+}
+
+// RolledBack is called whenever a Rollback completes, no-op for noops as it uses the legacy synchronous api
+func (i *Noops) RolledBack(tag interface{}) {
+	// Never called
+}
+
+// StatedUpdates is called when state transfer completes, if target is nil, this indicates a failure and a new target should be supplied, no-op for noops as it uses the legacy synchronous api
+func (i *Noops) StateUpdated(tag interface{}, target *pb.BlockchainInfo) {
+	// Never called
 }

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -78,6 +78,8 @@ const MaxStateTransferTime int = 200
 
 func (cs *completeStack) ValidateState()   {}
 func (cs *completeStack) InvalidateState() {}
+func (cs *completeStack) Start()           {}
+func (cs *completeStack) Halt()            {}
 
 func (cs *completeStack) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
 	select {

--- a/consensus/obcpbft/mock_consumer_test.go
+++ b/consensus/obcpbft/mock_consumer_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hyperledger/fabric/consensus/obcpbft/events"
 	pb "github.com/hyperledger/fabric/protos"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/spf13/viper"
 )
 
@@ -80,18 +79,15 @@ const MaxStateTransferTime int = 200
 func (cs *completeStack) ValidateState()   {}
 func (cs *completeStack) InvalidateState() {}
 
-func (cs *completeStack) SkipTo(tag uint64, id []byte, peers []*pb.PeerID) {
+func (cs *completeStack) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
 	select {
 	// This guarantees the first SkipTo call is the one that's queued, whereas a mutex can be raced for
 	case cs.skipTarget <- struct{}{}:
 		go func() {
-			cs.consumer.StateUpdating(tag, id)
 			// State transfer takes time, not simulating this hides bugs
 			time.Sleep(time.Duration((MaxStateTransferTime/2)+rand.Intn(MaxStateTransferTime/2)) * time.Millisecond)
-			meta := &Metadata{tag}
-			metaRaw, _ := proto.Marshal(meta)
-			cs.simulateStateTransfer(metaRaw, id, peers)
-			cs.consumer.StateUpdated(tag, id)
+			cs.simulateStateTransfer(target, peers)
+			cs.consumer.StateUpdated(tag, cs.GetBlockchainInfo())
 			<-cs.skipTarget // Basically like releasing a mutex
 		}()
 	default:
@@ -131,6 +127,7 @@ func makeConsumerNetwork(N int, makeConsumer func(id uint64, config *viper.Viper
 		}
 
 		ml := NewMockLedger(&twl)
+		ml.ce = ce
 		twl.mockLedgers[id] = ml
 
 		cs := &completeStack{

--- a/consensus/obcpbft/mock_ledger_test.go
+++ b/consensus/obcpbft/mock_ledger_test.go
@@ -124,6 +124,37 @@ func (mock *MockLedger) BeginTxBatch(id interface{}) error {
 	return nil
 }
 
+func (mock *MockLedger) Execute(tag interface{}, txs []*protos.Transaction) {
+	go func() {
+		if mock.txID == nil {
+			mock.BeginTxBatch(mock)
+		}
+
+		_, err := mock.ExecTxs(mock, txs)
+		if err != nil {
+			panic(err)
+		}
+		mock.ce.consumer.Executed(tag)
+	}()
+}
+
+func (mock *MockLedger) Commit(tag interface{}, meta []byte) {
+	go func() {
+		_, err := mock.CommitTxBatch(mock, meta)
+		if err != nil {
+			panic(err)
+		}
+		mock.ce.consumer.Committed(tag, mock.GetBlockchainInfo())
+	}()
+}
+
+func (mock *MockLedger) Rollback(tag interface{}) {
+	go func() {
+		mock.RollbackTxBatch(mock)
+		mock.ce.consumer.RolledBack(tag)
+	}()
+}
+
 func (mock *MockLedger) ExecTxs(id interface{}, txs []*protos.Transaction) ([]byte, error) {
 	if !reflect.DeepEqual(mock.txID, id) {
 		return nil, fmt.Errorf("Invalid batch ID")
@@ -242,16 +273,25 @@ func (mock *MockLedger) HashBlock(block *protos.Block) ([]byte, error) {
 	return block.GetHash()
 }
 
+func (mock *MockLedger) GetBlockchainInfo() *protos.BlockchainInfo {
+	b, _ := mock.GetBlock(mock.blockHeight - 1)
+	return mock.getBlockInfo(mock.blockHeight, b)
+}
+
 func (mock *MockLedger) GetBlockchainInfoBlob() []byte {
 	b, _ := mock.GetBlock(mock.blockHeight - 1)
 	return mock.getBlockInfoBlob(mock.blockHeight, b)
 }
 
 func (mock *MockLedger) getBlockInfoBlob(height uint64, block *protos.Block) []byte {
+	h, _ := proto.Marshal(mock.getBlockInfo(height, block))
+	return h
+}
+
+func (mock *MockLedger) getBlockInfo(height uint64, block *protos.Block) *protos.BlockchainInfo {
 	info := &protos.BlockchainInfo{Height: height}
 	info.CurrentBlockHash, _ = mock.HashBlock(block)
-	h, _ := proto.Marshal(info)
-	return h
+	return info
 }
 
 func (mock *MockLedger) GetBlockHeadMetadata() ([]byte, error) {
@@ -262,7 +302,7 @@ func (mock *MockLedger) GetBlockHeadMetadata() ([]byte, error) {
 	return b.ConsensusMetadata, nil
 }
 
-func (mock *MockLedger) simulateStateTransfer(meta []byte, id []byte, peers []*protos.PeerID) {
+func (mock *MockLedger) simulateStateTransfer(info *protos.BlockchainInfo, peers []*protos.PeerID) {
 	var remoteLedger consensus.ReadOnlyLedger
 	if len(peers) > 0 {
 		var ok bool
@@ -273,9 +313,7 @@ func (mock *MockLedger) simulateStateTransfer(meta []byte, id []byte, peers []*p
 	} else {
 		panic("TODO, support state transfer from nil peers")
 	}
-	info := &protos.BlockchainInfo{}
-	proto.Unmarshal(id, info)
-	fmt.Printf("TEST LEDGER skipping to %+v, %+v", meta, info)
+	fmt.Printf("TEST LEDGER skipping to %+v", info)
 	p := 0
 	if mock.blockHeight >= info.Height {
 		panic(fmt.Sprintf("Asked to skip to a block (%d) which is lower than our current height of %d", info.Height, mock.blockHeight))
@@ -296,7 +334,6 @@ func (mock *MockLedger) simulateStateTransfer(meta []byte, id []byte, peers []*p
 			continue
 		}
 
-		block.ConsensusMetadata = meta
 		mock.blocks[n] = block
 	}
 	mock.blockHeight = info.Height

--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -603,33 +603,6 @@ func (op *omniProto) Execute(tag interface{}, txs []*pb.Transaction) {
 	panic("unimplemented")
 }
 
-/*
-
-	op := &omniProto{
-		GetNetworkInfoImpl:         net.GetNetworkInfo,
-		GetNetworkHandlesImpl:      net.GetNetworkHandles,
-		BroadcastImpl:              net.Broadcast,
-		UnicastImpl:                net.Unicast,
-		SignImpl:                   security.Sign,
-		VerifyImpl:                 security.Verify,
-		GetBlockImpl:               ml.GetBlock,
-		GetCurrentStateHashImpl:    ml.GetCurrentStateHash,
-		GetBlockchainSizeImpl:      ml.GetBlockchainSize,
-		HashBlockImpl:              ml.HashBlock,
-		VerifyBlockchainImpl:       ml.VerifyBlockchain,
-		PutBlockImpl:               ml.PutBlock,
-		ApplyStateDeltaImpl:        ml.ApplyStateDelta,
-		CommitStateDeltaImpl:       ml.CommitStateDelta,
-		RollbackStateDeltaImpl:     ml.RollbackStateDelta,
-		EmptyStateImpl:             ml.EmptyState,
-		BeginTxBatchImpl:           ml.BeginTxBatch,
-		ExecTxsImpl:                ml.ExecTxs,
-		CommitTxBatchImpl:          ml.CommitTxBatch,
-		RollbackTxBatchImpl:        ml.RollbackTxBatch,
-		PreviewCommitTxBatchImpl:   ml.PreviewCommitTxBatch,
-		GetRemoteBlocksImpl:        ml.GetRemoteBlocks,
-		GetRemoteStateSnapshotImpl: ml.GetRemoteStateSnapshot,
-		GetRemoteStateDeltasImpl:   ml.GetRemoteStateDeltas,
-	}
-
-*/
+// These methods are a temporary hack until the consensus API can be cleaned a little
+func (op *omniProto) Start() {}
+func (op *omniProto) Halt()  {}

--- a/consensus/obcpbft/mock_utilities_test.go
+++ b/consensus/obcpbft/mock_utilities_test.go
@@ -154,6 +154,7 @@ type omniProto struct {
 	GetCurrentStateHashImpl    func() (stateHash []byte, err error)
 	GetBlockchainSizeImpl      func() uint64
 	GetBlockHeadMetadataImpl   func() ([]byte, error)
+	GetBlockchainInfoImpl      func() *pb.BlockchainInfo
 	GetBlockchainInfoBlobImpl  func() []byte
 	HashBlockImpl              func(block *pb.Block) ([]byte, error)
 	VerifyBlockchainImpl       func(start, finish uint64) (uint64, error)
@@ -162,6 +163,10 @@ type omniProto struct {
 	CommitStateDeltaImpl       func(id interface{}) error
 	RollbackStateDeltaImpl     func(id interface{}) error
 	EmptyStateImpl             func() error
+	ExecuteImpl                func(id interface{}, txs []*pb.Transaction)
+	CommitImpl                 func(id interface{}, meta []byte)
+	RollbackImpl               func(id interface{})
+	UpdateStateImpl            func(id interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID)
 	BeginTxBatchImpl           func(id interface{}) error
 	ExecTxsImpl                func(id interface{}, txs []*pb.Transaction) ([]byte, error)
 	CommitTxBatchImpl          func(id interface{}, metadata []byte) (*pb.Block, error)
@@ -274,6 +279,13 @@ func (op *omniProto) GetBlockHeadMetadata() ([]byte, error) {
 func (op *omniProto) GetBlockchainInfoBlob() []byte {
 	if nil != op.GetBlockchainInfoBlobImpl {
 		return op.GetBlockchainInfoBlobImpl()
+	}
+
+	panic("Unimplemented")
+}
+func (op *omniProto) GetBlockchainInfo() *pb.BlockchainInfo {
+	if nil != op.GetBlockchainInfoImpl {
+		return op.GetBlockchainInfoImpl()
 	}
 
 	panic("Unimplemented")
@@ -558,6 +570,34 @@ func (op *omniProto) validateState() {
 func (op *omniProto) invalidateState() {
 	if nil != op.invalidateStateImpl {
 		op.invalidateStateImpl()
+		return
+	}
+	panic("unimplemented")
+}
+func (op *omniProto) Commit(tag interface{}, meta []byte) {
+	if nil != op.CommitImpl {
+		op.CommitImpl(tag, meta)
+		return
+	}
+	panic("unimplemented")
+}
+func (op *omniProto) UpdateState(tag interface{}, target *pb.BlockchainInfo, peers []*pb.PeerID) {
+	if nil != op.UpdateStateImpl {
+		op.UpdateStateImpl(tag, target, peers)
+		return
+	}
+	panic("unimplemented")
+}
+func (op *omniProto) Rollback(tag interface{}) {
+	if nil != op.RollbackImpl {
+		op.RollbackImpl(tag)
+		return
+	}
+	panic("unimplemented")
+}
+func (op *omniProto) Execute(tag interface{}, txs []*pb.Transaction) {
+	if nil != op.ExecuteImpl {
+		op.ExecuteImpl(tag, txs)
 		return
 	}
 	panic("unimplemented")

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -173,12 +173,8 @@ func TestBatchStaleCustody(t *testing.T) {
 		BeginTxBatchImpl: func(id interface{}) error {
 			return nil
 		},
-		ExecTxsImpl: func(id interface{}, txs []*pb.Transaction) ([]byte, error) {
-			return nil, nil
-		},
-		CommitTxBatchImpl: func(id interface{}, meta []byte) (*pb.Block, error) {
-			return nil, nil
-		},
+		ExecuteImpl: func(tag interface{}, txs []*pb.Transaction) {},
+		CommitImpl:  func(tag interface{}, meta []byte) {},
 	}
 	op := newObcBatch(1, config, stack)
 	defer op.Close()

--- a/consensus/obcpbft/obc-classic.go
+++ b/consensus/obcpbft/obc-classic.go
@@ -168,13 +168,3 @@ func (op *obcClassic) main() {
 func (op *obcClassic) idleChannel() <-chan struct{} {
 	return op.idleChan
 }
-
-// StateUpdated is a signal from the stack that it has fast-forwarded its state
-func (op *obcClassic) StateUpdated(seqNo uint64, id []byte) {
-	op.pbft.stateUpdated(seqNo, id)
-}
-
-// StateUpdating is a signal from the stack that state transfer has started
-func (op *obcClassic) StateUpdating(seqNo uint64, id []byte) {
-	op.pbft.stateUpdating(seqNo, id)
-}

--- a/consensus/obcpbft/obc-classic_test.go
+++ b/consensus/obcpbft/obc-classic_test.go
@@ -128,19 +128,7 @@ func TestClassicBackToBackStateTransfer(t *testing.T) {
 	// will have already moved on and be past to seqNo 13, outside of Replica 3's watermarks, but
 	// Replica 3 will execute through seqNo 12
 	filterMsg = false
-	for n := 2; n <= 13; n++ {
-		net.endpoints[1].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(int64(n)), broadcaster)
-	}
-
-	net.process()
-
-	_, err := net.endpoints[3].(*consumerEndpoint).consumer.(*obcClassic).stack.GetBlock(13)
-	if nil == err {
-		t.Errorf("Replica 3 should not be caught up yet")
-	}
-
-	// Replica 3 has a stable checkpoint at seqNo 12, it will detect it is behind at seqNo 18, then skip to seqNo 20, and execute request 21
-	for n := 14; n <= 21; n++ {
+	for n := 2; n <= 21; n++ {
 		net.endpoints[1].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(int64(n)), broadcaster)
 	}
 

--- a/consensus/obcpbft/obc-pbft.go
+++ b/consensus/obcpbft/obc-pbft.go
@@ -131,7 +131,13 @@ type obcGeneric struct {
 }
 
 func (op *obcGeneric) skipTo(seqNo uint64, id []byte, replicas []uint64) {
-	op.stack.SkipTo(seqNo, id, getValidatorHandles(replicas))
+	info := &pb.BlockchainInfo{}
+	err := proto.Unmarshal(id, info)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Error unmarshaling: %s", err))
+		return
+	}
+	op.stack.UpdateState(&checkpointMessage{seqNo, id}, info, getValidatorHandles(replicas))
 }
 
 func (op *obcGeneric) invalidateState() {

--- a/consensus/obcpbft/pbft-core_mock_test.go
+++ b/consensus/obcpbft/pbft-core_mock_test.go
@@ -119,6 +119,15 @@ func (sc *simpleConsumer) validateState()   {}
 func (sc *simpleConsumer) skipTo(seqNo uint64, id []byte, replicas []uint64) {
 	sc.skipOccurred = true
 	sc.executions = seqNo
+	go func() {
+		sc.pe.manager.Queue() <- stateUpdatedEvent{
+			chkpt: &checkpointMessage{
+				seqNo: seqNo,
+				id:    id,
+			},
+			target: &pb.BlockchainInfo{},
+		}
+	}()
 	sc.pbftNet.debugMsg("TEST: skipping to %d\n", seqNo)
 }
 

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -353,8 +353,9 @@ func (instance *pbftCore) processNewView() events.Event {
 			return nil
 		}
 
+		instance.skipInProgress = true
+		instance.stateTransferring = true
 		instance.consumer.skipTo(cp.SequenceNumber, snapshotID, replicas)
-		instance.lastExec = cp.SequenceNumber
 	}
 
 	for n, d := range nv.Xset {

--- a/core/peer/statetransfer/statetransfer_test.go
+++ b/core/peer/statetransfer/statetransfer_test.go
@@ -55,12 +55,14 @@ func newPartialStack(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) Partial
 	}
 }
 
-func newTestStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *StateTransferState {
-	return NewStateTransferState(newPartialStack(ml, rld))
+func newTestStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *coordinatorImpl {
+	ci := NewCoordinatorImpl(newPartialStack(ml, rld)).(*coordinatorImpl)
+	ci.Start()
+	return ci
 }
 
-func newTestThreadlessStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *StateTransferState {
-	return threadlessNewStateTransferState(newPartialStack(ml, rld))
+func newTestThreadlessStateTransfer(ml *MockLedger, rld *MockRemoteHashLedgerDirectory) *coordinatorImpl {
+	return NewCoordinatorImpl(newPartialStack(ml, rld)).(*coordinatorImpl)
 }
 
 type MockRemoteHashLedgerDirectory struct {
@@ -85,7 +87,7 @@ func createRemoteLedgers(low, high uint64) *MockRemoteHashLedgerDirectory {
 	return &MockRemoteHashLedgerDirectory{&HashLedgerDirectory{rols}}
 }
 
-func executeStateTransfer(sts *StateTransferState, ml *MockLedger, blockNumber, sequenceNumber uint64, mrls *MockRemoteHashLedgerDirectory) error {
+func executeStateTransfer(sts *coordinatorImpl, ml *MockLedger, blockNumber, sequenceNumber uint64, mrls *MockRemoteHashLedgerDirectory) error {
 
 	for peerID := range mrls.remoteLedgers {
 		mrls.GetMockRemoteLedgerByPeerID(&peerID).blockHeight = blockNumber + 1


### PR DESCRIPTION
## Description

This changeset introduces the new executor service advertised in PR #1758.  It adds an API for asynchronously invoking executions, commits, and state transfer.

This changeset tries to minimally change the existing consensus plugins to adapt to the new API, and leaves the legacy execution infrastructure in place to attempt to minimize the changeset.
## Motivation and Context

The consensus API has always exposed assorted executor methods such as `ExecTxs` or `CommitTxBatch` as synchronous calls independent of state transfer.  This poses multiple problems.  Firstly, particularly with chaincode deploy transactions, but also for larger batches of transactions, these calls may block for long periods of time (seconds), which causes problems for liveliness tests, such as in PBFT.  Secondly, these calls do not coordinate with state transfer, and it is possible to incidentally execute transactions while state transfer is in progress.  These two problems compound eachother, because as state transfer and execution can both be long running calls, a caller must execute them both asynchronously, and coordinating between the two is bug prone and dangerous.

The executor interface is intended to serialize write access to the ledger, either via state transfer or via chaincode execution.  It is a simply contained testable state machine which is intended to accommodate one and only one asynchronous transaction at a time.  Once a particular transaction completes, a callback is invoked and the caller is informed that it is safe to inject a new request into the executor service.  In the event that a caller mistakenly calls in while another request is in progress, the executor will serialize the call, or in the event that the serialized calls are not consistent (for instance calling `Commit` without calling `Execute`) the executor will safely ignore the call to avoid putting the system into an inconsistent state.

As mentioned in the description, this changeset is intended to minimize the diff, so the legacy interfaces are intact, and code which is not obc-batch still uses these legacy methods to a large extent.  In the future, the consensus API should remove the obsolete and unsafe ledger access methods, the remainder of the consensus plugins should be migrated to use the new API, and the executor should be migrated to interact more directly with the ledger.

Although this PR is unfortunately on the larger side, please note that 522 of the added lines are new test cases for the introduced executor service.
## How Has This Been Tested?

The new executor service comes complete with a new suite of tests.  The consensus code which has been modified to execute using the new API passes unit tests, plus of course the remainder of CI.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
