### PR TITLE
Mutex introduced in Membership Services

### DIFF
--- a/membersrvc/ca/aca.go
+++ b/membersrvc/ca/aca.go
@@ -288,6 +288,9 @@ func (aca *ACA) fetchAttributes(id, affiliation string) ([]*AttributePair, error
 }
 
 func (aca *ACA) populateAttributes(attrs []*AttributePair) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	tx, dberr := aca.db.Begin()
 	if dberr != nil {
 		return dberr

--- a/membersrvc/ca/ca.go
+++ b/membersrvc/ca/ca.go
@@ -409,7 +409,7 @@ func (ca *CA) newCertificateFromSpec(spec *CertificateSpec) ([]byte, error) {
 	return raw, err
 }
 
-func (ca *CA) readCertificate(id string, usage x509.KeyUsage) ([]byte, error) {
+func (ca *CA) readCertificateByKeyUsage(id string, usage x509.KeyUsage) ([]byte, error) {
 	Trace.Println("Reading certificate for " + id + ".")
 
 	var raw []byte
@@ -418,7 +418,7 @@ func (ca *CA) readCertificate(id string, usage x509.KeyUsage) ([]byte, error) {
 	return raw, err
 }
 
-func (ca *CA) readCertificate1(id string, ts int64) ([]byte, error) {
+func (ca *CA) readCertificateByTimestamp(id string, ts int64) ([]byte, error) {
 	Trace.Println("Reading certificate for " + id + ".")
 
 	var raw []byte

--- a/membersrvc/ca/eca.go
+++ b/membersrvc/ca/eca.go
@@ -479,7 +479,7 @@ func (ecaa *ECAA) checkRegistrarSignature(in *pb.RegisterUserReq) error {
 
 	// Get the raw cert for the registrar
 	registrar := in.Registrar.Id.Id
-	raw, err := ecaa.eca.readCertificate(registrar, x509.KeyUsageDigitalSignature)
+	raw, err := ecaa.eca.readCertificateByKeyUsage(registrar, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return err
 	}
@@ -525,7 +525,7 @@ func (ecaa *ECAA) ReadUserSet(ctx context.Context, in *pb.ReadUserSetReq) (*pb.U
 		return nil, errors.New("Access denied.")
 	}
 
-	raw, err := ecaa.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
+	raw, err := ecaa.eca.readCertificateByKeyUsage(req, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -335,7 +335,7 @@ func (tcap *TCAP) CreateCertificateSet(ctx context.Context, in *pb.TCertCreateSe
 	Trace.Println("gRPC TCAP:CreateCertificateSet")
 
 	id := in.Id.Id
-	raw, err := tcap.tca.eca.readCertificate(id, x509.KeyUsageDigitalSignature)
+	raw, err := tcap.tca.eca.readCertificateByKeyUsage(id, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return nil, err
 	}
@@ -464,9 +464,6 @@ func (tcap *TCAP) generateExtensions(tcertid *big.Int, tidx []byte, enrollmentCe
 		return nil, nil, err
 	}
 
-	// save k used to encrypt EnrollmentID
-	//ks["enrollmentId"] = enrollmentIdKey
-
 	attributeIdentifierIndex := 9
 	count := 0
 	attrsHeader := make(map[string]int)
@@ -527,7 +524,7 @@ func (tcap *TCAP) ReadCertificate(ctx context.Context, in *pb.TCertReadReq) (*pb
 		return nil, errors.New("Access denied")
 	}
 
-	raw, err := tcap.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
+	raw, err := tcap.tca.eca.readCertificateByKeyUsage(req, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +548,7 @@ func (tcap *TCAP) ReadCertificate(ctx context.Context, in *pb.TCertReadReq) (*pb
 	}
 
 	if in.Ts.Seconds != 0 {
-		raw, err = tcap.tca.readCertificate1(id, in.Ts.Seconds)
+		raw, err = tcap.tca.readCertificateByTimestamp(id, in.Ts.Seconds)
 	} else {
 		raw, err = tcap.tca.readCertificateByHash(in.Hash.Hash)
 	}
@@ -573,7 +570,7 @@ func (tcap *TCAP) ReadCertificateSet(ctx context.Context, in *pb.TCertReadSetReq
 		return nil, errors.New("Access denied")
 	}
 
-	raw, err := tcap.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
+	raw, err := tcap.tca.eca.readCertificateByKeyUsage(req, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +640,7 @@ func (tcaa *TCAA) ReadCertificateSets(ctx context.Context, in *pb.TCertReadSetsR
 		return nil, errors.New("Access denied")
 	}
 
-	raw, err := tcaa.tca.eca.readCertificate(req, x509.KeyUsageDigitalSignature)
+	raw, err := tcaa.tca.eca.readCertificateByKeyUsage(req, x509.KeyUsageDigitalSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/membersrvc/ca/tlsca.go
+++ b/membersrvc/ca/tlsca.go
@@ -19,10 +19,9 @@ package ca
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
+	"database/sql"
 	"errors"
 	"math/big"
-	"database/sql"
-
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
@@ -50,7 +49,7 @@ type TLSCAA struct {
 	tlsca *TLSCA
 }
 
-func initializeTLSCATables(db *sql.DB) error { 
+func initializeTLSCATables(db *sql.DB) error {
 	return initializeCommonTables(db)
 }
 
@@ -130,7 +129,7 @@ func (tlscap *TLSCAP) CreateCertificate(ctx context.Context, in *pb.TLSCertCreat
 func (tlscap *TLSCAP) ReadCertificate(ctx context.Context, in *pb.TLSCertReadReq) (*pb.Cert, error) {
 	Trace.Println("grpc TLSCAP:ReadCertificate")
 
-	raw, err := tlscap.tlsca.readCertificate(in.Id.Id, x509.KeyUsageKeyAgreement)
+	raw, err := tlscap.tlsca.readCertificateByKeyUsage(in.Id.Id, x509.KeyUsageKeyAgreement)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Provide mutual exclusion in user registration, ecert generation and attributes population.
## Motivation and Context

This change prevents inconsistencies by taking into account multithreading.
Fix  #1800
## How Has This Been Tested?

Unit and behave tests passed
No new test cases have been created as part of this work
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] No new documentation is required by this change
- [x] No new tests are required by this change
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. The goal is clean, consistent, and readable code.

Signed-off-by: jeronimo.irazabal jeronimo.irazabal@gmail.com/iraza@ar.ibm.com
