### PR TITLE
Fix remaining references to old peer command usage in documentation [ci-skip]

### DIFF
--- a/docs/protocol-spec.md
+++ b/docs/protocol-spec.md
@@ -3047,17 +3047,14 @@ You will receive a response similar to below:
       peer [command]
 
     Available Commands:
-      peer        Run the peer.
-      status      Status of the peer.
-      stop        Stop the peer.
-      login       Login user on CLI.
-      vm          VM functionality on the fabric.
+      node        node specific commands.
+      network     network specific commands.
       chaincode   chaincode specific commands.
       help        Help about any command
 
     Flags:
-      -h, --help[=false]: help
-
+      -h, --help[=false]: help for peer
+          --logging-level="": Default logging level and overrides, see core.yaml for full syntax
 
     Use "peer [command] --help" for more information about a command.
 ```
@@ -3078,32 +3075,32 @@ Not all of the above commands are fully implemented in the current release. The 
 
 Note, that any configuration settings for the peer node listed in the `core.yaml` configuration file, which is the  configuration file for the `peer` process, may be modified on the command line with an environment variable. For example, to set the `peer.id` or the `peer.addressAutoDetect` settings, one may pass the `CORE_PEER_ID=vp1` and `CORE_PEER_ADDRESSAUTODETECT=true` on the command line.
 
-#### 6.3.1.1 peer
+#### 6.3.1.1 node start
 
-The CLI `peer` command will execute the peer process in either the development or production mode. The development mode is meant for running a single peer node locally, together with a local chaincode deployment. This allows a chaincode developer to modify and debug their code without standing up a complete network. An example for starting the peer in development mode follows:
+The CLI `node start` command will execute the peer process in either the development or production mode. The development mode is meant for running a single peer node locally, together with a local chaincode deployment. This allows a chaincode developer to modify and debug their code without standing up a complete network. An example for starting the peer in development mode follows:
 
 ```
-peer peer --peer-chaincodedev
+peer node start --peer-chaincodedev
 ```
 
 To start the peer process in production mode, modify the above command as follows:
 
 ```
-peer peer
+peer node start
 ```
 
-#### 6.3.1.2 login
+#### 6.3.1.2 network login
 
-The CLI `login` command will login a user, that is already registered with the CA, through the CLI. To login through the CLI, issue the following command, where `username` is the enrollment ID of a registered user.
+The CLI `network login` command will login a user, that is already registered with the CA, through the CLI. To login through the CLI, issue the following command, where `username` is the enrollment ID of a registered user.
 
 ```
-peer login <username>
+peer network login <username>
 ```
 
 The example below demonstrates the login process for user `jim`.
 
 ```
-peer login jim
+peer network login jim
 ```
 
 The command will prompt for a password, which must match the enrollment password for this user registered with the certificate authority. If the password entered does not match the registered password, an error will result.
@@ -3120,7 +3117,7 @@ Enter password for user 'jim': ************
 You can also pass a password for the user with `-p` parameter. An example is below.
 
 ```
-peer login jim -p 123456
+peer network login jim -p 123456
 ```
 
 #### 6.3.1.3 chaincode deploy

--- a/examples/chaincode/go/utxo/README.md
+++ b/examples/chaincode/go/utxo/README.md
@@ -52,7 +52,7 @@ go test github.com/hyperledger/fabric/core/container -run=BuildImage_Peer
 
 Using the Docker image that we just built, start a peer within a container in `chaincodedev` mode.
 ```
-docker run -it -p 30303:30303 -p 31315:31315 hyperledger/fabric-peer peer peer --peer-chaincodedev
+docker run -it -p 30303:30303 -p 31315:31315 hyperledger/fabric-peer peer node start --peer-chaincodedev
 ```
 
 

--- a/examples/events/block-listener/README.md
+++ b/examples/events/block-listener/README.md
@@ -9,13 +9,13 @@ block-listener.go will connect to a peer and recieve blocks. For every transacti
 # Example with PBFT
 
 ## Run 4 docker peers with PBFT
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp0 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer node start
 
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp1 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp1 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer node start
 
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp2 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp2 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer node start
 
-docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp3 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer peer
+docker run --rm -it -e CORE_VM_ENDPOINT=http://172.17.0.1:2375 -e CORE_PEER_ID=vp3 -e CORE_PEER_ADDRESSAUTODETECT=true -e CORE_PEER_DISCOVERY_ROOTNODE=172.17.0.2:30303 -e CORE_PEER_VALIDATOR_CONSENSUS_PLUGIN=pbft hyperledger/fabric-peer peer node start
 
 ## Attach event client to a Peer
 ./block-listener -event-address=172.17.0.2:31315


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Some doc files still referred to the old peer command usage. This fixes it.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Current doc confuses new users unaware of the change.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

This only concerns documentation files.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Arnaud J Le Hors lehors@us.ibm.com
