### PR TITLE
[ci skip] Add note regarding restarting CI builds to the CONTRIBUTING.md guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,12 @@ To work on something, whether a new feature or a bugfix:
 
   8. Did we mention tests? All code changes should be accompanied by new or modified tests.
 
-  9. Continuous Integration (CI): Be sure to check [Travis](https://travis-ci.org/) or the slack #fabric-ci-status chennel for status of your build.
+  9. Continuous Integration (CI): Be sure to check [Travis](https://travis-ci.org/) or the slack #fabric-ci-status channel for status of your build.
    _Note: while there is some underlying work to migrate the build system from [Travis](https://travis-ci.org/) to [Jenkins](https://jenkins.io/): you can trigger a rebuild of jenkins with a PR comment containing `reverify Jenkins` and you can trigger a Travis build by visiting the failed build page and clicking on the little re-run glyph in upper right.
 
   10. Any code changes that affect documentation should be accompanied by corresponding changes (or additions) to the documentation and tests. This will ensure that if the merged PR is reversed, all traces of the change will be reversed as well.
 
-After your pull request has been reviewed and signed off, a maintainer will merge it into the master branch.
+After your Pull Request (PR) has been reviewed and signed off, a maintainer will merge it into the master branch.
 
 ## Coding guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ To work on something, whether a new feature or a bugfix:
 
   8. Did we mention tests? All code changes should be accompanied by new or modified tests.
 
-  9. Continuous Integration (CI): Be sure to check [Travis](https://travis-ci.org/) or the slack #fabric-ci-status channel for status of your build.
-   _Note: while there is some underlying work to migrate the build system from [Travis](https://travis-ci.org/) to [Jenkins](https://jenkins.io/): you can trigger a rebuild of jenkins with a PR comment containing `reverify Jenkins` and you can trigger a Travis build by visiting the failed build page and clicking on the little re-run glyph in upper right.
+  9. Continuous Integration (CI): Be sure to check [Travis](https://travis-ci.org/) or the Slack [#fabric-ci-status](https://hyperledgerproject.slack.com/messages/fabric-ci-status) channel for status of your build. You can re-trigger a build on [Jenkins](https://jenkins.io/) with a PR comment containing `reverify jenkins`.
+
+   Note: While some underlying work to migrate the build system from Travis to Jenkins is taking place, you can ask the [maintainers](https://github.com/hyperledger/fabric/blob/master/MAINTAINERS.txt) to re-trigger a Travis build for your PR, either by adding a comment to the PR or on the [#fabric-ci-status](https://hyperledgerproject.slack.com/messages/fabric-ci-status) Slack channel.
 
   10. Any code changes that affect documentation should be accompanied by corresponding changes (or additions) to the documentation and tests. This will ensure that if the merged PR is reversed, all traces of the change will be reversed as well.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,12 @@ To work on something, whether a new feature or a bugfix:
 
    _Note: if your PR does not merge cleanly, use ```git rebase master``` in your feature branch to update your pull request rather than using ```git merge master```_.
 
-  8. Did we mention tests? All code changes should be accompanied by new or modified tests. Be sure to check [Travis](https://travis-ci.org/) or the slack #fabric-ci-status chennel for status of your build.
+  8. Did we mention tests? All code changes should be accompanied by new or modified tests.
 
-  9. Any code changes that affect documentation should be accompanied by corresponding changes (or additions) to the documentation and tests. This will ensure that if the merged PR is reversed, all traces of the change will be reversed as well.
+  9. Continuous Integration (CI): Be sure to check [Travis](https://travis-ci.org/) or the slack #fabric-ci-status chennel for status of your build.
+   _Note: while there is some underlying work to migrate the build system from [Travis](https://travis-ci.org/) to [Jenkins](https://jenkins.io/): you can trigger a rebuild of jenkins with a PR comment containing `reverify Jenkins` and you can trigger a Travis build by visiting the failed build page and clicking on the little re-run glyph in upper right.
+
+  10. Any code changes that affect documentation should be accompanied by corresponding changes (or additions) to the documentation and tests. This will ensure that if the merged PR is reversed, all traces of the change will be reversed as well.
 
 After your pull request has been reviewed and signed off, a maintainer will merge it into the master branch.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Add a section detailing how to restart builds on the CI server(s) Fabric uses to the contributing guidelines + fixing a typo.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1816 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

N/A (documentation)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
