### PR TITLE
Function name refactor in node_log.go

### DIFF
--- a/core/crypto/client_confidentiality.go
+++ b/core/crypto/client_confidentiality.go
@@ -31,13 +31,13 @@ func (client *clientImpl) encryptTx(tx *obc.Transaction) error {
 		return errors.New("Failed encrypting payload. Invalid nonce.")
 	}
 
-	client.debug("Confidentiality protocol version [%s]", tx.ConfidentialityProtocolVersion)
+	client.Debugf("Confidentiality protocol version [%s]", tx.ConfidentialityProtocolVersion)
 	switch tx.ConfidentialityProtocolVersion {
 	case "1.1":
-		client.debug("Using confidentiality protocol version 1.1")
+		client.Debug("Using confidentiality protocol version 1.1")
 		return client.encryptTxVersion1_1(tx)
 	case "1.2":
-		client.debug("Using confidentiality protocol version 1.2")
+		client.Debug("Using confidentiality protocol version 1.2")
 		return client.encryptTxVersion1_2(tx)
 	}
 
@@ -94,7 +94,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	// Create (PK_C,SK_C) pair
 	ccPrivateKey, err := client.eciesSPI.NewPrivateKey(rand.Reader, primitives.GetDefaultCurve())
 	if err != nil {
-		client.error("Failed generate chaincode keypair: [%s]", err)
+		client.Errorf("Failed generate chaincode keypair: [%s]", err)
 
 		return err
 	}
@@ -110,14 +110,14 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 		// Prepare chaincode stateKey and privateKey
 		stateKey, err = primitives.GenAESKey()
 		if err != nil {
-			client.error("Failed creating state key: [%s]", err)
+			client.Errorf("Failed creating state key: [%s]", err)
 
 			return err
 		}
 
 		privBytes, err = client.eciesSPI.SerializePrivateKey(ccPrivateKey)
 		if err != nil {
-			client.error("Failed serializing chaincode key: [%s]", err)
+			client.Errorf("Failed serializing chaincode key: [%s]", err)
 
 			return err
 		}
@@ -129,7 +129,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 
 		privBytes, err = client.eciesSPI.SerializePrivateKey(ccPrivateKey)
 		if err != nil {
-			client.error("Failed serializing chaincode key: [%s]", err)
+			client.Errorf("Failed serializing chaincode key: [%s]", err)
 
 			return err
 		}
@@ -141,7 +141,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 
 		privBytes, err = client.eciesSPI.SerializePrivateKey(ccPrivateKey)
 		if err != nil {
-			client.error("Failed serializing chaincode key: [%s]", err)
+			client.Errorf("Failed serializing chaincode key: [%s]", err)
 
 			return err
 		}
@@ -151,21 +151,21 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	// Encrypt message to the validators
 	cipher, err := client.eciesSPI.NewAsymmetricCipherFromPublicKey(client.chainPublicKey)
 	if err != nil {
-		client.error("Failed creating new encryption scheme: [%s]", err)
+		client.Errorf("Failed creating new encryption scheme: [%s]", err)
 
 		return err
 	}
 
 	msgToValidators, err := asn1.Marshal(chainCodeValidatorMessage1_2{privBytes, stateKey})
 	if err != nil {
-		client.error("Failed preparing message to the validators: [%s]", err)
+		client.Errorf("Failed preparing message to the validators: [%s]", err)
 
 		return err
 	}
 
 	encMsgToValidators, err := cipher.Process(msgToValidators)
 	if err != nil {
-		client.error("Failed encrypting message to the validators: [%s]", err)
+		client.Errorf("Failed encrypting message to the validators: [%s]", err)
 
 		return err
 	}
@@ -176,7 +176,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	// Init with chainccode pk
 	cipher, err = client.eciesSPI.NewAsymmetricCipherFromPublicKey(ccPrivateKey.GetPublicKey())
 	if err != nil {
-		client.error("Failed initiliazing encryption scheme: [%s]", err)
+		client.Errorf("Failed initiliazing encryption scheme: [%s]", err)
 
 		return err
 	}
@@ -184,7 +184,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	// Encrypt chaincodeID using pkC
 	encryptedChaincodeID, err := cipher.Process(tx.ChaincodeID)
 	if err != nil {
-		client.error("Failed encrypting chaincodeID: [%s]", err)
+		client.Errorf("Failed encrypting chaincodeID: [%s]", err)
 
 		return err
 	}
@@ -193,7 +193,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	// Encrypt payload using pkC
 	encryptedPayload, err := cipher.Process(tx.Payload)
 	if err != nil {
-		client.error("Failed encrypting payload: [%s]", err)
+		client.Errorf("Failed encrypting payload: [%s]", err)
 
 		return err
 	}
@@ -203,7 +203,7 @@ func (client *clientImpl) encryptTxVersion1_2(tx *obc.Transaction) error {
 	if len(tx.Metadata) != 0 {
 		encryptedMetadata, err := cipher.Process(tx.Metadata)
 		if err != nil {
-			client.error("Failed encrypting metadata: [%s]", err)
+			client.Errorf("Failed encrypting metadata: [%s]", err)
 
 			return err
 		}

--- a/core/crypto/client_ecert_handler.go
+++ b/core/crypto/client_ecert_handler.go
@@ -66,7 +66,7 @@ func (handler *eCertHandlerImpl) GetTransactionHandler() (TransactionHandler, er
 	txHandler := &eCertTransactionHandlerImpl{}
 	err := txHandler.init(handler.client)
 	if err != nil {
-		handler.client.error("Failed getting transaction handler [%s]", err)
+		handler.client.Errorf("Failed getting transaction handler [%s]", err)
 
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (handler *eCertHandlerImpl) GetTransactionHandler() (TransactionHandler, er
 func (handler *eCertTransactionHandlerImpl) init(client *clientImpl) error {
 	nonce, err := client.createTransactionNonce()
 	if err != nil {
-		client.error("Failed initiliazing transaction handler [%s]", err)
+		client.Errorf("Failed initiliazing transaction handler [%s]", err)
 
 		return err
 	}

--- a/core/crypto/client_impl.go
+++ b/core/crypto/client_impl.go
@@ -48,12 +48,12 @@ func (client *clientImpl) NewChaincodeDeployTransaction(chaincodeDeploymentSpec 
 	// Get next available (not yet used) transaction certificate
 	tCerts, err := client.tCertPool.GetNextTCerts(1, attributes...)
 	if err != nil {
-		client.error("Failed to obtain a (not yet used) TCert for Chaincode Deploy[%s].", err.Error())
+		client.Errorf("Failed to obtain a (not yet used) TCert for Chaincode Deploy[%s].", err.Error())
 		return nil, err
 	}
 
 	if len(tCerts) != 1 {
-		client.error("Failed to obtain a (not yet used) TCert.")
+		client.Error("Failed to obtain a (not yet used) TCert.")
 		return nil, errors.New("Failed to obtain a TCert for Chaincode Deploy Transaction using TCert. Expected exactly one returned TCert.")
 	}
 
@@ -75,7 +75,7 @@ func (client *clientImpl) GetNextTCerts(nCerts int, attributes ...string) (tCert
 	// Get next available (not yet used) transaction certificate
 	tBlocks, err := client.tCertPool.GetNextTCerts(nCerts, attributes...)
 	if err != nil {
-		client.error("Failed getting [%d] (not yet used) Transaction Certificates (TCerts) [%s].", nCerts, err.Error())
+		client.Errorf("Failed getting [%d] (not yet used) Transaction Certificates (TCerts) [%s].", nCerts, err.Error())
 		return nil, err
 	}
 	tCerts = make([]tCert, len(tBlocks))
@@ -95,12 +95,12 @@ func (client *clientImpl) NewChaincodeExecute(chaincodeInvocation *obc.Chaincode
 	// Get next available (not yet used) transaction certificate
 	tBlocks, err := client.tCertPool.GetNextTCerts(1, attributes...)
 	if err != nil {
-		client.error("Failed to obtain a (not yet used) TCert [%s].", err.Error())
+		client.Errorf("Failed to obtain a (not yet used) TCert [%s].", err.Error())
 		return nil, err
 	}
 
 	if len(tBlocks) != 1 {
-		client.error("Failed to obtain a (not yet used) TCert.")
+		client.Error("Failed to obtain a (not yet used) TCert.")
 		return nil, errors.New("Failed to obtain a TCert for Chaincode Execution. Expected exactly one returned TCert.")
 	}
 
@@ -118,12 +118,12 @@ func (client *clientImpl) NewChaincodeQuery(chaincodeInvocation *obc.ChaincodeIn
 	// Get next available (not yet used) transaction certificate
 	tBlocks, err := client.tCertPool.GetNextTCerts(1, attributes...)
 	if err != nil {
-		client.error("Failed to obtain a (not yet used) TCert [%s].", err.Error())
+		client.Errorf("Failed to obtain a (not yet used) TCert [%s].", err.Error())
 		return nil, err
 	}
 
 	if len(tBlocks) != 1 {
-		client.error("Failed to obtain a (not yet used) TCert.")
+		client.Error("Failed to obtain a (not yet used) TCert.")
 		return nil, errors.New("Failed to obtain a TCert for Chaincode Invocation. Expected exactly one returned TCert.")
 	}
 
@@ -142,7 +142,7 @@ func (client *clientImpl) GetEnrollmentCertificateHandler() (CertificateHandler,
 	handler := &eCertHandlerImpl{}
 	err := handler.init(client)
 	if err != nil {
-		client.error("Failed getting handler [%s].", err.Error())
+		client.Errorf("Failed getting handler [%s].", err.Error())
 		return nil, err
 	}
 
@@ -159,12 +159,12 @@ func (client *clientImpl) GetTCertificateHandlerNext(attributes ...string) (Cert
 	// Get next TCert
 	tBlocks, err := client.tCertPool.GetNextTCerts(1, attributes...)
 	if err != nil {
-		client.error("Failed to obtain a (not yet used) TCert for creating a CertificateHandler [%s].", err.Error())
+		client.Errorf("Failed to obtain a (not yet used) TCert for creating a CertificateHandler [%s].", err.Error())
 		return nil, err
 	}
 
 	if len(tBlocks) != 1 {
-		client.error("Failed to obtain a TCert for creating a CertificateHandler.")
+		client.Error("Failed to obtain a TCert for creating a CertificateHandler.")
 		return nil, errors.New("Failed to obtain a TCert for creating a CertificateHandler")
 	}
 
@@ -172,7 +172,7 @@ func (client *clientImpl) GetTCertificateHandlerNext(attributes ...string) (Cert
 	handler := &tCertHandlerImpl{}
 	err = handler.init(client, tBlocks[0].tCert)
 	if err != nil {
-		client.error("Failed getting handler [%s].", err.Error())
+		client.Errorf("Failed getting handler [%s].", err.Error())
 		return nil, err
 	}
 
@@ -189,7 +189,7 @@ func (client *clientImpl) GetTCertificateHandlerFromDER(tCertDER []byte) (Certif
 	// Validate the transaction certificate
 	tCert, err := client.getTCertFromExternalDER(tCertDER)
 	if err != nil {
-		client.warning("Failed validating transaction certificate [%s].", err)
+		client.Warningf("Failed validating transaction certificate [%s].", err)
 
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (client *clientImpl) GetTCertificateHandlerFromDER(tCertDER []byte) (Certif
 	handler := &tCertHandlerImpl{}
 	err = handler.init(client, tCert)
 	if err != nil {
-		client.error("Failed getting handler [%s].", err.Error())
+		client.Errorf("Failed getting handler [%s].", err.Error())
 		return nil, err
 	}
 
@@ -207,7 +207,7 @@ func (client *clientImpl) GetTCertificateHandlerFromDER(tCertDER []byte) (Certif
 
 func (client *clientImpl) register(id string, pwd []byte, enrollID, enrollPWD string) (err error) {
 	if client.isInitialized {
-		client.error("Registering [%s]...done! Initialization already performed", id)
+		client.Errorf("Registering [%s]...done! Initialization already performed", id)
 
 		return
 	}
@@ -217,13 +217,13 @@ func (client *clientImpl) register(id string, pwd []byte, enrollID, enrollPWD st
 		return
 	}
 
-	client.info("Register crypto engine...")
+	client.Info("Register crypto engine...")
 	err = client.registerCryptoEngine()
 	if err != nil {
-		log.Errorf("Failed registering crypto engine [%s]: [%s].", enrollID, err.Error())
+		client.Errorf("Failed registering crypto engine [%s]: [%s].", enrollID, err.Error())
 		return
 	}
-	client.info("Register crypto engine...done.")
+	client.Info("Register crypto engine...done.")
 
 	return
 }
@@ -239,23 +239,23 @@ func (client *clientImpl) init(id string, pwd []byte) error {
 	}
 
 	// Initialize keystore
-	client.debug("Init keystore...")
+	client.Debug("Init keystore...")
 	err := client.initKeyStore()
 	if err != nil {
 		if err != utils.ErrKeyStoreAlreadyInitialized {
-			client.error("Keystore already initialized.")
+			client.Error("Keystore already initialized.")
 		} else {
-			client.error("Failed initiliazing keystore [%s].", err.Error())
+			client.Errorf("Failed initiliazing keystore [%s].", err.Error())
 
 			return err
 		}
 	}
-	client.debug("Init keystore...done.")
+	client.Debug("Init keystore...done.")
 
 	// Init crypto engine
 	err = client.initCryptoEngine()
 	if err != nil {
-		client.error("Failed initiliazing crypto engine [%s].", err.Error())
+		client.Errorf("Failed initiliazing crypto engine [%s].", err.Error())
 		return err
 	}
 
@@ -268,12 +268,12 @@ func (client *clientImpl) init(id string, pwd []byte) error {
 func (client *clientImpl) close() (err error) {
 	if client.tCertPool != nil {
 		if err = client.tCertPool.Stop(); err != nil {
-			client.debug("Failed closing TCertPool [%s]", err)
+			client.Debugf("Failed closing TCertPool [%s]", err)
 		}
 	}
 
 	if err = client.nodeImpl.close(); err != nil {
-		client.debug("Failed closing node [%s]", err)
+		client.Debugf("Failed closing node [%s]", err)
 	}
 	return
 }

--- a/core/crypto/client_state.go
+++ b/core/crypto/client_state.go
@@ -62,7 +62,7 @@ func (client *clientImpl) DecryptQueryResult(queryTx *obc.Transaction, ct []byte
 
 	out, err := gcm.Open(nil, nonce, ct[gcm.NonceSize():], nil)
 	if err != nil {
-		client.error("Failed decrypting query result [%s].", err.Error())
+		client.Errorf("Failed decrypting query result [%s].", err.Error())
 		return nil, utils.ErrDecrypt
 	}
 	return out, nil

--- a/core/crypto/client_tca.go
+++ b/core/crypto/client_tca.go
@@ -41,8 +41,8 @@ func (client *clientImpl) initTCertEngine() (err error) {
 	}
 
 	// init TCerPool
-	client.debug("Using multithreading [%t]", client.conf.IsMultithreadingEnabled())
-	client.debug("TCert batch size [%d]", client.conf.getTCertBatchSize())
+	client.Debugf("Using multithreading [%t]", client.conf.IsMultithreadingEnabled())
+	client.Debugf("TCert batch size [%d]", client.conf.getTCertBatchSize())
 
 	if client.conf.IsMultithreadingEnabled() {
 		client.tCertPool = new(tCertPoolMultithreadingImpl)
@@ -51,12 +51,12 @@ func (client *clientImpl) initTCertEngine() (err error) {
 	}
 
 	if err = client.tCertPool.init(client); err != nil {
-		client.error("Failied inizializing TCertPool: [%s]", err)
+		client.Errorf("Failied inizializing TCertPool: [%s]", err)
 
 		return
 	}
 	if err = client.tCertPool.Start(); err != nil {
-		client.error("Failied starting TCertPool: [%s]", err)
+		client.Errorf("Failied starting TCertPool: [%s]", err)
 
 		return
 	}
@@ -65,7 +65,7 @@ func (client *clientImpl) initTCertEngine() (err error) {
 
 func (client *clientImpl) storeTCertOwnerKDFKey() error {
 	if err := client.ks.storeKey(client.conf.getTCertOwnerKDFKeyFilename(), client.tCertOwnerKDFKey); err != nil {
-		client.error("Failed storing TCertOwnerKDFKey [%s].", err.Error())
+		client.Errorf("Failed storing TCertOwnerKDFKey [%s].", err.Error())
 
 		return err
 	}
@@ -74,23 +74,23 @@ func (client *clientImpl) storeTCertOwnerKDFKey() error {
 
 func (client *clientImpl) loadTCertOwnerKDFKey() error {
 	// Load TCertOwnerKDFKey
-	client.debug("Loading TCertOwnerKDFKey...")
+	client.Debug("Loading TCertOwnerKDFKey...")
 
 	if !client.ks.isAliasSet(client.conf.getTCertOwnerKDFKeyFilename()) {
-		client.debug("Failed loading TCertOwnerKDFKey. Key is missing.")
+		client.Debug("Failed loading TCertOwnerKDFKey. Key is missing.")
 
 		return nil
 	}
 
 	tCertOwnerKDFKey, err := client.ks.loadKey(client.conf.getTCertOwnerKDFKeyFilename())
 	if err != nil {
-		client.error("Failed parsing TCertOwnerKDFKey [%s].", err.Error())
+		client.Errorf("Failed parsing TCertOwnerKDFKey [%s].", err.Error())
 
 		return err
 	}
 	client.tCertOwnerKDFKey = tCertOwnerKDFKey
 
-	client.debug("Loading TCertOwnerKDFKey...done!")
+	client.Debug("Loading TCertOwnerKDFKey...done!")
 
 	return nil
 }
@@ -99,7 +99,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 	// DER to x509
 	x509Cert, err := primitives.DERToX509Certificate(der)
 	if err != nil {
-		client.debug("Failed parsing certificate [% x]: [%s].", der, err)
+		client.Debugf("Failed parsing certificate [% x]: [%s].", der, err)
 
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 	// Handle Critical Extension TCertEncTCertIndex
 	tCertIndexCT, err := primitives.GetCriticalExtension(x509Cert, primitives.TCertEncTCertIndex)
 	if err != nil {
-		client.error("Failed getting extension TCERT_ENC_TCERTINDEX [% x]: [%s].", der, err)
+		client.Errorf("Failed getting extension TCERT_ENC_TCERTINDEX [% x]: [%s].", der, err)
 
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 	// Handle Critical Extension TCertEncEnrollmentID TODO validate encEnrollmentID
 	_, err = primitives.GetCriticalExtension(x509Cert, primitives.TCertEncEnrollmentID)
 	if err != nil {
-		client.error("Failed getting extension TCERT_ENC_ENROLLMENT_ID [%s].", err.Error())
+		client.Errorf("Failed getting extension TCERT_ENC_ENROLLMENT_ID [%s].", err.Error())
 
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 	//		attributeExtensionIdentifier := append(utils.TCertEncAttributesBase, i + 9)
 	//		_ , err = utils.GetCriticalExtension(x509Cert, attributeExtensionIdentifier)
 	//		if err != nil {
-	//			client.error("Failed getting extension TCERT_ATTRIBUTE_%s [%s].", i, err.Error())
+	//			client.Errorf("Failed getting extension TCERT_ATTRIBUTE_%s [%s].", i, err.Error())
 	//
 	//			return nil, err
 	//		}
@@ -133,7 +133,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 
 	// Verify certificate against root
 	if _, err := primitives.CheckCertAgainRoot(x509Cert, client.tcaCertPool); err != nil {
-		client.warning("Warning verifing certificate [% x]: [%s].", der, err)
+		client.Warningf("Warning verifing certificate [% x]: [%s].", der, err)
 
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 
 		// TODO: verify that TCertIndex has right format.
 
-		client.debug("TCertIndex: [% x].", TCertIndex)
+		client.Debugf("TCertIndex: [% x].", TCertIndex)
 		mac := hmac.New(primitives.NewHash, ExpansionKey)
 		mac.Write(TCertIndex)
 		ExpansionValue := mac.Sum(nil)
@@ -194,7 +194,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 		// Verify temporary public key is a valid point on the reference curve
 		isOn := tempSK.Curve.IsOnCurve(tempSK.PublicKey.X, tempSK.PublicKey.Y)
 		if !isOn {
-			client.warning("Failed temporary public key IsOnCurve check. This is an foreign certificate.")
+			client.Warning("Failed temporary public key IsOnCurve check. This is an foreign certificate.")
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
@@ -203,13 +203,13 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 		certPK := x509Cert.PublicKey.(*ecdsa.PublicKey)
 
 		if certPK.X.Cmp(tempSK.PublicKey.X) != 0 {
-			client.warning("Derived public key is different on X. This is an foreign certificate.")
+			client.Warning("Derived public key is different on X. This is an foreign certificate.")
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
 
 		if certPK.Y.Cmp(tempSK.PublicKey.Y) != 0 {
-			client.warning("Derived public key is different on Y. This is an foreign certificate.")
+			client.Warning("Derived public key is different on Y. This is an foreign certificate.")
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
@@ -217,27 +217,27 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 		// Verify the signing capability of tempSK
 		err = primitives.VerifySignCapability(tempSK, x509Cert.PublicKey)
 		if err != nil {
-			client.warning("Failed verifing signing capability [%s]. This is an foreign certificate.", err.Error())
+			client.Warning("Failed verifing signing capability [%s]. This is an foreign certificate.", err.Error())
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
 
 		// Marshall certificate and secret key to be stored in the database
 		if err != nil {
-			client.warning("Failed marshalling private key [%s]. This is an foreign certificate.", err.Error())
+			client.Warningf("Failed marshalling private key [%s]. This is an foreign certificate.", err.Error())
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
 
 		if err = primitives.CheckCertPKAgainstSK(x509Cert, interface{}(tempSK)); err != nil {
-			client.warning("Failed checking TCA cert PK against private key [%s]. This is an foreign certificate.", err.Error())
+			client.Warningf("Failed checking TCA cert PK against private key [%s]. This is an foreign certificate.", err.Error())
 
 			return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 		}
 
 		return &tCertImpl{client, x509Cert, tempSK, []byte{}}, nil
 	}
-	client.warning("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s]. This is an foreign certificate.", err.Error())
+	client.Warningf("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s]. This is an foreign certificate.", err.Error())
 	return &tCertImpl{client, x509Cert, nil, []byte{}}, nil
 }
 
@@ -252,7 +252,7 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// DER to x509
 	x509Cert, err := primitives.DERToX509Certificate(certBlk.tCertDER)
 	if err != nil {
-		client.debug("Failed parsing certificate [% x]: [%s].", certBlk.tCertDER, err)
+		client.Debugf("Failed parsing certificate [% x]: [%s].", certBlk.tCertDER, err)
 
 		return
 	}
@@ -260,14 +260,14 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// Handle Critical Extenstion TCertEncTCertIndex
 	tCertIndexCT, err := primitives.GetCriticalExtension(x509Cert, primitives.TCertEncTCertIndex)
 	if err != nil {
-		client.error("Failed getting extension TCERT_ENC_TCERTINDEX [%v].", err.Error())
+		client.Errorf("Failed getting extension TCERT_ENC_TCERTINDEX [%v].", err.Error())
 
 		return
 	}
 
 	// Verify certificate against root
 	if _, err = primitives.CheckCertAgainRoot(x509Cert, client.tcaCertPool); err != nil {
-		client.warning("Warning verifing certificate [%s].", err.Error())
+		client.Warningf("Warning verifing certificate [%s].", err.Error())
 
 		return
 	}
@@ -281,7 +281,7 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// Decrypt ct to TCertIndex (TODO: || EnrollPub_Key || EnrollID ?)
 	pt, err := primitives.CBCPKCS7Decrypt(TCertOwnerEncryptKey, tCertIndexCT)
 	if err != nil {
-		client.error("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s].", err.Error())
+		client.Errorf("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s].", err.Error())
 
 		return
 	}
@@ -290,7 +290,7 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	TCertIndex := pt
 	//		TCertIndex := []byte(strconv.Itoa(i))
 
-	client.debug("TCertIndex: [% x].", TCertIndex)
+	client.Debugf("TCertIndex: [% x].", TCertIndex)
 	mac := hmac.New(primitives.NewHash, ExpansionKey)
 	mac.Write(TCertIndex)
 	ExpansionValue := mac.Sum(nil)
@@ -329,7 +329,7 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// Verify temporary public key is a valid point on the reference curve
 	isOn := tempSK.Curve.IsOnCurve(tempSK.PublicKey.X, tempSK.PublicKey.Y)
 	if !isOn {
-		client.error("Failed temporary public key IsOnCurve check.")
+		client.Error("Failed temporary public key IsOnCurve check.")
 
 		return nil, fmt.Errorf("Failed temporary public key IsOnCurve check.")
 	}
@@ -338,13 +338,13 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	certPK := x509Cert.PublicKey.(*ecdsa.PublicKey)
 
 	if certPK.X.Cmp(tempSK.PublicKey.X) != 0 {
-		client.error("Derived public key is different on X")
+		client.Error("Derived public key is different on X")
 
 		return nil, fmt.Errorf("Derived public key is different on X")
 	}
 
 	if certPK.Y.Cmp(tempSK.PublicKey.Y) != 0 {
-		client.error("Derived public key is different on Y")
+		client.Error("Derived public key is different on Y")
 
 		return nil, fmt.Errorf("Derived public key is different on Y")
 	}
@@ -352,20 +352,20 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// Verify the signing capability of tempSK
 	err = primitives.VerifySignCapability(tempSK, x509Cert.PublicKey)
 	if err != nil {
-		client.error("Failed verifing signing capability [%s].", err.Error())
+		client.Errorf("Failed verifing signing capability [%s].", err.Error())
 
 		return
 	}
 
 	// Marshall certificate and secret key to be stored in the database
 	if err != nil {
-		client.error("Failed marshalling private key [%s].", err.Error())
+		client.Errorf("Failed marshalling private key [%s].", err.Error())
 
 		return
 	}
 
 	if err = primitives.CheckCertPKAgainstSK(x509Cert, interface{}(tempSK)); err != nil {
-		client.error("Failed checking TCA cert PK against private key [%s].", err.Error())
+		client.Errorf("Failed checking TCA cert PK against private key [%s].", err.Error())
 
 		return
 	}
@@ -376,12 +376,12 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 }
 
 func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string, num int) error {
-	client.debug("Get [%d] certificates from the TCA...", num)
+	client.Debugf("Get [%d] certificates from the TCA...", num)
 
 	// Contact the TCA
 	TCertOwnerKDFKey, certDERs, err := client.callTCACreateCertificateSet(num, attributes)
 	if err != nil {
-		client.debug("Failed contacting TCA [%s].", err.Error())
+		client.Debugf("Failed contacting TCA [%s].", err.Error())
 
 		return err
 	}
@@ -400,7 +400,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 
 		// TODO: handle this situation more carefully
 		if err := client.storeTCertOwnerKDFKey(); err != nil {
-			client.error("Failed storing TCertOwnerKDFKey [%s].", err.Error())
+			client.Errorf("Failed storing TCertOwnerKDFKey [%s].", err.Error())
 
 			return err
 		}
@@ -417,7 +417,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		x509Cert, err := primitives.DERToX509Certificate(certDERs[i].Cert)
 		prek0 := certDERs[i].Prek0
 		if err != nil {
-			client.debug("Failed parsing certificate [% x]: [%s].", certDERs[i].Cert, err)
+			client.Debugf("Failed parsing certificate [% x]: [%s].", certDERs[i].Cert, err)
 
 			continue
 		}
@@ -425,14 +425,14 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		// Handle Critical Extenstion TCertEncTCertIndex
 		tCertIndexCT, err := primitives.GetCriticalExtension(x509Cert, primitives.TCertEncTCertIndex)
 		if err != nil {
-			client.error("Failed getting extension TCERT_ENC_TCERTINDEX [% x]: [%s].", err)
+			client.Errorf("Failed getting extension TCERT_ENC_TCERTINDEX [% x]: [%s].", err)
 
 			continue
 		}
 
 		// Verify certificate against root
 		if _, err := primitives.CheckCertAgainRoot(x509Cert, client.tcaCertPool); err != nil {
-			client.warning("Warning verifing certificate [%s].", err.Error())
+			client.Warningf("Warning verifing certificate [%s].", err.Error())
 
 			continue
 		}
@@ -446,7 +446,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		// Decrypt ct to TCertIndex (TODO: || EnrollPub_Key || EnrollID ?)
 		pt, err := primitives.CBCPKCS7Decrypt(TCertOwnerEncryptKey, tCertIndexCT)
 		if err != nil {
-			client.error("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s].", err.Error())
+			client.Errorf("Failed decrypting extension TCERT_ENC_TCERTINDEX [%s].", err.Error())
 
 			continue
 		}
@@ -455,7 +455,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		TCertIndex := pt
 		//		TCertIndex := []byte(strconv.Itoa(i))
 
-		client.debug("TCertIndex: [% x].", TCertIndex)
+		client.Debugf("TCertIndex: [% x].", TCertIndex)
 		mac := hmac.New(primitives.NewHash, ExpansionKey)
 		mac.Write(TCertIndex)
 		ExpansionValue := mac.Sum(nil)
@@ -494,7 +494,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		// Verify temporary public key is a valid point on the reference curve
 		isOn := tempSK.Curve.IsOnCurve(tempSK.PublicKey.X, tempSK.PublicKey.Y)
 		if !isOn {
-			client.error("Failed temporary public key IsOnCurve check.")
+			client.Error("Failed temporary public key IsOnCurve check.")
 
 			continue
 		}
@@ -503,13 +503,13 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		certPK := x509Cert.PublicKey.(*ecdsa.PublicKey)
 
 		if certPK.X.Cmp(tempSK.PublicKey.X) != 0 {
-			client.error("Derived public key is different on X")
+			client.Error("Derived public key is different on X")
 
 			continue
 		}
 
 		if certPK.Y.Cmp(tempSK.PublicKey.Y) != 0 {
-			client.error("Derived public key is different on Y")
+			client.Error("Derived public key is different on Y")
 
 			continue
 		}
@@ -517,27 +517,27 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		// Verify the signing capability of tempSK
 		err = primitives.VerifySignCapability(tempSK, x509Cert.PublicKey)
 		if err != nil {
-			client.error("Failed verifing signing capability [%s].", err.Error())
+			client.Errorf("Failed verifing signing capability [%s].", err.Error())
 
 			continue
 		}
 
 		// Marshall certificate and secret key to be stored in the database
 		if err != nil {
-			client.error("Failed marshalling private key [%s].", err.Error())
+			client.Errorf("Failed marshalling private key [%s].", err.Error())
 
 			continue
 		}
 
 		if err := primitives.CheckCertPKAgainstSK(x509Cert, interface{}(tempSK)); err != nil {
-			client.error("Failed checking TCA cert PK against private key [%s].", err.Error())
+			client.Errorf("Failed checking TCA cert PK against private key [%s].", err.Error())
 
 			continue
 		}
 
-		client.debug("Sub index [%d]", j)
+		client.Debugf("Sub index [%d]", j)
 		j++
-		client.debug("Certificate [%d] validated.", i)
+		client.Debugf("Certificate [%d] validated.", i)
 
 		prek0Cp := make([]byte, len(prek0))
 		copy(prek0Cp, prek0)
@@ -551,7 +551,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 	}
 
 	if j == 0 {
-		client.error("No valid TCert was sent")
+		client.Error("No valid TCert was sent")
 
 		return errors.New("No valid TCert was sent.")
 	}
@@ -585,14 +585,14 @@ func (client *clientImpl) callTCACreateCertificateSet(num int, attributes []stri
 
 	rawReq, err := proto.Marshal(req)
 	if err != nil {
-		client.error("Failed marshaling request [%s] [%s].", err.Error())
+		client.Errorf("Failed marshaling request [%s] [%s].", err.Error())
 		return nil, nil, err
 	}
 
 	// 2. Sign rawReq
 	r, s, err := client.ecdsaSignWithEnrollmentKey(rawReq)
 	if err != nil {
-		client.error("Failed creating signature for [% x]: [%s].", rawReq, err.Error())
+		client.Errorf("Failed creating signature for [% x]: [%s].", rawReq, err.Error())
 		return nil, nil, err
 	}
 
@@ -605,7 +605,7 @@ func (client *clientImpl) callTCACreateCertificateSet(num int, attributes []stri
 	// 4. Send request
 	certSet, err := tcaP.CreateCertificateSet(context.Background(), req)
 	if err != nil {
-		client.error("Failed requesting tca create certificate set [%s].", err.Error())
+		client.Errorf("Failed requesting tca create certificate set [%s].", err.Error())
 
 		return nil, nil, err
 	}

--- a/core/crypto/client_tcert_handler.go
+++ b/core/crypto/client_tcert_handler.go
@@ -62,7 +62,7 @@ func (handler *tCertHandlerImpl) GetTransactionHandler() (TransactionHandler, er
 	txHandler := &tCertTransactionHandlerImpl{}
 	err := txHandler.init(handler)
 	if err != nil {
-		handler.client.error("Failed initiliazing transaction handler [%s]", err)
+		handler.client.Errorf("Failed initiliazing transaction handler [%s]", err)
 
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (handler *tCertHandlerImpl) GetTransactionHandler() (TransactionHandler, er
 func (handler *tCertTransactionHandlerImpl) init(tCertHandler *tCertHandlerImpl) error {
 	nonce, err := tCertHandler.client.createTransactionNonce()
 	if err != nil {
-		tCertHandler.client.error("Failed initiliazing transaction handler [%s]", err)
+		tCertHandler.client.Errorf("Failed initiliazing transaction handler [%s]", err)
 
 		return err
 	}

--- a/core/crypto/client_tcert_pool_st.go
+++ b/core/crypto/client_tcert_pool_st.go
@@ -55,24 +55,24 @@ func (tCertPool *tCertPoolSingleThreadImpl) Start() (err error) {
 	tCertPool.m.Lock()
 	defer tCertPool.m.Unlock()
 
-	tCertPool.client.debug("Starting TCert Pool...")
+	tCertPool.client.Debug("Starting TCert Pool...")
 
 	// Load unused TCerts if any
 	tCertDBBlocks, err := tCertPool.client.ks.loadUnusedTCerts()
 	if err != nil {
-		tCertPool.client.error("Failed loading TCerts from cache: [%s]", err)
+		tCertPool.client.Errorf("Failed loading TCerts from cache: [%s]", err)
 
 		return
 	}
 
 	if len(tCertDBBlocks) > 0 {
 
-		tCertPool.client.debug("TCerts in cache found! Loading them...")
+		tCertPool.client.Debug("TCerts in cache found! Loading them...")
 
 		for _, tCertDBBlock := range tCertDBBlocks {
 			tCertBlock, err := tCertPool.client.getTCertFromDER(tCertDBBlock)
 			if err != nil {
-				tCertPool.client.error("Failed paring TCert [% x]: [%s]", tCertDBBlock.tCertDER, err)
+				tCertPool.client.Errorf("Failed paring TCert [% x]: [%s]", tCertDBBlock.tCertDER, err)
 
 				continue
 			}
@@ -93,7 +93,7 @@ func (tCertPool *tCertPoolSingleThreadImpl) Stop() (err error) {
 		tCertPool.client.ks.storeUnusedTCerts(certList[:certListLen])
 	}
 
-	tCertPool.client.debug("Store unused TCerts...done!")
+	tCertPool.client.Debug("Store unused TCerts...done!")
 
 	return
 }
@@ -161,7 +161,7 @@ func (tCertPool *tCertPoolSingleThreadImpl) getNextTCert(attributes ...string) (
 //AddTCert adds a TCert into the pool is invoked by the client after TCA is called.
 func (tCertPool *tCertPoolSingleThreadImpl) AddTCert(tCertBlock *TCertBlock) (err error) {
 
-	tCertPool.client.debug("Adding new Cert [% x].", tCertBlock.tCert.GetCertificate().Raw)
+	tCertPool.client.Debugf("Adding new Cert [% x].", tCertBlock.tCert.GetCertificate().Raw)
 
 	if tCertPool.length[tCertBlock.attributesHash] <= 0 {
 		tCertPool.length[tCertBlock.attributesHash] = 0
@@ -182,7 +182,7 @@ func (tCertPool *tCertPoolSingleThreadImpl) AddTCert(tCertBlock *TCertBlock) (er
 
 func (tCertPool *tCertPoolSingleThreadImpl) init(client *clientImpl) (err error) {
 	tCertPool.client = client
-	tCertPool.client.debug("Init TCert Pool...")
+	tCertPool.client.Debug("Init TCert Pool...")
 
 	tCertPool.tCerts = make(map[string][]*TCertBlock)
 

--- a/core/crypto/client_tx.go
+++ b/core/crypto/client_tx.go
@@ -26,7 +26,7 @@ import (
 func (client *clientImpl) createTransactionNonce() ([]byte, error) {
 	nonce, err := primitives.GetRandomNonce()
 	if err != nil {
-		client.error("Failed creating nonce [%s].", err.Error())
+		client.Errorf("Failed creating nonce [%s].", err.Error())
 		return nil, err
 	}
 
@@ -37,21 +37,21 @@ func (client *clientImpl) createDeployTx(chaincodeDeploymentSpec *obc.ChaincodeD
 	// Create a new transaction
 	tx, err := obc.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, uuid)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Copy metadata from ChaincodeSpec
 	tx.Metadata, err = getMetadata(chaincodeDeploymentSpec.GetChaincodeSpec(), tCert, attrs...)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	if nonce == nil {
 		tx.Nonce, err = primitives.GetRandomNonce()
 		if err != nil {
-			client.error("Failed creating nonce [%s].", err.Error())
+			client.Errorf("Failed creating nonce [%s].", err.Error())
 			return nil, err
 		}
 	} else {
@@ -70,7 +70,7 @@ func (client *clientImpl) createDeployTx(chaincodeDeploymentSpec *obc.ChaincodeD
 		// 3. encrypt tx
 		err = client.encryptTx(tx)
 		if err != nil {
-			client.error("Failed encrypting payload [%s].", err.Error())
+			client.Errorf("Failed encrypting payload [%s].", err.Error())
 			return nil, err
 
 		}
@@ -100,20 +100,20 @@ func (client *clientImpl) createExecuteTx(chaincodeInvocation *obc.ChaincodeInvo
 	/// Create a new transaction
 	tx, err := obc.NewChaincodeExecute(chaincodeInvocation, uuid, obc.Transaction_CHAINCODE_INVOKE)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Copy metadata from ChaincodeSpec
 	tx.Metadata, err = getMetadata(chaincodeInvocation.GetChaincodeSpec(), tCert, attrs...)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 	if nonce == nil {
 		tx.Nonce, err = primitives.GetRandomNonce()
 		if err != nil {
-			client.error("Failed creating nonce [%s].", err.Error())
+			client.Errorf("Failed creating nonce [%s].", err.Error())
 			return nil, err
 		}
 	} else {
@@ -132,7 +132,7 @@ func (client *clientImpl) createExecuteTx(chaincodeInvocation *obc.ChaincodeInvo
 		// 3. encrypt tx
 		err = client.encryptTx(tx)
 		if err != nil {
-			client.error("Failed encrypting payload [%s].", err.Error())
+			client.Errorf("Failed encrypting payload [%s].", err.Error())
 			return nil, err
 
 		}
@@ -145,20 +145,20 @@ func (client *clientImpl) createQueryTx(chaincodeInvocation *obc.ChaincodeInvoca
 	// Create a new transaction
 	tx, err := obc.NewChaincodeExecute(chaincodeInvocation, uuid, obc.Transaction_CHAINCODE_QUERY)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Copy metadata from ChaincodeSpec
 	tx.Metadata, err = getMetadata(chaincodeInvocation.GetChaincodeSpec(), tCert, attrs...)
 	if err != nil {
-		client.error("Failed creating new transaction [%s].", err.Error())
+		client.Errorf("Failed creating new transaction [%s].", err.Error())
 		return nil, err
 	}
 	if nonce == nil {
 		tx.Nonce, err = primitives.GetRandomNonce()
 		if err != nil {
-			client.error("Failed creating nonce [%s].", err.Error())
+			client.Errorf("Failed creating nonce [%s].", err.Error())
 			return nil, err
 		}
 	} else {
@@ -177,7 +177,7 @@ func (client *clientImpl) createQueryTx(chaincodeInvocation *obc.ChaincodeInvoca
 		// 3. encrypt tx
 		err = client.encryptTx(tx)
 		if err != nil {
-			client.error("Failed encrypting payload [%s].", err.Error())
+			client.Errorf("Failed encrypting payload [%s].", err.Error())
 			return nil, err
 
 		}
@@ -190,35 +190,35 @@ func (client *clientImpl) newChaincodeDeployUsingTCert(chaincodeDeploymentSpec *
 	// Create a new transaction
 	tx, err := client.createDeployTx(chaincodeDeploymentSpec, uuid, nonce, tCert, attributeNames...)
 	if err != nil {
-		client.error("Failed creating new deploy transaction [%s].", err.Error())
+		client.Errorf("Failed creating new deploy transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", tCert.GetCertificate().Raw)
+	client.Debugf("Appending certificate [% x].", tCert.GetCertificate().Raw)
 	tx.Cert = tCert.GetCertificate().Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := tCert.Sign(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", rawTx, err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", rawTx, err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature: [% x]", rawSignature)
+	client.Debugf("Appending signature: [% x]", rawSignature)
 
 	return tx, nil
 }
@@ -227,35 +227,35 @@ func (client *clientImpl) newChaincodeExecuteUsingTCert(chaincodeInvocation *obc
 	/// Create a new transaction
 	tx, err := client.createExecuteTx(chaincodeInvocation, uuid, nonce, tCert, attributeKeys...)
 	if err != nil {
-		client.error("Failed creating new execute transaction [%s].", err.Error())
+		client.Errorf("Failed creating new execute transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", tCert.GetCertificate().Raw)
+	client.Debugf("Appending certificate [% x].", tCert.GetCertificate().Raw)
 	tx.Cert = tCert.GetCertificate().Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := tCert.Sign(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature [% x].", rawSignature)
+	client.Debugf("Appending signature [% x].", rawSignature)
 
 	return tx, nil
 }
@@ -264,35 +264,35 @@ func (client *clientImpl) newChaincodeQueryUsingTCert(chaincodeInvocation *obc.C
 	// Create a new transaction
 	tx, err := client.createQueryTx(chaincodeInvocation, uuid, nonce, tCert, attributeNames...)
 	if err != nil {
-		client.error("Failed creating new query transaction [%s].", err.Error())
+		client.Errorf("Failed creating new query transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", tCert.GetCertificate().Raw)
+	client.Debugf("Appending certificate [% x].", tCert.GetCertificate().Raw)
 	tx.Cert = tCert.GetCertificate().Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := tCert.Sign(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature [% x].", rawSignature)
+	client.Debugf("Appending signature [% x].", rawSignature)
 
 	return tx, nil
 }
@@ -301,35 +301,35 @@ func (client *clientImpl) newChaincodeDeployUsingECert(chaincodeDeploymentSpec *
 	// Create a new transaction
 	tx, err := client.createDeployTx(chaincodeDeploymentSpec, uuid, nonce, nil)
 	if err != nil {
-		client.error("Failed creating new deploy transaction [%s].", err.Error())
+		client.Errorf("Failed creating new deploy transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", client.enrollCert.Raw)
+	client.Debugf("Appending certificate [% x].", client.enrollCert.Raw)
 	tx.Cert = client.enrollCert.Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := client.signWithEnrollmentKey(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", rawTx, err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", rawTx, err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature: [% x]", rawSignature)
+	client.Debugf("Appending signature: [% x]", rawSignature)
 
 	return tx, nil
 }
@@ -338,35 +338,35 @@ func (client *clientImpl) newChaincodeExecuteUsingECert(chaincodeInvocation *obc
 	/// Create a new transaction
 	tx, err := client.createExecuteTx(chaincodeInvocation, uuid, nonce, nil)
 	if err != nil {
-		client.error("Failed creating new execute transaction [%s].", err.Error())
+		client.Errorf("Failed creating new execute transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", client.enrollCert.Raw)
+	client.Debugf("Appending certificate [% x].", client.enrollCert.Raw)
 	tx.Cert = client.enrollCert.Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := client.signWithEnrollmentKey(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", rawTx, err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", rawTx, err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature [% x].", rawSignature)
+	client.Debugf("Appending signature [% x].", rawSignature)
 
 	return tx, nil
 }
@@ -375,35 +375,35 @@ func (client *clientImpl) newChaincodeQueryUsingECert(chaincodeInvocation *obc.C
 	// Create a new transaction
 	tx, err := client.createQueryTx(chaincodeInvocation, uuid, nonce, nil)
 	if err != nil {
-		client.error("Failed creating new query transaction [%s].", err.Error())
+		client.Errorf("Failed creating new query transaction [%s].", err.Error())
 		return nil, err
 	}
 
 	// Sign the transaction
 
 	// Append the certificate to the transaction
-	client.debug("Appending certificate [% x].", client.enrollCert.Raw)
+	client.Debugf("Appending certificate [% x].", client.enrollCert.Raw)
 	tx.Cert = client.enrollCert.Raw
 
 	// Sign the transaction and append the signature
 	// 1. Marshall tx to bytes
 	rawTx, err := proto.Marshal(tx)
 	if err != nil {
-		client.error("Failed marshaling tx [%s].", err.Error())
+		client.Errorf("Failed marshaling tx [%s].", err.Error())
 		return nil, err
 	}
 
 	// 2. Sign rawTx and check signature
 	rawSignature, err := client.signWithEnrollmentKey(rawTx)
 	if err != nil {
-		client.error("Failed creating signature [% x]: [%s].", rawTx, err.Error())
+		client.Errorf("Failed creating signature [% x]: [%s].", rawTx, err.Error())
 		return nil, err
 	}
 
 	// 3. Append the signature
 	tx.Signature = rawSignature
 
-	client.debug("Appending signature [% x].", rawSignature)
+	client.Debugf("Appending signature [% x].", rawSignature)
 
 	return tx, nil
 }
@@ -425,7 +425,7 @@ func (client *clientImpl) checkTransaction(tx *obc.Transaction) error {
 		// 1. Unmarshal cert
 		cert, err := primitives.DERToX509Certificate(tx.Cert)
 		if err != nil {
-			client.error("Failed unmarshalling cert [%s].", err.Error())
+			client.Errorf("Failed unmarshalling cert [%s].", err.Error())
 			return err
 		}
 		// TODO: verify cert
@@ -435,7 +435,7 @@ func (client *clientImpl) checkTransaction(tx *obc.Transaction) error {
 		tx.Signature = nil
 		rawTx, err := proto.Marshal(tx)
 		if err != nil {
-			client.error("Failed marshaling tx [%s].", err.Error())
+			client.Errorf("Failed marshaling tx [%s].", err.Error())
 			return err
 		}
 		tx.Signature = signature
@@ -443,7 +443,7 @@ func (client *clientImpl) checkTransaction(tx *obc.Transaction) error {
 		// 2. Verify signature
 		ver, err := client.verify(cert.PublicKey, rawTx, tx.Signature)
 		if err != nil {
-			client.error("Failed marshaling tx [%s].", err.Error())
+			client.Errorf("Failed marshaling tx [%s].", err.Error())
 			return err
 		}
 

--- a/core/crypto/node_conf.go
+++ b/core/crypto/node_conf.go
@@ -33,7 +33,7 @@ func (node *nodeImpl) initConfiguration(name string) (err error) {
 		return
 	}
 
-	node.debug("Data will be stored at [%s]", node.conf.configurationPath)
+	node.Debugf("Data will be stored at [%s]", node.conf.configurationPath)
 
 	return
 }

--- a/core/crypto/node_crypto.go
+++ b/core/crypto/node_crypto.go
@@ -23,48 +23,48 @@ import (
 )
 
 func (node *nodeImpl) registerCryptoEngine(enrollID, enrollPWD string) error {
-	node.debug("Registering node crypto engine...")
+	node.Debug("Registering node crypto engine...")
 
 	// Init CLI
 	node.eciesSPI = ecies.NewSPI()
 
 	if err := node.initTLS(); err != nil {
-		node.error("Failed initliazing TLS [%s].", err.Error())
+		node.Errorf("Failed initliazing TLS [%s].", err.Error())
 
 		return err
 	}
 
 	if err := node.retrieveECACertsChain(enrollID); err != nil {
-		node.error("Failed retrieving ECA certs chain [%s].", err.Error())
+		node.Errorf("Failed retrieving ECA certs chain [%s].", err.Error())
 
 		return err
 	}
 
 	if err := node.retrieveTCACertsChain(enrollID); err != nil {
-		node.error("Failed retrieving ECA certs chain [%s].", err.Error())
+		node.Errorf("Failed retrieving ECA certs chain [%s].", err.Error())
 
 		return err
 	}
 
 	if err := node.retrieveEnrollmentData(enrollID, enrollPWD); err != nil {
-		node.error("Failed retrieving enrollment data [%s].", err.Error())
+		node.Errorf("Failed retrieving enrollment data [%s].", err.Error())
 
 		return err
 	}
 
 	if err := node.retrieveTLSCertificate(enrollID, enrollPWD); err != nil {
-		node.error("Failed retrieving enrollment data: %s", err)
+		node.Errorf("Failed retrieving enrollment data: %s", err)
 
 		return err
 	}
 
-	node.debug("Registering node crypto engine...done!")
+	node.Debug("Registering node crypto engine...done!")
 
 	return nil
 }
 
 func (node *nodeImpl) initCryptoEngine() error {
-	node.debug("Initializing node crypto engine...")
+	node.Debug("Initializing node crypto engine...")
 
 	// Init CLI
 	node.eciesSPI = ecies.NewSPI()
@@ -115,7 +115,7 @@ func (node *nodeImpl) initCryptoEngine() error {
 		return err
 	}
 
-	node.debug("Initializing node crypto engine...done!")
+	node.Debug("Initializing node crypto engine...done!")
 
 	return nil
 }

--- a/core/crypto/node_eca.go
+++ b/core/crypto/node_eca.go
@@ -45,17 +45,17 @@ func (node *nodeImpl) retrieveECACertsChain(userID string) error {
 	// Retrieve ECA certificate and verify it
 	ecaCertRaw, err := node.getECACertificate()
 	if err != nil {
-		node.error("Failed getting ECA certificate [%s].", err.Error())
+		node.Errorf("Failed getting ECA certificate [%s].", err.Error())
 
 		return err
 	}
-	node.debug("ECA certificate [% x].", ecaCertRaw)
+	node.Debugf("ECA certificate [% x].", ecaCertRaw)
 
 	// TODO: Test ECA cert againt root CA
 	// TODO: check response.Cert against rootCA
 	x509ECACert, err := primitives.DERToX509Certificate(ecaCertRaw)
 	if err != nil {
-		node.error("Failed parsing ECA certificate [%s].", err.Error())
+		node.Errorf("Failed parsing ECA certificate [%s].", err.Error())
 
 		return err
 	}
@@ -65,10 +65,10 @@ func (node *nodeImpl) retrieveECACertsChain(userID string) error {
 	node.ecaCertPool.AddCert(x509ECACert)
 
 	// Store ECA cert
-	node.debug("Storing ECA certificate for [%s]...", userID)
+	node.Debugf("Storing ECA certificate for [%s]...", userID)
 
 	if err := node.ks.storeCert(node.conf.getECACertsChainFilename(), ecaCertRaw); err != nil {
-		node.error("Failed storing eca certificate [%s].", err.Error())
+		node.Errorf("Failed storing eca certificate [%s].", err.Error())
 		return err
 	}
 
@@ -78,30 +78,30 @@ func (node *nodeImpl) retrieveECACertsChain(userID string) error {
 func (node *nodeImpl) retrieveEnrollmentData(enrollID, enrollPWD string) error {
 	key, enrollCertRaw, enrollChainKey, err := node.getEnrollmentCertificateFromECA(enrollID, enrollPWD)
 	if err != nil {
-		node.error("Failed getting enrollment certificate [id=%s]: [%s]", enrollID, err)
+		node.Errorf("Failed getting enrollment certificate [id=%s]: [%s]", enrollID, err)
 
 		return err
 	}
-	node.debug("Enrollment certificate [% x].", enrollCertRaw)
+	node.Debugf("Enrollment certificate [% x].", enrollCertRaw)
 
-	node.debug("Storing enrollment data for user [%s]...", enrollID)
+	node.Debugf("Storing enrollment data for user [%s]...", enrollID)
 
 	// Store enrollment id
 	err = ioutil.WriteFile(node.conf.getEnrollmentIDPath(), []byte(enrollID), 0700)
 	if err != nil {
-		node.error("Failed storing enrollment certificate [id=%s]: [%s]", enrollID, err)
+		node.Errorf("Failed storing enrollment certificate [id=%s]: [%s]", enrollID, err)
 		return err
 	}
 
 	// Store enrollment key
 	if err := node.ks.storePrivateKey(node.conf.getEnrollmentKeyFilename(), key); err != nil {
-		node.error("Failed storing enrollment key [id=%s]: [%s]", enrollID, err)
+		node.Errorf("Failed storing enrollment key [id=%s]: [%s]", enrollID, err)
 		return err
 	}
 
 	// Store enrollment cert
 	if err := node.ks.storeCert(node.conf.getEnrollmentCertFilename(), enrollCertRaw); err != nil {
-		node.error("Failed storing enrollment certificate [id=%s]: [%s]", enrollID, err)
+		node.Errorf("Failed storing enrollment certificate [id=%s]: [%s]", enrollID, err)
 		return err
 	}
 
@@ -113,34 +113,34 @@ func (node *nodeImpl) retrieveEnrollmentData(enrollID, enrollPWD string) error {
 	// Code for confidentiality 1.2
 	// Store enrollment chain key
 	if node.eType == NodeValidator {
-		node.debug("Enrollment chain key for validator [%s]...", enrollID)
+		node.Debugf("Enrollment chain key for validator [%s]...", enrollID)
 		// enrollChainKey is a secret key
 
-		node.debug("key [%s]...", string(enrollChainKey))
+		node.Debugf("key [%s]...", string(enrollChainKey))
 
 		key, err := primitives.PEMtoPrivateKey(enrollChainKey, nil)
 		if err != nil {
-			node.error("Failed unmarshalling enrollment chain key [id=%s]: [%s]", enrollID, err)
+			node.Errorf("Failed unmarshalling enrollment chain key [id=%s]: [%s]", enrollID, err)
 			return err
 		}
 
 		if err := node.ks.storePrivateKey(node.conf.getEnrollmentChainKeyFilename(), key); err != nil {
-			node.error("Failed storing enrollment chain key [id=%s]: [%s]", enrollID, err)
+			node.Errorf("Failed storing enrollment chain key [id=%s]: [%s]", enrollID, err)
 			return err
 		}
 	} else {
-		node.debug("Enrollment chain key for non-validator [%s]...", enrollID)
+		node.Debugf("Enrollment chain key for non-validator [%s]...", enrollID)
 		// enrollChainKey is a public key
 
 		key, err := primitives.PEMtoPublicKey(enrollChainKey, nil)
 		if err != nil {
-			node.error("Failed unmarshalling enrollment chain key [id=%s]: [%s]", enrollID, err)
+			node.Errorf("Failed unmarshalling enrollment chain key [id=%s]: [%s]", enrollID, err)
 			return err
 		}
-		node.debug("Key decoded from PEM [%s]...", enrollID)
+		node.Debugf("Key decoded from PEM [%s]...", enrollID)
 
 		if err := node.ks.storePublicKey(node.conf.getEnrollmentChainKeyFilename(), key); err != nil {
-			node.error("Failed storing enrollment chain key [id=%s]: [%s]", enrollID, err)
+			node.Errorf("Failed storing enrollment chain key [id=%s]: [%s]", enrollID, err)
 			return err
 		}
 	}
@@ -149,11 +149,11 @@ func (node *nodeImpl) retrieveEnrollmentData(enrollID, enrollPWD string) error {
 }
 
 func (node *nodeImpl) loadEnrollmentKey() error {
-	node.debug("Loading enrollment key...")
+	node.Debug("Loading enrollment key...")
 
 	enrollPrivKey, err := node.ks.loadPrivateKey(node.conf.getEnrollmentKeyFilename())
 	if err != nil {
-		node.error("Failed loading enrollment private key [%s].", err.Error())
+		node.Errorf("Failed loading enrollment private key [%s].", err.Error())
 
 		return err
 	}
@@ -164,11 +164,11 @@ func (node *nodeImpl) loadEnrollmentKey() error {
 }
 
 func (node *nodeImpl) loadEnrollmentCertificate() error {
-	node.debug("Loading enrollment certificate...")
+	node.Debug("Loading enrollment certificate...")
 
 	cert, der, err := node.ks.loadCertX509AndDer(node.conf.getEnrollmentCertFilename())
 	if err != nil {
-		node.error("Failed parsing enrollment certificate [%s].", err.Error())
+		node.Errorf("Failed parsing enrollment certificate [%s].", err.Error())
 
 		return err
 	}
@@ -178,41 +178,41 @@ func (node *nodeImpl) loadEnrollmentCertificate() error {
 	pk := node.enrollCert.PublicKey.(*ecdsa.PublicKey)
 	err = primitives.VerifySignCapability(node.enrollPrivKey, pk)
 	if err != nil {
-		node.error("Failed checking enrollment certificate against enrollment key [%s].", err.Error())
+		node.Errorf("Failed checking enrollment certificate against enrollment key [%s].", err.Error())
 
 		return err
 	}
 
 	// Set node ID
 	node.id = primitives.Hash(der)
-	node.debug("Setting id to [% x].", node.id)
+	node.Debugf("Setting id to [% x].", node.id)
 
 	// Set eCertHash
 	node.enrollCertHash = primitives.Hash(der)
-	node.debug("Setting enrollCertHash to [% x].", node.enrollCertHash)
+	node.Debugf("Setting enrollCertHash to [% x].", node.enrollCertHash)
 
 	return nil
 }
 
 func (node *nodeImpl) loadEnrollmentID() error {
-	node.debug("Loading enrollment id at [%s]...", node.conf.getEnrollmentIDPath())
+	node.Debugf("Loading enrollment id at [%s]...", node.conf.getEnrollmentIDPath())
 
 	enrollID, err := ioutil.ReadFile(node.conf.getEnrollmentIDPath())
 	if err != nil {
-		node.error("Failed loading enrollment id [%s].", err.Error())
+		node.Errorf("Failed loading enrollment id [%s].", err.Error())
 
 		return err
 	}
 
 	// Set enrollment ID
 	node.enrollID = string(enrollID)
-	node.debug("Setting enrollment id to [%s].", node.enrollID)
+	node.Debugf("Setting enrollment id to [%s].", node.enrollID)
 
 	return nil
 }
 
 func (node *nodeImpl) loadEnrollmentChainKey() error {
-	node.debug("Loading enrollment chain key...")
+	node.Debug("Loading enrollment chain key...")
 
 	// Code for confidentiality 1.1
 	//enrollChainKey, err := node.ks.loadKey(node.conf.getEnrollmentChainKeyFilename())
@@ -228,7 +228,7 @@ func (node *nodeImpl) loadEnrollmentChainKey() error {
 		// enrollChainKey is a secret key
 		enrollChainKey, err := node.ks.loadPrivateKey(node.conf.getEnrollmentChainKeyFilename())
 		if err != nil {
-			node.error("Failed loading enrollment chain key: [%s]", err)
+			node.Errorf("Failed loading enrollment chain key: [%s]", err)
 			return err
 		}
 		node.enrollChainKey = enrollChainKey
@@ -236,7 +236,7 @@ func (node *nodeImpl) loadEnrollmentChainKey() error {
 		// enrollChainKey is a public key
 		enrollChainKey, err := node.ks.loadPublicKey(node.conf.getEnrollmentChainKeyFilename())
 		if err != nil {
-			node.error("Failed load enrollment chain key: [%s]", err)
+			node.Errorf("Failed load enrollment chain key: [%s]", err)
 			return err
 		}
 		node.enrollChainKey = enrollChainKey
@@ -246,18 +246,18 @@ func (node *nodeImpl) loadEnrollmentChainKey() error {
 }
 
 func (node *nodeImpl) loadECACertsChain() error {
-	node.debug("Loading ECA certificates chain...")
+	node.Debug("Loading ECA certificates chain...")
 
 	pem, err := node.ks.loadCert(node.conf.getECACertsChainFilename())
 	if err != nil {
-		node.error("Failed loading ECA certificates chain [%s].", err.Error())
+		node.Errorf("Failed loading ECA certificates chain [%s].", err.Error())
 
 		return err
 	}
 
 	ok := node.ecaCertPool.AppendCertsFromPEM(pem)
 	if !ok {
-		node.error("Failed appending ECA certificates chain.")
+		node.Error("Failed appending ECA certificates chain.")
 
 		return errors.New("Failed appending ECA certificates chain.")
 	}
@@ -266,16 +266,16 @@ func (node *nodeImpl) loadECACertsChain() error {
 }
 
 func (node *nodeImpl) getECAClient() (*grpc.ClientConn, membersrvc.ECAPClient, error) {
-	node.debug("Getting ECA client...")
+	node.Debug("Getting ECA client...")
 
 	conn, err := node.getClientConn(node.conf.getECAPAddr(), node.conf.getECAServerName())
 	if err != nil {
-		node.error("Failed getting client connection: [%s]", err)
+		node.Errorf("Failed getting client connection: [%s]", err)
 	}
 
 	client := membersrvc.NewECAPClient(conn)
 
-	node.debug("Getting ECA client...done")
+	node.Debug("Getting ECA client...done")
 
 	return conn, client, nil
 }
@@ -288,7 +288,7 @@ func (node *nodeImpl) callECAReadCACertificate(ctx context.Context, opts ...grpc
 	// Issue the request
 	cert, err := ecaP.ReadCACertificate(ctx, &membersrvc.Empty{}, opts...)
 	if err != nil {
-		node.error("Failed requesting read certificate [%s].", err.Error())
+		node.Errorf("Failed requesting read certificate [%s].", err.Error())
 
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (node *nodeImpl) callECAReadCertificate(ctx context.Context, in *membersrvc
 	// Issue the request
 	resp, err := ecaP.ReadCertificatePair(ctx, in, opts...)
 	if err != nil {
-		node.error("Failed requesting read certificate [%s].", err.Error())
+		node.Errorf("Failed requesting read certificate [%s].", err.Error())
 
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (node *nodeImpl) callECAReadCertificateByHash(ctx context.Context, in *memb
 	// Issue the request
 	resp, err := ecaP.ReadCertificateByHash(ctx, in, opts...)
 	if err != nil {
-		node.error("Failed requesting read certificate [%s].", err.Error())
+		node.Errorf("Failed requesting read certificate [%s].", err.Error())
 
 		return nil, err
 	}
@@ -337,26 +337,26 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 
 	signPriv, err := primitives.NewECDSAKey()
 	if err != nil {
-		node.error("Failed generating ECDSA key [%s].", err.Error())
+		node.Errorf("Failed generating ECDSA key [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
 	signPub, err := x509.MarshalPKIXPublicKey(&signPriv.PublicKey)
 	if err != nil {
-		node.error("Failed mashalling ECDSA key [%s].", err.Error())
+		node.Errorf("Failed mashalling ECDSA key [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
 
 	encPriv, err := primitives.NewECDSAKey()
 	if err != nil {
-		node.error("Failed generating Encryption key [%s].", err.Error())
+		node.Errorf("Failed generating Encryption key [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
 	encPub, err := x509.MarshalPKIXPublicKey(&encPriv.PublicKey)
 	if err != nil {
-		node.error("Failed marshalling Encryption key [%s].", err.Error())
+		node.Errorf("Failed marshalling Encryption key [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
@@ -371,33 +371,33 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 
 	resp, err := ecaP.CreateCertificatePair(context.Background(), req)
 	if err != nil {
-		node.error("Failed invoking CreateCertficatePair [%s].", err.Error())
+		node.Errorf("Failed invoking CreateCertficatePair [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
-	
-	if resp.FetchResult != nil && resp.FetchResult.Status != membersrvc.FetchAttrsResult_SUCCESS { 
-		node.warning(resp.FetchResult.Msg)
-	} 
+
+	if resp.FetchResult != nil && resp.FetchResult.Status != membersrvc.FetchAttrsResult_SUCCESS {
+		node.Warning(resp.FetchResult.Msg)
+	}
 	//out, err := rsa.DecryptPKCS1v15(rand.Reader, encPriv, resp.Tok.Tok)
 	spi := ecies.NewSPI()
 	eciesKey, err := spi.NewPrivateKey(nil, encPriv)
 	if err != nil {
-		node.error("Failed parsing decrypting key [%s].", err.Error())
+		node.Errorf("Failed parsing decrypting key [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
 
 	ecies, err := spi.NewAsymmetricCipherFromPublicKey(eciesKey)
 	if err != nil {
-		node.error("Failed creating asymmetrinc cipher [%s].", err.Error())
+		node.Errorf("Failed creating asymmetrinc cipher [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
 
 	out, err := ecies.Process(resp.Tok.Tok)
 	if err != nil {
-		node.error("Failed decrypting toke [%s].", err.Error())
+		node.Errorf("Failed decrypting toke [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
@@ -411,7 +411,7 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 
 	r, s, err := ecdsa.Sign(rand.Reader, signPriv, hash.Sum(nil))
 	if err != nil {
-		node.error("Failed signing [%s].", err.Error())
+		node.Errorf("Failed signing [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
@@ -421,7 +421,7 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 
 	resp, err = ecaP.CreateCertificatePair(context.Background(), req)
 	if err != nil {
-		node.error("Failed invoking CreateCertificatePair [%s].", err.Error())
+		node.Errorf("Failed invoking CreateCertificatePair [%s].", err.Error())
 
 		return nil, nil, nil, err
 	}
@@ -429,49 +429,49 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 	// Verify response
 
 	// Verify cert for signing
-	node.debug("Enrollment certificate for signing [% x]", primitives.Hash(resp.Certs.Sign))
+	node.Debugf("Enrollment certificate for signing [% x]", primitives.Hash(resp.Certs.Sign))
 
 	x509SignCert, err := primitives.DERToX509Certificate(resp.Certs.Sign)
 	if err != nil {
-		node.error("Failed parsing signing enrollment certificate for signing: [%s]", err)
+		node.Errorf("Failed parsing signing enrollment certificate for signing: [%s]", err)
 
 		return nil, nil, nil, err
 	}
 
 	_, err = primitives.GetCriticalExtension(x509SignCert, ECertSubjectRole)
 	if err != nil {
-		node.error("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
+		node.Errorf("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
 
 		return nil, nil, nil, err
 	}
 
 	err = primitives.CheckCertAgainstSKAndRoot(x509SignCert, signPriv, node.ecaCertPool)
 	if err != nil {
-		node.error("Failed checking signing enrollment certificate for signing: [%s]", err)
+		node.Errorf("Failed checking signing enrollment certificate for signing: [%s]", err)
 
 		return nil, nil, nil, err
 	}
 
 	// Verify cert for encrypting
-	node.debug("Enrollment certificate for encrypting [% x]", primitives.Hash(resp.Certs.Enc))
+	node.Debugf("Enrollment certificate for encrypting [% x]", primitives.Hash(resp.Certs.Enc))
 
 	x509EncCert, err := primitives.DERToX509Certificate(resp.Certs.Enc)
 	if err != nil {
-		node.error("Failed parsing signing enrollment certificate for encrypting: [%s]", err)
+		node.Errorf("Failed parsing signing enrollment certificate for encrypting: [%s]", err)
 
 		return nil, nil, nil, err
 	}
 
 	_, err = primitives.GetCriticalExtension(x509EncCert, ECertSubjectRole)
 	if err != nil {
-		node.error("Failed parsing ECertSubjectRole in enrollment certificate for encrypting: [%s]", err)
+		node.Errorf("Failed parsing ECertSubjectRole in enrollment certificate for encrypting: [%s]", err)
 
 		return nil, nil, nil, err
 	}
 
 	err = primitives.CheckCertAgainstSKAndRoot(x509EncCert, encPriv, node.ecaCertPool)
 	if err != nil {
-		node.error("Failed checking signing enrollment certificate for encrypting: [%s]", err)
+		node.Errorf("Failed checking signing enrollment certificate for encrypting: [%s]", err)
 
 		return nil, nil, nil, err
 	}
@@ -482,7 +482,7 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 func (node *nodeImpl) getECACertificate() ([]byte, error) {
 	responce, err := node.callECAReadCACertificate(context.Background())
 	if err != nil {
-		node.error("Failed requesting ECA certificate [%s].", err.Error())
+		node.Errorf("Failed requesting ECA certificate [%s].", err.Error())
 
 		return nil, err
 	}

--- a/core/crypto/node_grpc.go
+++ b/core/crypto/node_grpc.go
@@ -28,12 +28,12 @@ import (
 )
 
 func (node *nodeImpl) initTLS() error {
-	node.debug("Initiliazing TLS...")
+	node.Debug("Initiliazing TLS...")
 
 	if node.conf.isTLSEnabled() {
 		pem, err := node.ks.loadExternalCert(node.conf.getTLSCACertsExternalPath())
 		if err != nil {
-			node.error("Failed loading TLSCA certificates chain [%s].", err.Error())
+			node.Errorf("Failed loading TLSCA certificates chain [%s].", err.Error())
 
 			return err
 		}
@@ -41,23 +41,23 @@ func (node *nodeImpl) initTLS() error {
 		node.tlsCertPool = x509.NewCertPool()
 		ok := node.tlsCertPool.AppendCertsFromPEM(pem)
 		if !ok {
-			node.error("Failed appending TLSCA certificates chain.")
+			node.Error("Failed appending TLSCA certificates chain.")
 
 			return errors.New("Failed appending TLSCA certificates chain.")
 		}
-		node.debug("Initiliazing TLS...Done")
+		node.Debug("Initiliazing TLS...Done")
 	} else {
-		node.debug("Initiliazing TLS...Disabled!!!")
+		node.Debug("Initiliazing TLS...Disabled!!!")
 	}
 
 	return nil
 }
 
 func (node *nodeImpl) getClientConn(address string, serverName string) (*grpc.ClientConn, error) {
-	node.debug("Dial to addr:[%s], with serverName:[%s]...", address, serverName)
+	node.Debugf("Dial to addr:[%s], with serverName:[%s]...", address, serverName)
 
 	if node.conf.isTLSEnabled() {
-		node.debug("TLS enabled...")
+		node.Debug("TLS enabled...")
 
 		config := tls.Config{
 			InsecureSkipVerify: false,
@@ -70,6 +70,6 @@ func (node *nodeImpl) getClientConn(address string, serverName string) (*grpc.Cl
 
 		return comm.NewClientConnectionWithAddress(address, false, true, credentials.NewTLS(&config))
 	}
-	node.debug("TLS disabled...")
+	node.Debug("TLS disabled...")
 	return comm.NewClientConnectionWithAddress(address, false, false, nil)
 }

--- a/core/crypto/node_impl.go
+++ b/core/crypto/node_impl.go
@@ -86,7 +86,7 @@ func (node *nodeImpl) register(eType NodeType, name string, pwd []byte, enrollID
 
 	// Init Conf
 	if err := node.initConfiguration(name); err != nil {
-		log.Errorf("Failed initiliazing configuration [%s]: [%s].", enrollID, err)
+		node.Errorf("Failed initiliazing configuration [%s]: [%s].", enrollID, err)
 
 		return err
 	}
@@ -96,15 +96,15 @@ func (node *nodeImpl) register(eType NodeType, name string, pwd []byte, enrollID
 		return utils.ErrAlreadyRegistered
 	}
 
-	node.debug("Registering node [%s]...", enrollID)
+	node.Debugf("Registering node [%s]...", enrollID)
 
 	// Initialize keystore
 	err := node.initKeyStore(pwd)
 	if err != nil {
 		if err != utils.ErrKeyStoreAlreadyInitialized {
-			node.error("Keystore already initialized.")
+			node.Error("Keystore already initialized.")
 		} else {
-			node.error("Failed initiliazing keystore [%s].", err.Error())
+			node.Errorf("Failed initiliazing keystore [%s].", err.Error())
 
 			return err
 		}
@@ -113,18 +113,18 @@ func (node *nodeImpl) register(eType NodeType, name string, pwd []byte, enrollID
 	// Register crypto engine
 	err = node.registerCryptoEngine(enrollID, enrollPWD)
 	if err != nil {
-		node.error("Failed registering node crypto engine [%s].", err.Error())
+		node.Errorf("Failed registering node crypto engine [%s].", err.Error())
 		return err
 	}
 
-	node.debug("Registering node [%s]...done!", enrollID)
+	node.Debugf("Registering node [%s]...done!", enrollID)
 
 	return nil
 }
 
 func (node *nodeImpl) init(eType NodeType, name string, pwd []byte) error {
 	if node.isInitialized {
-		node.error("Already initializaed.")
+		node.Error("Already initializaed.")
 
 		return utils.ErrAlreadyInitialized
 	}
@@ -138,36 +138,36 @@ func (node *nodeImpl) init(eType NodeType, name string, pwd []byte) error {
 	}
 
 	if !node.isRegistered() {
-		node.error("Not registered yet.")
+		node.Error("Not registered yet.")
 
 		return utils.ErrRegistrationRequired
 	}
 
 	// Initialize keystore
-	node.debug("Init keystore...")
+	node.Debug("Init keystore...")
 	err := node.initKeyStore(pwd)
 	if err != nil {
 		if err != utils.ErrKeyStoreAlreadyInitialized {
-			node.error("Keystore already initialized.")
+			node.Error("Keystore already initialized.")
 		} else {
-			node.error("Failed initiliazing keystore [%s].", err.Error())
+			node.Errorf("Failed initiliazing keystore [%s].", err.Error())
 
 			return err
 		}
 	}
-	node.debug("Init keystore...done.")
+	node.Debug("Init keystore...done.")
 
 	// Init crypto engine
 	err = node.initCryptoEngine()
 	if err != nil {
-		node.error("Failed initiliazing crypto engine [%s].", err.Error())
+		node.Errorf("Failed initiliazing crypto engine [%s].", err.Error())
 		return err
 	}
 
 	// Initialisation complete
 	node.isInitialized = true
 
-	node.debug("Initialization...done.")
+	node.Debug("Initialization...done.")
 
 	return nil
 }

--- a/core/crypto/node_ks.go
+++ b/core/crypto/node_ks.go
@@ -26,8 +26,8 @@ import (
 	"sync"
 
 	// Required to successfully initialized the driver
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 /*
@@ -119,13 +119,13 @@ func (ks *keyStore) isAliasSet(alias string) bool {
 func (ks *keyStore) storePrivateKey(alias string, privateKey interface{}) error {
 	rawKey, err := primitives.PrivateKeyToPEM(privateKey, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed converting private key to PEM [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed converting private key to PEM [%s]: [%s]", alias, err)
 		return err
 	}
 
 	err = ioutil.WriteFile(ks.node.conf.getPathForAlias(alias), rawKey, 0700)
 	if err != nil {
-		ks.node.error("Failed storing private key [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed storing private key [%s]: [%s]", alias, err)
 		return err
 	}
 
@@ -135,13 +135,13 @@ func (ks *keyStore) storePrivateKey(alias string, privateKey interface{}) error 
 func (ks *keyStore) storePrivateKeyInClear(alias string, privateKey interface{}) error {
 	rawKey, err := primitives.PrivateKeyToPEM(privateKey, nil)
 	if err != nil {
-		ks.node.error("Failed converting private key to PEM [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed converting private key to PEM [%s]: [%s]", alias, err)
 		return err
 	}
 
 	err = ioutil.WriteFile(ks.node.conf.getPathForAlias(alias), rawKey, 0700)
 	if err != nil {
-		ks.node.error("Failed storing private key [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed storing private key [%s]: [%s]", alias, err)
 		return err
 	}
 
@@ -150,18 +150,18 @@ func (ks *keyStore) storePrivateKeyInClear(alias string, privateKey interface{})
 
 func (ks *keyStore) loadPrivateKey(alias string) (interface{}, error) {
 	path := ks.node.conf.getPathForAlias(alias)
-	ks.node.debug("Loading private key [%s] at [%s]...", alias, path)
+	ks.node.Debugf("Loading private key [%s] at [%s]...", alias, path)
 
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading private key [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed loading private key [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
 
 	privateKey, err := primitives.PEMtoPrivateKey(raw, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed parsing private key [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed parsing private key [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
@@ -172,13 +172,13 @@ func (ks *keyStore) loadPrivateKey(alias string) (interface{}, error) {
 func (ks *keyStore) storePublicKey(alias string, publicKey interface{}) error {
 	rawKey, err := primitives.PublicKeyToPEM(publicKey, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed converting public key to PEM [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed converting public key to PEM [%s]: [%s]", alias, err)
 		return err
 	}
 
 	err = ioutil.WriteFile(ks.node.conf.getPathForAlias(alias), rawKey, 0700)
 	if err != nil {
-		ks.node.error("Failed storing private key [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed storing private key [%s]: [%s]", alias, err)
 		return err
 	}
 
@@ -187,18 +187,18 @@ func (ks *keyStore) storePublicKey(alias string, publicKey interface{}) error {
 
 func (ks *keyStore) loadPublicKey(alias string) (interface{}, error) {
 	path := ks.node.conf.getPathForAlias(alias)
-	ks.node.debug("Loading public key [%s] at [%s]...", alias, path)
+	ks.node.Debugf("Loading public key [%s] at [%s]...", alias, path)
 
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading public key [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed loading public key [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
 
 	privateKey, err := primitives.PEMtoPublicKey(raw, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed parsing private key [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed parsing private key [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
@@ -209,13 +209,13 @@ func (ks *keyStore) loadPublicKey(alias string) (interface{}, error) {
 func (ks *keyStore) storeKey(alias string, key []byte) error {
 	pem, err := primitives.AEStoEncryptedPEM(key, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed converting key to PEM [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed converting key to PEM [%s]: [%s]", alias, err)
 		return err
 	}
 
 	err = ioutil.WriteFile(ks.node.conf.getPathForAlias(alias), pem, 0700)
 	if err != nil {
-		ks.node.error("Failed storing key [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed storing key [%s]: [%s]", alias, err)
 		return err
 	}
 
@@ -224,18 +224,18 @@ func (ks *keyStore) storeKey(alias string, key []byte) error {
 
 func (ks *keyStore) loadKey(alias string) ([]byte, error) {
 	path := ks.node.conf.getPathForAlias(alias)
-	ks.node.debug("Loading key [%s] at [%s]...", alias, path)
+	ks.node.Debugf("Loading key [%s] at [%s]...", alias, path)
 
 	pem, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading key [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed loading key [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
 
 	key, err := primitives.PEMtoAES(pem, ks.pwd)
 	if err != nil {
-		ks.node.error("Failed parsing key [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed parsing key [%s]: [%s]", alias, err)
 
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (ks *keyStore) loadKey(alias string) ([]byte, error) {
 func (ks *keyStore) storeCert(alias string, der []byte) error {
 	err := ioutil.WriteFile(ks.node.conf.getPathForAlias(alias), primitives.DERCertToPEM(der), 0700)
 	if err != nil {
-		ks.node.error("Failed storing certificate [%s]: [%s]", alias, err)
+		ks.node.Errorf("Failed storing certificate [%s]: [%s]", alias, err)
 		return err
 	}
 
@@ -255,11 +255,11 @@ func (ks *keyStore) storeCert(alias string, der []byte) error {
 
 func (ks *keyStore) loadCert(alias string) ([]byte, error) {
 	path := ks.node.conf.getPathForAlias(alias)
-	ks.node.debug("Loading certificate [%s] at [%s]...", alias, path)
+	ks.node.Debugf("Loading certificate [%s] at [%s]...", alias, path)
 
 	pem, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading certificate [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed loading certificate [%s]: [%s].", alias, err.Error())
 
 		return nil, err
 	}
@@ -268,11 +268,11 @@ func (ks *keyStore) loadCert(alias string) ([]byte, error) {
 }
 
 func (ks *keyStore) loadExternalCert(path string) ([]byte, error) {
-	ks.node.debug("Loading external certificate at [%s]...", path)
+	ks.node.Debugf("Loading external certificate at [%s]...", path)
 
 	pem, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading external certificate: [%s].", err.Error())
+		ks.node.Errorf("Failed loading external certificate: [%s].", err.Error())
 
 		return nil, err
 	}
@@ -282,18 +282,18 @@ func (ks *keyStore) loadExternalCert(path string) ([]byte, error) {
 
 func (ks *keyStore) loadCertX509AndDer(alias string) (*x509.Certificate, []byte, error) {
 	path := ks.node.conf.getPathForAlias(alias)
-	ks.node.debug("Loading certificate [%s] at [%s]...", alias, path)
+	ks.node.Debugf("Loading certificate [%s] at [%s]...", alias, path)
 
 	pem, err := ioutil.ReadFile(path)
 	if err != nil {
-		ks.node.error("Failed loading certificate [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed loading certificate [%s]: [%s].", alias, err.Error())
 
 		return nil, nil, err
 	}
 
 	cert, der, err := primitives.PEMtoCertificateAndDER(pem)
 	if err != nil {
-		ks.node.error("Failed parsing certificate [%s]: [%s].", alias, err.Error())
+		ks.node.Errorf("Failed parsing certificate [%s]: [%s].", alias, err.Error())
 
 		return nil, nil, err
 	}
@@ -302,13 +302,13 @@ func (ks *keyStore) loadCertX509AndDer(alias string) (*x509.Certificate, []byte,
 }
 
 func (ks *keyStore) close() error {
-	ks.node.debug("Closing keystore...")
+	ks.node.Debug("Closing keystore...")
 	err := ks.sqlDB.Close()
 
 	if err != nil {
-		ks.node.error("Failed closing keystore [%s].", err.Error())
+		ks.node.Errorf("Failed closing keystore [%s].", err.Error())
 	} else {
-		ks.node.debug("Closing keystore...done!")
+		ks.node.Debug("Closing keystore...done!")
 	}
 
 	ks.isOpen = false
@@ -319,18 +319,18 @@ func (ks *keyStore) createKeyStoreIfNotExists() error {
 	// Check keystore directory
 	ksPath := ks.node.conf.getKeyStorePath()
 	missing, err := utils.DirMissingOrEmpty(ksPath)
-	ks.node.debug("Keystore path [%s] missing [%t]: [%s]", ksPath, missing, utils.ErrToString(err))
+	ks.node.Debugf("Keystore path [%s] missing [%t]: [%s]", ksPath, missing, utils.ErrToString(err))
 
 	if !missing {
 		// Check keystore file
 		missing, err = utils.FileMissing(ks.node.conf.getKeyStorePath(), ks.node.conf.getKeyStoreFilename())
-		ks.node.debug("Keystore [%s] missing [%t]:[%s]", ks.node.conf.getKeyStoreFilePath(), missing, utils.ErrToString(err))
+		ks.node.Debugf("Keystore [%s] missing [%t]:[%s]", ks.node.conf.getKeyStoreFilePath(), missing, utils.ErrToString(err))
 	}
 
 	if missing {
 		err := ks.createKeyStore()
 		if err != nil {
-			ks.node.debug("Failed creating db At [%s]: ", ks.node.conf.getKeyStoreFilePath(), err.Error())
+			ks.node.Debugf("Failed creating db At [%s]: ", ks.node.conf.getKeyStoreFilePath(), err.Error())
 			return nil
 		}
 	}
@@ -341,11 +341,11 @@ func (ks *keyStore) createKeyStoreIfNotExists() error {
 func (ks *keyStore) createKeyStore() error {
 	// Create keystore directory root if it doesn't exist yet
 	ksPath := ks.node.conf.getKeyStorePath()
-	ks.node.debug("Creating Keystore at [%s]...", ksPath)
+	ks.node.Debugf("Creating Keystore at [%s]...", ksPath)
 
 	missing, err := utils.FileMissing(ksPath, ks.node.conf.getKeyStoreFilename())
 	if !missing {
-		ks.node.debug("Creating Keystore at [%s]. Keystore already there", ksPath)
+		ks.node.Debugf("Creating Keystore at [%s]. Keystore already there", ksPath)
 		return nil
 	}
 
@@ -355,27 +355,27 @@ func (ks *keyStore) createKeyStore() error {
 	os.MkdirAll(ks.node.conf.getRawsPath(), 0755)
 
 	// Create DB
-	ks.node.debug("Open Keystore DB...")
+	ks.node.Debug("Open Keystore DB...")
 	db, err := sql.Open("sqlite3", filepath.Join(ksPath, ks.node.conf.getKeyStoreFilename()))
 	if err != nil {
 		return err
 	}
 
-	ks.node.debug("Ping Keystore DB...")
+	ks.node.Debug("Ping Keystore DB...")
 	err = db.Ping()
 	if err != nil {
-		ks.node.error("Failend pinged keystore DB: [%s]", err)
+		ks.node.Errorf("Failend pinged keystore DB: [%s]", err)
 
 		return err
 	}
 	defer db.Close()
 
-	ks.node.debug("Keystore created at [%s].", ksPath)
+	ks.node.Debugf("Keystore created at [%s].", ksPath)
 	return nil
 }
 
 func (ks *keyStore) deleteKeyStore() error {
-	ks.node.debug("Removing KeyStore at [%s].", ks.node.conf.getKeyStorePath())
+	ks.node.Debugf("Removing KeyStore at [%s].", ks.node.conf.getKeyStorePath())
 
 	return os.RemoveAll(ks.node.conf.getKeyStorePath())
 }
@@ -390,13 +390,13 @@ func (ks *keyStore) openKeyStore() error {
 
 	sqlDB, err := sql.Open("sqlite3", filepath.Join(ksPath, ks.node.conf.getKeyStoreFilename()))
 	if err != nil {
-		ks.node.error("Error opening keystore%s", err.Error())
+		ks.node.Errorf("Error opening keystore%s", err.Error())
 		return err
 	}
 	ks.isOpen = true
 	ks.sqlDB = sqlDB
 
-	ks.node.debug("Keystore opened at [%s]...done", ksPath)
+	ks.node.Debugf("Keystore opened at [%s]...done", ksPath)
 
 	return nil
 }

--- a/core/crypto/node_log.go
+++ b/core/crypto/node_log.go
@@ -16,18 +16,38 @@ limitations under the License.
 
 package crypto
 
-func (node *nodeImpl) info(format string, args ...interface{}) {
+func (node *nodeImpl) prependPrefix(args []interface{}) []interface{} {
+	return append([]interface{}{node.conf.logPrefix}, args...)
+}
+
+func (node *nodeImpl) Infof(format string, args ...interface{}) {
 	log.Infof(node.conf.logPrefix+format, args...)
 }
 
-func (node *nodeImpl) debug(format string, args ...interface{}) {
+func (node *nodeImpl) Info(args ...interface{}) {
+	log.Info(node.prependPrefix(args)...)
+}
+
+func (node *nodeImpl) Debugf(format string, args ...interface{}) {
 	log.Debugf(node.conf.logPrefix+format, args...)
 }
 
-func (node *nodeImpl) error(format string, args ...interface{}) {
+func (node *nodeImpl) Debug(args ...interface{}) {
+	log.Debug(node.prependPrefix(args)...)
+}
+
+func (node *nodeImpl) Errorf(format string, args ...interface{}) {
 	log.Errorf(node.conf.logPrefix+format, args...)
 }
 
-func (node *nodeImpl) warning(format string, args ...interface{}) {
+func (node *nodeImpl) Error(args ...interface{}) {
+	log.Error(node.prependPrefix(args)...)
+}
+
+func (node *nodeImpl) Warningf(format string, args ...interface{}) {
 	log.Warningf(node.conf.logPrefix+format, args...)
+}
+
+func (node *nodeImpl) Warning(args ...interface{}) {
+	log.Warning(node.prependPrefix(args)...)
 }

--- a/core/crypto/node_tca.go
+++ b/core/crypto/node_tca.go
@@ -20,34 +20,34 @@ import (
 	membersrvc "github.com/hyperledger/fabric/membersrvc/protos"
 
 	"errors"
+	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"github.com/hyperledger/fabric/core/crypto/primitives"
 )
 
 func (node *nodeImpl) retrieveTCACertsChain(userID string) error {
 	// Retrieve TCA certificate and verify it
 	tcaCertRaw, err := node.getTCACertificate()
 	if err != nil {
-		node.error("Failed getting TCA certificate [%s].", err.Error())
+		node.Errorf("Failed getting TCA certificate [%s].", err.Error())
 
 		return err
 	}
-	node.debug("TCA certificate [% x]", tcaCertRaw)
+	node.Debugf("TCA certificate [% x]", tcaCertRaw)
 
 	// TODO: Test TCA cert againt root CA
 	_, err = primitives.DERToX509Certificate(tcaCertRaw)
 	if err != nil {
-		node.error("Failed parsing TCA certificate [%s].", err.Error())
+		node.Errorf("Failed parsing TCA certificate [%s].", err.Error())
 
 		return err
 	}
 
 	// Store TCA cert
-	node.debug("Storing TCA certificate for [%s]...", userID)
+	node.Debugf("Storing TCA certificate for [%s]...", userID)
 
 	if err := node.ks.storeCert(node.conf.getTCACertsChainFilename(), tcaCertRaw); err != nil {
-		node.error("Failed storing tca certificate [%s].", err.Error())
+		node.Errorf("Failed storing tca certificate [%s].", err.Error())
 		return err
 	}
 
@@ -56,11 +56,11 @@ func (node *nodeImpl) retrieveTCACertsChain(userID string) error {
 
 func (node *nodeImpl) loadTCACertsChain() error {
 	// Load TCA certs chain
-	node.debug("Loading TCA certificates chain...")
+	node.Debug("Loading TCA certificates chain...")
 
 	cert, err := node.ks.loadCert(node.conf.getTCACertsChainFilename())
 	if err != nil {
-		node.error("Failed loading TCA certificates chain [%s].", err.Error())
+		node.Errorf("Failed loading TCA certificates chain [%s].", err.Error())
 
 		return err
 	}
@@ -68,7 +68,7 @@ func (node *nodeImpl) loadTCACertsChain() error {
 	// Prepare ecaCertPool
 	ok := node.tcaCertPool.AppendCertsFromPEM(cert)
 	if !ok {
-		node.error("Failed appending TCA certificates chain.")
+		node.Error("Failed appending TCA certificates chain.")
 
 		return errors.New("Failed appending TCA certificates chain.")
 	}
@@ -77,16 +77,16 @@ func (node *nodeImpl) loadTCACertsChain() error {
 }
 
 func (node *nodeImpl) getTCAClient() (*grpc.ClientConn, membersrvc.TCAPClient, error) {
-	node.debug("Getting TCA client...")
+	node.Debug("Getting TCA client...")
 
 	conn, err := node.getClientConn(node.conf.getTCAPAddr(), node.conf.getTCAServerName())
 	if err != nil {
-		node.error("Failed getting client connection: [%s]", err)
+		node.Errorf("Failed getting client connection: [%s]", err)
 	}
 
 	client := membersrvc.NewTCAPClient(conn)
 
-	node.debug("Getting TCA client...done")
+	node.Debug("Getting TCA client...done")
 
 	return conn, client, nil
 }
@@ -99,7 +99,7 @@ func (node *nodeImpl) callTCAReadCACertificate(ctx context.Context, opts ...grpc
 	// Issue the request
 	cert, err := tcaP.ReadCACertificate(ctx, &membersrvc.Empty{}, opts...)
 	if err != nil {
-		node.error("Failed requesting tca read certificate [%s].", err.Error())
+		node.Errorf("Failed requesting tca read certificate [%s].", err.Error())
 
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (node *nodeImpl) callTCAReadCACertificate(ctx context.Context, opts ...grpc
 func (node *nodeImpl) getTCACertificate() ([]byte, error) {
 	response, err := node.callTCAReadCACertificate(context.Background())
 	if err != nil {
-		node.error("Failed requesting TCA certificate [%s].", err.Error())
+		node.Errorf("Failed requesting TCA certificate [%s].", err.Error())
 
 		return nil, err
 	}

--- a/core/crypto/peer_eca.go
+++ b/core/crypto/peer_eca.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	membersrvc "github.com/hyperledger/fabric/membersrvc/protos"
 	"golang.org/x/net/context"
-	"github.com/hyperledger/fabric/core/crypto/primitives"
 )
 
 func (peer *peerImpl) getEnrollmentCert(id []byte) (*x509.Certificate, error) {
@@ -34,25 +34,25 @@ func (peer *peerImpl) getEnrollmentCert(id []byte) (*x509.Certificate, error) {
 
 	sid := utils.EncodeBase64(id)
 
-	peer.debug("Getting enrollment certificate for [%s]", sid)
+	peer.Debugf("Getting enrollment certificate for [%s]", sid)
 
 	if cert := peer.getNodeEnrollmentCertificate(sid); cert != nil {
-		peer.debug("Enrollment certificate for [%s] already in memory.", sid)
+		peer.Debugf("Enrollment certificate for [%s] already in memory.", sid)
 		return cert, nil
 	}
 
 	// Retrieve from the DB or from the ECA in case
-	peer.debug("Retrieve Enrollment certificate for [%s]...", sid)
+	peer.Debugf("Retrieve Enrollment certificate for [%s]...", sid)
 	rawCert, err := peer.ks.GetSignEnrollmentCert(id, peer.getEnrollmentCertByHashFromECA)
 	if err != nil {
-		peer.error("Failed getting enrollment certificate for [%s]: [%s]", sid, err)
+		peer.Errorf("Failed getting enrollment certificate for [%s]: [%s]", sid, err)
 
 		return nil, err
 	}
 
 	cert, err := primitives.DERToX509Certificate(rawCert)
 	if err != nil {
-		peer.error("Failed parsing enrollment certificate for [%s]: [% x],[% x]", sid, rawCert, err)
+		peer.Errorf("Failed parsing enrollment certificate for [%s]: [% x],[% x]", sid, rawCert, err)
 
 		return nil, err
 	}
@@ -64,22 +64,22 @@ func (peer *peerImpl) getEnrollmentCert(id []byte) (*x509.Certificate, error) {
 
 func (peer *peerImpl) getEnrollmentCertByHashFromECA(id []byte) ([]byte, []byte, error) {
 	// Prepare the request
-	peer.debug("Reading certificate for hash [% x]", id)
+	peer.Debugf("Reading certificate for hash [% x]", id)
 
 	req := &membersrvc.Hash{Hash: id}
 	response, err := peer.callECAReadCertificateByHash(context.Background(), req)
 	if err != nil {
-		peer.error("Failed requesting enrollment certificate [%s].", err.Error())
+		peer.Errorf("Failed requesting enrollment certificate [%s].", err.Error())
 
 		return nil, nil, err
 	}
 
-	peer.debug("Certificate for hash [% x] = [% x][% x]", id, response.Sign, response.Enc)
+	peer.Debugf("Certificate for hash [% x] = [% x][% x]", id, response.Sign, response.Enc)
 
 	// Verify response.Sign
 	x509Cert, err := primitives.DERToX509Certificate(response.Sign)
 	if err != nil {
-		peer.error("Failed parsing signing enrollment certificate for encrypting: [%s]", err)
+		peer.Errorf("Failed parsing signing enrollment certificate for encrypting: [%s]", err)
 
 		return nil, nil, err
 	}
@@ -87,20 +87,20 @@ func (peer *peerImpl) getEnrollmentCertByHashFromECA(id []byte) ([]byte, []byte,
 	// Check role
 	roleRaw, err := primitives.GetCriticalExtension(x509Cert, ECertSubjectRole)
 	if err != nil {
-		peer.error("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
+		peer.Errorf("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
 
 		return nil, nil, err
 	}
 
 	role, err := strconv.ParseInt(string(roleRaw), 10, len(roleRaw)*8)
 	if err != nil {
-		peer.error("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
+		peer.Errorf("Failed parsing ECertSubjectRole in enrollment certificate for signing: [%s]", err)
 
 		return nil, nil, err
 	}
 
 	if membersrvc.Role(role) != membersrvc.Role_VALIDATOR && membersrvc.Role(role) != membersrvc.Role_PEER {
-		peer.error("Invalid ECertSubjectRole in enrollment certificate for signing. Not a validator or peer: [%s]", err)
+		peer.Errorf("Invalid ECertSubjectRole in enrollment certificate for signing. Not a validator or peer: [%s]", err)
 
 		return nil, nil, err
 	}

--- a/core/crypto/peer_impl.go
+++ b/core/crypto/peer_impl.go
@@ -57,14 +57,14 @@ func (peer *peerImpl) TransactionPreValidation(tx *obc.Transaction) (*obc.Transa
 	}
 
 	//	peer.debug("Pre validating [%s].", tx.String())
-	peer.debug("Tx confdential level [%s].", tx.ConfidentialityLevel.String())
+	peer.Debugf("Tx confdential level [%s].", tx.ConfidentialityLevel.String())
 
 	if tx.Cert != nil && tx.Signature != nil {
 		// Verify the transaction
 		// 1. Unmarshal cert
 		cert, err := primitives.DERToX509Certificate(tx.Cert)
 		if err != nil {
-			peer.error("TransactionPreExecution: failed unmarshalling cert [%s] [%s].", err.Error())
+			peer.Errorf("TransactionPreExecution: failed unmarshalling cert [%s] [%s].", err.Error())
 			return tx, err
 		}
 
@@ -75,7 +75,7 @@ func (peer *peerImpl) TransactionPreValidation(tx *obc.Transaction) (*obc.Transa
 		tx.Signature = nil
 		rawTx, err := proto.Marshal(tx)
 		if err != nil {
-			peer.error("TransactionPreExecution: failed marshaling tx [%s] [%s].", err.Error())
+			peer.Errorf("TransactionPreExecution: failed marshaling tx [%s] [%s].", err.Error())
 			return tx, err
 		}
 		tx.Signature = signature
@@ -83,7 +83,7 @@ func (peer *peerImpl) TransactionPreValidation(tx *obc.Transaction) (*obc.Transa
 		// 2. Verify signature
 		ok, err := peer.verify(cert.PublicKey, rawTx, tx.Signature)
 		if err != nil {
-			peer.error("TransactionPreExecution: failed marshaling tx [%s] [%s].", err.Error())
+			peer.Errorf("TransactionPreExecution: failed marshaling tx [%s] [%s].", err.Error())
 			return tx, err
 		}
 
@@ -133,7 +133,7 @@ func (peer *peerImpl) Verify(vkID, signature, message []byte) error {
 
 	cert, err := peer.getEnrollmentCert(vkID)
 	if err != nil {
-		peer.error("Failed getting enrollment cert for [% x]: [%s]", vkID, err)
+		peer.Errorf("Failed getting enrollment cert for [% x]: [%s]", vkID, err)
 
 		return err
 	}
@@ -142,13 +142,13 @@ func (peer *peerImpl) Verify(vkID, signature, message []byte) error {
 
 	ok, err := peer.verify(vk, message, signature)
 	if err != nil {
-		peer.error("Failed verifying signature for [% x]: [%s]", vkID, err)
+		peer.Errorf("Failed verifying signature for [% x]: [%s]", vkID, err)
 
 		return err
 	}
 
 	if !ok {
-		peer.error("Failed invalid signature for [% x]", vkID)
+		peer.Errorf("Failed invalid signature for [% x]", vkID)
 
 		return utils.ErrInvalidSignature
 	}
@@ -168,14 +168,14 @@ func (peer *peerImpl) GetTransactionBinding(tx *obc.Transaction) ([]byte, error)
 
 func (peer *peerImpl) register(eType NodeType, name string, pwd []byte, enrollID, enrollPWD string) error {
 	if peer.isInitialized {
-		peer.error("Registering [%s]...done! Initialization already performed", enrollID)
+		peer.Errorf("Registering [%s]...done! Initialization already performed", enrollID)
 
 		return utils.ErrAlreadyInitialized
 	}
 
 	// Register node
 	if err := peer.nodeImpl.register(eType, name, pwd, enrollID, enrollPWD); err != nil {
-		log.Errorf("Failed registering [%s]: [%s]", enrollID, err)
+		peer.Errorf("Failed registering [%s]: [%s]", enrollID, err)
 		return err
 	}
 
@@ -193,18 +193,18 @@ func (peer *peerImpl) init(eType NodeType, id string, pwd []byte) error {
 	}
 
 	// Initialize keystore
-	peer.debug("Init keystore...")
+	peer.Debug("Init keystore...")
 	err := peer.initKeyStore()
 	if err != nil {
 		if err != utils.ErrKeyStoreAlreadyInitialized {
-			peer.error("Keystore already initialized.")
+			peer.Error("Keystore already initialized.")
 		} else {
-			peer.error("Failed initiliazing keystore [%s].", err)
+			peer.Errorf("Failed initiliazing keystore [%s].", err)
 
 			return err
 		}
 	}
-	peer.debug("Init keystore...done.")
+	peer.Debug("Init keystore...done.")
 
 	// initialized
 	peer.isInitialized = true

--- a/core/crypto/peer_ks.go
+++ b/core/crypto/peer_ks.go
@@ -24,9 +24,9 @@ import (
 
 func (peer *peerImpl) initKeyStore() error {
 	// create tables
-	peer.debug("Create Table [%s] if not exists", "Certificates")
+	peer.Debugf("Create Table [%s] if not exists", "Certificates")
 	if _, err := peer.ks.sqlDB.Exec("CREATE TABLE IF NOT EXISTS Certificates (id VARCHAR, certsign BLOB, certenc BLOB, PRIMARY KEY (id))"); err != nil {
-		peer.debug("Failed creating table [%s].", err.Error())
+		peer.Debugf("Failed creating table [%s].", err.Error())
 		return err
 	}
 
@@ -45,39 +45,39 @@ func (ks *keyStore) GetSignEnrollmentCert(id []byte, certFetcher func(id []byte)
 
 	certSign, certEnc, err := ks.selectSignEnrollmentCert(sid)
 	if err != nil {
-		ks.node.error("Failed selecting enrollment cert [%s].", err.Error())
+		ks.node.Errorf("Failed selecting enrollment cert [%s].", err.Error())
 
 		return nil, err
 	}
 
 	if certSign == nil {
-		ks.node.debug("Cert for [%s] not available. Fetching from ECA....", sid)
+		ks.node.Debugf("Cert for [%s] not available. Fetching from ECA....", sid)
 
 		// If No cert is available, fetch from ECA
 
 		// 1. Fetch
-		ks.node.debug("Fectch Enrollment Certificate from ECA...")
+		ks.node.Debug("Fectch Enrollment Certificate from ECA...")
 		certSign, certEnc, err = certFetcher(id)
 		if err != nil {
 			return nil, err
 		}
 
 		// 2. Store
-		ks.node.debug("Store certificate...")
+		ks.node.Debug("Store certificate...")
 		tx, err := ks.sqlDB.Begin()
 		if err != nil {
-			ks.node.error("Failed beginning transaction [%s].", err.Error())
+			ks.node.Errorf("Failed beginning transaction [%s].", err.Error())
 
 			return nil, err
 		}
 
-		ks.node.debug("Insert id [%s].", sid)
-		ks.node.debug("Insert cert [% x].", certSign)
+		ks.node.Debugf("Insert id [%s].", sid)
+		ks.node.Debugf("Insert cert [% x].", certSign)
 
 		_, err = tx.Exec("INSERT INTO Certificates (id, certsign, certenc) VALUES (?, ?, ?)", sid, certSign, certEnc)
 
 		if err != nil {
-			ks.node.error("Failed inserting cert [%s].", err.Error())
+			ks.node.Errorf("Failed inserting cert [%s].", err.Error())
 
 			tx.Rollback()
 
@@ -86,30 +86,30 @@ func (ks *keyStore) GetSignEnrollmentCert(id []byte, certFetcher func(id []byte)
 
 		err = tx.Commit()
 		if err != nil {
-			ks.node.error("Failed committing transaction [%s].", err.Error())
+			ks.node.Errorf("Failed committing transaction [%s].", err.Error())
 
 			tx.Rollback()
 
 			return nil, err
 		}
 
-		ks.node.debug("Fectch Enrollment Certificate from ECA...done!")
+		ks.node.Debug("Fectch Enrollment Certificate from ECA...done!")
 
 		certSign, certEnc, err = ks.selectSignEnrollmentCert(sid)
 		if err != nil {
-			ks.node.error("Failed selecting next TCert after fetching [%s].", err.Error())
+			ks.node.Errorf("Failed selecting next TCert after fetching [%s].", err.Error())
 
 			return nil, err
 		}
 	}
 
-	ks.node.debug("Cert for [%s] = [% x]", sid, certSign)
+	ks.node.Debugf("Cert for [%s] = [% x]", sid, certSign)
 
 	return certSign, nil
 }
 
 func (ks *keyStore) selectSignEnrollmentCert(id string) ([]byte, []byte, error) {
-	ks.node.debug("Select Sign Enrollment Cert for id [%s]", id)
+	ks.node.Debugf("Select Sign Enrollment Cert for id [%s]", id)
 
 	// Get the first row available
 	var cert []byte
@@ -119,14 +119,14 @@ func (ks *keyStore) selectSignEnrollmentCert(id string) ([]byte, []byte, error) 
 	if err == sql.ErrNoRows {
 		return nil, nil, nil
 	} else if err != nil {
-		ks.node.error("Error during select [%s].", err.Error())
+		ks.node.Errorf("Error during select [%s].", err.Error())
 
 		return nil, nil, err
 	}
 
-	ks.node.debug("Cert [% x].", cert)
+	ks.node.Debugf("Cert [% x].", cert)
 
-	ks.node.debug("Select Enrollment Cert...done!")
+	ks.node.Debug("Select Enrollment Cert...done!")
 
 	return cert, nil, nil
 }

--- a/core/crypto/validator_confidentiality.go
+++ b/core/crypto/validator_confidentiality.go
@@ -28,7 +28,7 @@ import (
 func (validator *validatorImpl) deepCloneTransaction(tx *obc.Transaction) (*obc.Transaction, error) {
 	raw, err := proto.Marshal(tx)
 	if err != nil {
-		validator.error("Failed cloning transaction [%s].", err.Error())
+		validator.Errorf("Failed cloning transaction [%s].", err.Error())
 
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (validator *validatorImpl) deepCloneTransaction(tx *obc.Transaction) (*obc.
 	clone := &obc.Transaction{}
 	err = proto.Unmarshal(raw, clone)
 	if err != nil {
-		validator.error("Failed cloning transaction [%s].", err.Error())
+		validator.Errorf("Failed cloning transaction [%s].", err.Error())
 
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_1(tx *obc.Transaction) (*
 	// clone tx
 	clone, err := validator.deepCloneTransaction(tx)
 	if err != nil {
-		validator.error("Failed deep cloning [%s].", err.Error())
+		validator.Errorf("Failed deep cloning [%s].", err.Error())
 		return nil, err
 	}
 
@@ -82,7 +82,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_1(tx *obc.Transaction) (*
 	payloadKey := primitives.HMACAESTruncated(key, []byte{1})
 	payload, err := primitives.CBCPKCS7Decrypt(payloadKey, utils.Clone(clone.Payload))
 	if err != nil {
-		validator.error("Failed decrypting payload [%s].", err.Error())
+		validator.Errorf("Failed decrypting payload [%s].", err.Error())
 		return nil, err
 	}
 	clone.Payload = payload
@@ -91,7 +91,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_1(tx *obc.Transaction) (*
 	chaincodeIDKey := primitives.HMACAESTruncated(key, []byte{2})
 	chaincodeID, err := primitives.CBCPKCS7Decrypt(chaincodeIDKey, utils.Clone(clone.ChaincodeID))
 	if err != nil {
-		validator.error("Failed decrypting chaincode [%s].", err.Error())
+		validator.Errorf("Failed decrypting chaincode [%s].", err.Error())
 		return nil, err
 	}
 	clone.ChaincodeID = chaincodeID
@@ -101,7 +101,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_1(tx *obc.Transaction) (*
 		metadataKey := primitives.HMACAESTruncated(key, []byte{3})
 		metadata, err := primitives.CBCPKCS7Decrypt(metadataKey, utils.Clone(clone.Metadata))
 		if err != nil {
-			validator.error("Failed decrypting metadata [%s].", err.Error())
+			validator.Errorf("Failed decrypting metadata [%s].", err.Error())
 			return nil, err
 		}
 		clone.Metadata = metadata
@@ -118,54 +118,54 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_2(tx *obc.Transaction) (*
 	// clone tx
 	clone, err := validator.deepCloneTransaction(tx)
 	if err != nil {
-		validator.error("Failed deep cloning [%s].", err.Error())
+		validator.Errorf("Failed deep cloning [%s].", err.Error())
 		return nil, err
 	}
 
 	var ccPrivateKey primitives.PrivateKey
 
-	validator.debug("Transaction type [%s].", tx.Type.String())
+	validator.Debugf("Transaction type [%s].", tx.Type.String())
 
-	validator.debug("Extract transaction key...")
+	validator.Debug("Extract transaction key...")
 
 	// Derive transaction key
 	cipher, err := validator.eciesSPI.NewAsymmetricCipherFromPrivateKey(validator.chainPrivateKey)
 	if err != nil {
-		validator.error("Failed init decryption engine [%s].", err.Error())
+		validator.Errorf("Failed init decryption engine [%s].", err.Error())
 		return nil, err
 	}
 
 	msgToValidatorsRaw, err := cipher.Process(tx.ToValidators)
 	if err != nil {
-		validator.error("Failed decrypting message to validators [% x]: [%s].", tx.ToValidators, err.Error())
+		validator.Errorf("Failed decrypting message to validators [% x]: [%s].", tx.ToValidators, err.Error())
 		return nil, err
 	}
 
 	msgToValidators := new(chainCodeValidatorMessage1_2)
 	_, err = asn1.Unmarshal(msgToValidatorsRaw, msgToValidators)
 	if err != nil {
-		validator.error("Failed unmarshalling message to validators [%s].", err.Error())
+		validator.Errorf("Failed unmarshalling message to validators [%s].", err.Error())
 		return nil, err
 	}
 
-	validator.debug("Deserializing transaction key [% x].", msgToValidators.PrivateKey)
+	validator.Debugf("Deserializing transaction key [% x].", msgToValidators.PrivateKey)
 	ccPrivateKey, err = validator.eciesSPI.DeserializePrivateKey(msgToValidators.PrivateKey)
 	if err != nil {
-		validator.error("Failed deserializing transaction key [%s].", err.Error())
+		validator.Errorf("Failed deserializing transaction key [%s].", err.Error())
 		return nil, err
 	}
 
-	validator.debug("Extract transaction key...done")
+	validator.Debug("Extract transaction key...done")
 
 	cipher, err = validator.eciesSPI.NewAsymmetricCipherFromPrivateKey(ccPrivateKey)
 	if err != nil {
-		validator.error("Failed init transaction decryption engine [%s].", err.Error())
+		validator.Errorf("Failed init transaction decryption engine [%s].", err.Error())
 		return nil, err
 	}
 	// Decrypt Payload
 	payload, err := cipher.Process(clone.Payload)
 	if err != nil {
-		validator.error("Failed decrypting payload [%s].", err.Error())
+		validator.Errorf("Failed decrypting payload [%s].", err.Error())
 		return nil, err
 	}
 	clone.Payload = payload
@@ -173,7 +173,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_2(tx *obc.Transaction) (*
 	// Decrypt ChaincodeID
 	chaincodeID, err := cipher.Process(clone.ChaincodeID)
 	if err != nil {
-		validator.error("Failed decrypting chaincode [%s].", err.Error())
+		validator.Errorf("Failed decrypting chaincode [%s].", err.Error())
 		return nil, err
 	}
 	clone.ChaincodeID = chaincodeID
@@ -182,7 +182,7 @@ func (validator *validatorImpl) deepCloneAndDecryptTx1_2(tx *obc.Transaction) (*
 	if len(clone.Metadata) != 0 {
 		metadata, err := cipher.Process(clone.Metadata)
 		if err != nil {
-			validator.error("Failed decrypting metadata [%s].", err.Error())
+			validator.Errorf("Failed decrypting metadata [%s].", err.Error())
 			return nil, err
 		}
 		clone.Metadata = metadata

--- a/core/crypto/validator_impl.go
+++ b/core/crypto/validator_impl.go
@@ -57,12 +57,12 @@ func (validator *validatorImpl) TransactionPreExecution(tx *obc.Transaction) (*o
 	}
 
 	//	validator.debug("Pre executing [%s].", tx.String())
-	validator.debug("Tx confdential level [%s].", tx.ConfidentialityLevel.String())
+	validator.Debugf("Tx confdential level [%s].", tx.ConfidentialityLevel.String())
 
 	if validityPeriodVerificationEnabled() {
 		tx, err := validator.verifyValidityPeriod(tx)
 		if err != nil {
-			validator.error("TransactionPreExecution: error verifying certificate validity period %s:", err)
+			validator.Errorf("TransactionPreExecution: error verifying certificate validity period %s:", err)
 			return tx, err
 		}
 	}
@@ -73,12 +73,12 @@ func (validator *validatorImpl) TransactionPreExecution(tx *obc.Transaction) (*o
 
 		return tx, nil
 	case obc.ConfidentialityLevel_CONFIDENTIAL:
-		validator.debug("Clone and Decrypt.")
+		validator.Debug("Clone and Decrypt.")
 
 		// Clone the transaction and decrypt it
 		newTx, err := validator.deepCloneAndDecryptTx(tx)
 		if err != nil {
-			validator.error("Failed decrypting [%s].", err.Error())
+			validator.Errorf("Failed decrypting [%s].", err.Error())
 
 			return nil, err
 		}
@@ -111,7 +111,7 @@ func (validator *validatorImpl) Verify(vkID, signature, message []byte) error {
 
 	cert, err := validator.getEnrollmentCert(vkID)
 	if err != nil {
-		validator.error("Failed getting enrollment cert for [% x]: [%s]", vkID, err)
+		validator.Errorf("Failed getting enrollment cert for [% x]: [%s]", vkID, err)
 
 		return err
 	}
@@ -120,13 +120,13 @@ func (validator *validatorImpl) Verify(vkID, signature, message []byte) error {
 
 	ok, err := validator.verify(vk, message, signature)
 	if err != nil {
-		validator.error("Failed verifying signature for [% x]: [%s]", vkID, err)
+		validator.Errorf("Failed verifying signature for [% x]: [%s]", vkID, err)
 
 		return err
 	}
 
 	if !ok {
-		validator.error("Failed invalid signature for [% x]", vkID)
+		validator.Errorf("Failed invalid signature for [% x]", vkID)
 
 		return utils.ErrInvalidSignature
 	}
@@ -138,14 +138,14 @@ func (validator *validatorImpl) Verify(vkID, signature, message []byte) error {
 
 func (validator *validatorImpl) register(id string, pwd []byte, enrollID, enrollPWD string) error {
 	if validator.isInitialized {
-		validator.error("Registering...done! Initialization already performed", enrollID)
+		validator.Errorf("Registering...done! Initialization already performed", enrollID)
 
 		return utils.ErrAlreadyInitialized
 	}
 
 	// Register node
 	if err := validator.peerImpl.register(NodeValidator, id, pwd, enrollID, enrollPWD); err != nil {
-		log.Errorf("Failed registering [%s]: [%s]", enrollID, err)
+		validator.Errorf("Failed registering [%s]: [%s]", enrollID, err)
 		return err
 	}
 
@@ -154,7 +154,7 @@ func (validator *validatorImpl) register(id string, pwd []byte, enrollID, enroll
 
 func (validator *validatorImpl) init(name string, pwd []byte) error {
 	if validator.isInitialized {
-		validator.error("Already initializaed.")
+		validator.Error("Already initializaed.")
 
 		return utils.ErrAlreadyInitialized
 	}
@@ -167,7 +167,7 @@ func (validator *validatorImpl) init(name string, pwd []byte) error {
 	// Init crypto engine
 	err := validator.initCryptoEngine()
 	if err != nil {
-		validator.error("Failed initiliazing crypto engine [%s].", err.Error())
+		validator.Errorf("Failed initiliazing crypto engine [%s].", err.Error())
 		return err
 	}
 

--- a/core/crypto/validator_state.go
+++ b/core/crypto/validator_state.go
@@ -64,13 +64,13 @@ func (validator *validatorImpl) getStateEncryptor1_1(deployTx, executeTx *obc.Tr
 		return nil, utils.ErrDifferrentConfidentialityProtocolVersion
 	}
 
-	validator.debug("Parsing transaction. Type [%s]. Confidentiality Protocol Version [%d]", executeTx.Type.String(), executeTx.ConfidentialityProtocolVersion)
+	validator.Debugf("Parsing transaction. Type [%s]. Confidentiality Protocol Version [%d]", executeTx.Type.String(), executeTx.ConfidentialityProtocolVersion)
 
 	// client.enrollChainKey is an AES key represented as byte array
 	enrollChainKey := validator.enrollChainKey.([]byte)
 
 	if executeTx.Type == obc.Transaction_CHAINCODE_QUERY {
-		validator.debug("Parsing Query transaction...")
+		validator.Debug("Parsing Query transaction...")
 
 		// Compute deployTxKey key from the deploy transaction. This is used to decrypt the actual state
 		// of the chaincode
@@ -134,12 +134,12 @@ func (validator *validatorImpl) getStateEncryptor1_2(deployTx, executeTx *obc.Tr
 		return nil, utils.ErrDifferrentConfidentialityProtocolVersion
 	}
 
-	validator.debug("Parsing transaction. Type [%s]. Confidentiality Protocol Version [%s]", executeTx.Type.String(), executeTx.ConfidentialityProtocolVersion)
+	validator.Debugf("Parsing transaction. Type [%s]. Confidentiality Protocol Version [%s]", executeTx.Type.String(), executeTx.ConfidentialityProtocolVersion)
 
 	deployStateKey, err := validator.getStateKeyFromTransaction(deployTx)
 
 	if executeTx.Type == obc.Transaction_CHAINCODE_QUERY {
-		validator.debug("Parsing Query transaction...")
+		validator.Debug("Parsing Query transaction...")
 
 		executeStateKey, err := validator.getStateKeyFromTransaction(executeTx)
 
@@ -184,20 +184,20 @@ func (validator *validatorImpl) getStateEncryptor1_2(deployTx, executeTx *obc.Tr
 func (validator *validatorImpl) getStateKeyFromTransaction(tx *obc.Transaction) ([]byte, error) {
 	cipher, err := validator.eciesSPI.NewAsymmetricCipherFromPrivateKey(validator.chainPrivateKey)
 	if err != nil {
-		validator.error("Failed init decryption engine [%s].", err.Error())
+		validator.Errorf("Failed init decryption engine [%s].", err.Error())
 		return nil, err
 	}
 
 	msgToValidatorsRaw, err := cipher.Process(tx.ToValidators)
 	if err != nil {
-		validator.error("Failed decrypting message to validators [% x]: [%s].", tx.ToValidators, err.Error())
+		validator.Errorf("Failed decrypting message to validators [% x]: [%s].", tx.ToValidators, err.Error())
 		return nil, err
 	}
 
 	msgToValidators := new(chainCodeValidatorMessage1_2)
 	_, err = asn1.Unmarshal(msgToValidatorsRaw, msgToValidators)
 	if err != nil {
-		validator.error("Failed unmarshalling message to validators [% x]: [%s].", msgToValidators, err.Error())
+		validator.Errorf("Failed unmarshalling message to validators [% x]: [%s].", msgToValidators, err.Error())
 		return nil, err
 	}
 
@@ -249,7 +249,7 @@ func (se *stateEncryptorImpl) Encrypt(msg []byte) ([]byte, error) {
 	var b = make([]byte, 8)
 	binary.BigEndian.PutUint64(b, se.counter)
 
-	se.node.debug("Encrypting with counter [% x].", b)
+	se.node.Debugf("Encrypting with counter [% x].", b)
 	//	se.log.Infof("Encrypting with txNonce  ", utils.EncodeBase64(se.txNonce))
 
 	nonce := primitives.HMACTruncated(se.nonceStateKey, b, se.nonceSize)
@@ -339,7 +339,7 @@ func (se *queryStateEncryptor) init(node *nodeImpl, queryKey, deployTxKey []byte
 func (se *queryStateEncryptor) Encrypt(msg []byte) ([]byte, error) {
 	nonce, err := primitives.GetRandomBytes(se.nonceSize)
 	if err != nil {
-		se.node.error("Failed getting randomness [%s].", err.Error())
+		se.node.Errorf("Failed getting randomness [%s].", err.Error())
 		return nil, err
 	}
 

--- a/core/crypto/validator_validity_period.go
+++ b/core/crypto/validator_validity_period.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/hyperledger/fabric/core/ledger"
 	obc "github.com/hyperledger/fabric/protos"
-	"github.com/hyperledger/fabric/core/crypto/primitives"
 )
 
 //We are temporarily disabling the validity period functionality
@@ -46,7 +46,7 @@ func (validator *validatorImpl) verifyValidityPeriod(tx *obc.Transaction) (*obc.
 		// Unmarshal cert
 		cert, err := primitives.DERToX509Certificate(tx.Cert)
 		if err != nil {
-			validator.error("verifyValidityPeriod: failed unmarshalling cert %s:", err)
+			validator.Errorf("verifyValidityPeriod: failed unmarshalling cert %s:", err)
 			return tx, err
 		}
 
@@ -54,19 +54,19 @@ func (validator *validatorImpl) verifyValidityPeriod(tx *obc.Transaction) (*obc.
 
 		ledger, err := ledger.GetLedger()
 		if err != nil {
-			validator.error("verifyValidityPeriod: failed getting access to the ledger %s:", err)
+			validator.Errorf("verifyValidityPeriod: failed getting access to the ledger %s:", err)
 			return tx, err
 		}
 
 		vpBytes, err := ledger.GetState(cid, "system.validity.period", true)
 		if err != nil {
-			validator.error("verifyValidityPeriod: failed reading validity period from the ledger %s:", err)
+			validator.Errorf("verifyValidityPeriod: failed reading validity period from the ledger %s:", err)
 			return tx, err
 		}
 
 		i, err := strconv.ParseInt(string(vpBytes[:]), 10, 64)
 		if err != nil {
-			validator.error("verifyValidityPeriod: failed to parse validity period %s:", err)
+			validator.Errorf("verifyValidityPeriod: failed to parse validity period %s:", err)
 			return tx, err
 		}
 
@@ -85,7 +85,7 @@ func (validator *validatorImpl) verifyValidityPeriod(tx *obc.Transaction) (*obc.
 		}
 
 		if errMsg != "" {
-			validator.error(errMsg)
+			validator.Error(errMsg)
 			return tx, errors.New(errMsg)
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Function name refactor in node_log.go to meet the naming conventions
## Motivation and Context

After we upgrade the go-loging package to the latest version in #1683, we need refine the function names in github.com/hyperledger/fabric/core/crypto/node_log.go to eliminate more go vet warnings (https://goreportcard.com/report/github.com/hyperledger/fabric#go_vet)

Fixes #1845 
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [] Either no new documentation is required by this change, OR I added new documentation
- [] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: David Geng david@esse.io
