### PR TITLE
consensus: non-blocking broadcast

### DIFF
--- a/bddtests/environment.py
+++ b/bddtests/environment.py
@@ -36,6 +36,8 @@ def after_scenario(context, scenario):
 
             print("Decomposing with yaml '{0}' after scenario {1}, ".format(context.compose_yaml, scenario.name))
             context.compose_output, context.compose_error, context.compose_returncode = \
+                cli_call(context, ["docker-compose"] + fileArgsToDockerCompose + ["unpause"], expect_success=True)
+            context.compose_output, context.compose_error, context.compose_returncode = \
                 cli_call(context, ["docker-compose"] + fileArgsToDockerCompose + ["kill"], expect_success=True)
             context.compose_output, context.compose_error, context.compose_returncode = \
                 cli_call(context, ["docker-compose"] + fileArgsToDockerCompose + ["rm","-f"], expect_success=True)

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -918,3 +918,46 @@ Feature: lanching 3 peers
         |          ComposeFile                       |   WaitTime   |
 #       |   docker-compose-4-consensus-classic.yml   |      60      |
         |   docker-compose-4-consensus-batch.yml     |      60      |
+
+#    @doNotDecompose
+#    @wip
+    Scenario: chaincode example02 with 4 peers, one paused, issue #1056
+        Given we compose "docker-compose-4-consensus-batch.yml"
+	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
+                     | vp0  |
+            And I use the following credentials for querying peers:
+		     | peer |   username  |    secret    |
+		     | vp0  |  test_user0 | MS9qrN8hFjlE |
+		     | vp1  |  test_user1 | jGlNl6ImkuDo |
+		     | vp2  |  test_user2 | zMflqOKezFiA |
+		     | vp3  |  test_user3 | vWdLCE00vJy0 |
+
+        When requesting "/chain" from "vp0"
+	Then I should get a JSON response with "height" = "1"
+
+        Given I pause peers:
+              | vp3  |
+
+        When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+	     | arg1 |  arg2 | arg3 | arg4 |
+	     |  a   |  100  |  b   |  200 |
+	     Then I should have received a chaincode name
+             Then I wait up to "60" seconds for transaction to be committed to peers:
+                  | vp0  | vp1 | vp2 |
+
+        When I query chaincode "example2" function name "query" with value "a" on peers:
+             | vp0  | vp1 | vp2 |
+             Then I should get a JSON response from peers with "OK" = "100"
+             | vp0  | vp1 | vp2 |
+
+        When I invoke chaincode "example2" function name "invoke" on "vp0" "20" times
+	     |arg1|arg2|arg3|
+             | a  | b  |  1 |
+             Then I should have received a transactionID
+             Then I wait up to "20" seconds for transaction to be committed to peers:
+                  | vp0  | vp1 | vp2 |
+
+        When I query chaincode "example2" function name "query" with value "a" on peers:
+             | vp0  | vp1 | vp2 |
+             Then I should get a JSON response from peers with "OK" = "80"
+             | vp0  | vp1 | vp2 |

--- a/consensus/obcpbft/broadcast.go
+++ b/consensus/obcpbft/broadcast.go
@@ -1,0 +1,141 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hyperledger/fabric/consensus"
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+type communicator interface {
+	consensus.Communicator
+	consensus.Inquirer
+}
+
+type broadcaster struct {
+	comm communicator
+
+	f        int
+	msgChans map[uint64]chan *pb.Message
+	closed   sync.WaitGroup
+	closedCh chan struct{}
+}
+
+func newBroadcaster(self uint64, N int, f int, c communicator) *broadcaster {
+	queueSize := 10 // XXX increase after testing
+
+	chans := make(map[uint64]chan *pb.Message)
+	for i := 0; i < N; i++ {
+		if uint64(i) == self {
+			continue
+		}
+		chans[uint64(i)] = make(chan *pb.Message, queueSize)
+	}
+	b := &broadcaster{
+		comm:     c,
+		f:        f,
+		msgChans: chans,
+		closedCh: make(chan struct{}),
+	}
+	return b
+}
+
+func (b *broadcaster) Close() {
+	close(b.closedCh)
+	b.closed.Wait()
+}
+
+func (b *broadcaster) Wait() {
+	b.closed.Wait()
+}
+
+func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan bool) {
+	defer func() {
+		b.closed.Done()
+		wait <- true
+	}()
+
+	select {
+	case <-b.closedCh:
+		return
+	default:
+	}
+
+	h, err := getValidatorHandle(dest)
+	if err != nil {
+		logger.Warningf("could not get handle for replica %d", dest)
+	} else {
+		err = b.comm.Unicast(msg, h)
+	}
+	if err != nil {
+		logger.Debugf("could not send to replica %d: %v", dest, err)
+		select {
+		case <-b.closedCh:
+			return
+		case <-time.After(1 * time.Second):
+			return
+		}
+	}
+}
+
+func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
+	select {
+	case <-b.closedCh:
+		return fmt.Errorf("broadcaster closed")
+	default:
+	}
+
+	var destCount int
+	var required int
+	if dest != nil {
+		destCount = 1
+		required = 1
+	} else {
+		destCount = len(b.msgChans)
+		required = destCount - b.f
+	}
+
+	wait := make(chan bool, destCount)
+
+	if dest != nil {
+		b.closed.Add(1)
+		go b.unicastOne(msg, *dest, wait)
+	} else {
+		b.closed.Add(len(b.msgChans))
+		for i := range b.msgChans {
+			go b.unicastOne(msg, i, wait)
+		}
+	}
+
+	for i := 0; i < required; i++ {
+		<-wait
+	}
+
+	return nil
+}
+
+func (b *broadcaster) Unicast(msg *pb.Message, dest uint64) error {
+	return b.send(msg, &dest)
+}
+
+func (b *broadcaster) Broadcast(msg *pb.Message) error {
+	return b.send(msg, nil)
+}

--- a/consensus/obcpbft/broadcast_test.go
+++ b/consensus/obcpbft/broadcast_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	pb "github.com/hyperledger/fabric/protos"
+)
+
+type mockMsg struct {
+	msg  *pb.Message
+	dest *pb.PeerID
+}
+
+type mockComm struct {
+	self  uint64
+	n     uint64
+	msgCh chan mockMsg
+}
+
+func (m *mockComm) Unicast(msg *pb.Message, dest *pb.PeerID) error {
+	m.msgCh <- mockMsg{msg, dest}
+	return nil
+}
+
+func (m *mockComm) Broadcast(msg *pb.Message, t pb.PeerEndpoint_Type) error {
+	return nil
+}
+
+func (m *mockComm) GetNetworkInfo() (*pb.PeerEndpoint, []*pb.PeerEndpoint, error) {
+	return nil, nil, nil
+}
+
+func (m *mockComm) GetNetworkHandles() (*pb.PeerID, []*pb.PeerID, error) {
+	var h []*pb.PeerID
+	for n := uint64(0); n < m.n; n++ {
+		h = append(h, &pb.PeerID{fmt.Sprintf("vp%d", n)})
+	}
+	return h[m.self], h, nil
+}
+
+func TestBroadcast(t *testing.T) {
+	m := &mockComm{
+		self:  1,
+		n:     4,
+		msgCh: make(chan mockMsg, 4),
+	}
+	sent := make(map[string]int)
+	go func() {
+		for msg := range m.msgCh {
+			sent[msg.dest.Name] += 1
+		}
+	}()
+
+	b := newBroadcaster(1, 4, 1, m)
+
+	msg := &pb.Message{Payload: []byte("hi")}
+	b.Broadcast(msg)
+	time.Sleep(100 * time.Millisecond)
+	b.Close()
+
+	sentCount := 0
+	for _, q := range sent {
+		if q == 1 {
+			sentCount += 1
+		}
+	}
+
+	if sentCount < 2 {
+		t.Error("broadcast did not send to all peers: %v", sent)
+	}
+}
+
+type mockStuckComm struct {
+	mockComm
+	done chan struct{}
+}
+
+func (m *mockStuckComm) Unicast(msg *pb.Message, dest *pb.PeerID) error {
+	ret := m.mockComm.Unicast(msg, dest)
+	if dest.Name == "vp0" {
+		select {
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("timeout")
+		case <-m.done:
+			return fmt.Errorf("closed")
+		}
+	}
+	return ret
+}
+
+func TestBroadcastStuck(t *testing.T) {
+	m := &mockStuckComm{
+		mockComm: mockComm{
+			self:  1,
+			n:     4,
+			msgCh: make(chan mockMsg),
+		},
+		done: make(chan struct{}),
+	}
+	sent := make(map[string][]string)
+	go func() {
+		for msg := range m.msgCh {
+			key := string(msg.msg.Payload)
+			sent[key] = append(sent[key], msg.dest.Name)
+		}
+	}()
+
+	b := newBroadcaster(1, 4, 1, m)
+
+	maxc := 20
+	for c := 0; c < maxc; c++ {
+		b.Broadcast(&pb.Message{Payload: []byte(fmt.Sprintf("%d", c))})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-time.After(time.Second):
+			t.Fatal("blocked")
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	close(m.done)
+	b.Close()
+	close(done)
+
+	sendDone := 0
+	for _, q := range sent {
+		if len(q) >= 2 {
+			sendDone += 1
+		}
+	}
+	if sendDone != maxc {
+		t.Errorf("expected %d sent messages: %v", maxc, sent)
+	}
+}
+
+func TestBroadcastUnicast(t *testing.T) {
+	m := &mockComm{
+		self:  1,
+		n:     4,
+		msgCh: make(chan mockMsg, 4),
+	}
+	sent := make(map[string]int)
+	go func() {
+		for msg := range m.msgCh {
+			sent[msg.dest.Name] += 1
+		}
+	}()
+
+	b := newBroadcaster(1, 4, 1, m)
+
+	msg := &pb.Message{Payload: []byte("hi")}
+	b.Unicast(msg, 0)
+	time.Sleep(100 * time.Millisecond)
+	b.Close()
+
+	sentCount := 0
+	for _, q := range sent {
+		if q == 1 {
+			sentCount += 1
+		}
+	}
+
+	if sentCount != 1 {
+		t.Error("broadcast did not send to dest peer: %v", sent)
+	}
+}

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -87,12 +87,14 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	op.manager.Start()
 	op.externalEventReceiver.manager = op.manager
 
-	op.batchSize = config.GetInt("general.batchSize")
+	op.batchSize = config.GetInt("general.batchsize")
 	op.batchStore = nil
 	op.batchTimeout, err = time.ParseDuration(config.GetString("general.timeout.batch"))
 	if err != nil {
 		panic(fmt.Errorf("Cannot parse batch timeout: %s", err))
 	}
+	logger.Infof("PBFT Batch size = %d", op.batchSize)
+	logger.Infof("PBFT Batch timeout = %v", op.batchTimeout)
 
 	op.incomingChan = make(chan *batchMessage)
 

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -25,9 +25,10 @@ import (
 	"github.com/hyperledger/fabric/consensus/obcpbft/events"
 	pb "github.com/hyperledger/fabric/protos"
 
+	google_protobuf "google/protobuf"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/viper"
-	google_protobuf "google/protobuf"
 )
 
 type obcBatch struct {

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -123,7 +123,7 @@ func (op *obcBatch) submitToLeader(req *Request) events.Event {
 	if leader == op.pbft.id && op.pbft.activeView {
 		return op.leaderProcReq(req)
 	} else {
-		logger.Debug("Replica %d add request %v to its oustanding store", op.pbft.id, req)
+		logger.Debugf("Replica %d add request %v to its outstanding store", op.pbft.id, req)
 		op.outstandingReqs[req] = struct{}{}
 		op.startTimerIfOutstandingRequests()
 	}
@@ -301,14 +301,14 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 	}
 
 	if ocMsg.Type != pb.Message_CONSENSUS {
-		logger.Error("Unexpected message type: %s", ocMsg.Type)
+		logger.Errorf("Unexpected message type: %s", ocMsg.Type)
 		return nil
 	}
 
 	batchMsg := &BatchMessage{}
 	err := proto.Unmarshal(ocMsg.Payload, batchMsg)
 	if err != nil {
-		logger.Error("Error unmarshaling message: %s", err)
+		logger.Errorf("Error unmarshaling message: %s", err)
 		return nil
 	}
 

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package obcpbft
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -101,17 +100,18 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 	bs := [3]*obcBatch{}
 	for i := range bs {
 		omni := &omniProto{
-			BroadcastImpl: func(ocMsg *pb.Message, peerType pb.PeerEndpoint_Type) error { return nil },
+			UnicastImpl: func(ocMsg *pb.Message, peer *pb.PeerID) error { return nil },
 		}
-		bs[i] = newObcBatch(1, loadConfig(), omni)
+		bs[i] = newObcBatch(uint64(i), loadConfig(), omni)
 		defer bs[i].Close()
 
 		// Have vp1 only deliver messages
 		if i == 1 {
-			omni.BroadcastImpl = func(ocMsg *pb.Message, peerType pb.PeerEndpoint_Type) error {
-				fmt.Println("ASDF: sending to others")
-				bs[0].RecvMsg(ocMsg, &pb.PeerID{"vp1"})
-				bs[2].RecvMsg(ocMsg, &pb.PeerID{"vp1"})
+			omni.UnicastImpl = func(ocMsg *pb.Message, peer *pb.PeerID) error {
+				dest, _ := getValidatorID(peer)
+				if dest == 0 || dest == 2 {
+					bs[dest].RecvMsg(ocMsg, &pb.PeerID{"vp1"})
+				}
 				return nil
 			}
 		}
@@ -122,12 +122,18 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 		t.Fatalf("External request was not processed by backup: %v", err)
 	}
 
+	for _, b := range bs {
+		b.manager.Queue() <- nil
+		b.broadcaster.Wait()
+		b.manager.Queue() <- nil
+	}
+
 	for i, b := range bs {
 		b.manager.Queue() <- nil
 		count := len(b.outstandingReqs)
 		if i == 0 {
 			if count != 0 {
-				t.Errorf("Batch primary should not have the request in its store")
+				t.Errorf("Batch primary should not have the request in its store: %v", b.outstandingReqs)
 			}
 		} else {
 			if count != 1 {
@@ -150,7 +156,11 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 		b.manager.Inject(committedEvent{})
 	}
 
-	omni.BroadcastImpl = func(ocMsg *pb.Message, peerType pb.PeerEndpoint_Type) error {
+	omni.UnicastImpl = func(ocMsg *pb.Message, dest *pb.PeerID) error {
+		if dest.Name != "vp1" {
+			return nil
+		}
+
 		batchMsg := &BatchMessage{}
 		err := proto.Unmarshal(ocMsg.Payload, batchMsg)
 
@@ -164,6 +174,8 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error unpacking payload from message: %s", err)
 		}
+
+		logger.Debug("unicast: %v", msg)
 
 		prePrepare := msg.GetPrePrepare()
 
@@ -187,6 +199,8 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	b.manager.Queue() <- committedEvent{}
 	b.manager.Queue() <- nil
 
+	b.broadcaster.Wait()
+
 	if len(b.outstandingReqs) != 0 {
 		t.Fatalf("All requests should have been resubmitted")
 	}
@@ -194,9 +208,9 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 
 func TestViewChangeOnPrimarySilence(t *testing.T) {
 	b := newObcBatch(1, loadConfig(), &omniProto{
-		BroadcastImpl: func(ocMsg *pb.Message, peerType pb.PeerEndpoint_Type) error { return nil },
-		SignImpl:      func(msg []byte) ([]byte, error) { return msg, nil },
-		VerifyImpl:    func(peerID *pb.PeerID, signature []byte, message []byte) error { return nil },
+		UnicastImpl: func(ocMsg *pb.Message, peer *pb.PeerID) error { return nil },
+		SignImpl:    func(msg []byte) ([]byte, error) { return msg, nil },
+		VerifyImpl:  func(peerID *pb.PeerID, signature []byte, message []byte) error { return nil },
 	})
 	b.pbft.requestTimeout = 50 * time.Millisecond
 	defer b.Close()

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -47,7 +47,7 @@ func TestNetworkBatch(t *testing.T) {
 	broadcaster := net.endpoints[generateBroadcaster(validatorCount)].getHandle()
 	err := net.endpoints[1].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(1), broadcaster)
 	if err != nil {
-		t.Fatalf("External request was not processed by backup: %v", err)
+		t.Errorf("External request was not processed by backup: %v", err)
 	}
 	err = net.endpoints[2].(*consumerEndpoint).consumer.RecvMsg(createOcMsgWithChainTx(2), broadcaster)
 	if err != nil {
@@ -55,9 +55,11 @@ func TestNetworkBatch(t *testing.T) {
 	}
 
 	net.process()
+	net.process()
 
 	if l := len(net.endpoints[0].(*consumerEndpoint).consumer.(*obcBatch).batchStore); l != 0 {
-		t.Fatalf("%d messages expected in primary's batchStore, found %d", 0, l)
+		t.Errorf("%d messages expected in primary's batchStore, found %v", 0,
+			net.endpoints[0].(*consumerEndpoint).consumer.(*obcBatch).batchStore)
 	}
 
 	for _, ep := range net.endpoints {

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -628,7 +628,7 @@ func (instance *pbftCore) sendPrePrepare(req *Request, digest string) {
 	for _, cert := range instance.certStore { // check for other PRE-PREPARE for same digest, but different seqNo
 		if p := cert.prePrepare; p != nil {
 			if p.View == instance.view && p.SequenceNumber != n && p.RequestDigest == digest && digest != "" {
-				logger.Info("Other pre-prepare found with same digest but different seqNo: %d instead of %d", p.SequenceNumber, n)
+				logger.Infof("Other pre-prepare found with same digest but different seqNo: %d instead of %d", p.SequenceNumber, n)
 				return
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Introduces a broadcaster service, which will block only for N-f replicas, so that a byzantine replica cannot halt the network.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1056 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

new unit tests, new bddtest
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:
Simon Schubert sis@zurich.ibm.com
