### PR TITLE
Run docker builds as the host user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ PROJECT_NAME=hyperledger/fabric
 PKGNAME = github.com/$(PROJECT_NAME)
 CGO_FLAGS = CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
 UID = $(shell id -u)
-DOCKER_USER_NS="host"
 
 EXECUTABLES = go docker git
 K := $(foreach exec,$(EXECUTABLES),\
@@ -115,7 +114,7 @@ $(GOPATH)/bin/%:
 	@echo "Building $@"
 	@mkdir -p $(@D)
 	@docker run -i \
-		--user=$(UID) --userns=$(DOCKER_USER_NS) \
+		--user=$(UID) \
 		-v $(abspath vendor/github.com/golang/protobuf):/opt/gopath/src/github.com/golang/protobuf \
 		-v $(abspath $(@D)):/opt/gopath/bin \
 		hyperledger/fabric-baseimage go install github.com/golang/protobuf/protoc-gen-go
@@ -131,7 +130,7 @@ build/docker/bin/%: build/image/src/.dummy $(PROJECT_FILES)
 	@echo "Building $@"
 	@mkdir -p build/docker/bin build/docker/pkg
 	@docker run -i \
-		--user=$(UID) --userns=$(DOCKER_USER_NS) \
+		--user=$(UID) \
 		-v $(abspath build/docker/bin):/opt/gopath/bin \
 		-v $(abspath build/docker/pkg):/opt/gopath/pkg \
 		hyperledger/fabric-src go install github.com/hyperledger/fabric/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@
 PROJECT_NAME=hyperledger/fabric
 PKGNAME = github.com/$(PROJECT_NAME)
 CGO_FLAGS = CGO_CFLAGS=" " CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
+UID = $(shell id -u)
+DOCKER_USER_NS="host"
 
 EXECUTABLES = go docker git
 K := $(foreach exec,$(EXECUTABLES),\
@@ -113,6 +115,7 @@ $(GOPATH)/bin/%:
 	@echo "Building $@"
 	@mkdir -p $(@D)
 	@docker run -i \
+		--user=$(UID) --userns=$(DOCKER_USER_NS) \
 		-v $(abspath vendor/github.com/golang/protobuf):/opt/gopath/src/github.com/golang/protobuf \
 		-v $(abspath $(@D)):/opt/gopath/bin \
 		hyperledger/fabric-baseimage go install github.com/golang/protobuf/protoc-gen-go
@@ -128,6 +131,7 @@ build/docker/bin/%: build/image/src/.dummy $(PROJECT_FILES)
 	@echo "Building $@"
 	@mkdir -p build/docker/bin build/docker/pkg
 	@docker run -i \
+		--user=$(UID) --userns=$(DOCKER_USER_NS) \
 		-v $(abspath build/docker/bin):/opt/gopath/bin \
 		-v $(abspath build/docker/pkg):/opt/gopath/pkg \
 		hyperledger/fabric-src go install github.com/hyperledger/fabric/$(TARGET)

--- a/scripts/provision/docker.sh
+++ b/scripts/provision/docker.sh
@@ -97,6 +97,7 @@ do
 done`
 COPY scripts $REMOTESCRIPTS
 RUN $REMOTESCRIPTS/common.sh
+RUN chmod a+rw -R /opt/gopath
 EOF
 
 [ ! -z "$http_proxy" ] && DOCKER_ARGS_PROXY="$DOCKER_ARGS_PROXY --build-arg http_proxy=$http_proxy"


### PR DESCRIPTION
Modify build process to lower the privilege level of docker-based build steps so that we avoid the problem introduced in Issue #1790
## Description

We utilize the --user feature of docker-run to lower the priviledge level of our build
## Motivation and Context

Current methodology results in certain build artifacts to be owned by root, which is both dangerous and problematic in that non-root users cannot perform operations such as "make clean" 
## How Has This Been Tested?

Ran various scenarios and checked that build artifacts are now owned by vagrant/vagrant.  Also ran "make checks" at the conclusion of the directed testing to ensure nothing else broke.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com

Fixes #1790

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
