### PR TITLE
Remove syscc from genesis#issue1741

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -73,7 +73,6 @@ eca:
 
                 vp: 4 f3489fy98ghf
 
-
 ###############################################################################
 #
 #    CLI section
@@ -176,15 +175,15 @@ peer:
 
 
     # The Address this Peer will listen on
-    listenAddress: 0.0.0.0:40404
+    listenAddress: 0.0.0.0:41414
     # The Address this Peer will bind to for providing services
-    address: 0.0.0.0:40404
+    address: 0.0.0.0:41414
     # Whether the Peer should programmatically determine the address to bind to.
     # This case is useful for docker containers.
     addressAutoDetect: false
 
     # Peer port to accept connections on
-    port:    40404
+    port:    41414
     # Setting for runtime.GOMAXPROCS(n). If n < 1, it does not change the current setting
     gomaxprocs: -1
     workers: 2
@@ -278,10 +277,10 @@ peer:
         # testNodes:
         #    - node   : 1
         #      ip     : 127.0.0.1
-        #      port   : 40404
+        #      port   : 41414
         #    - node   : 2
         #      ip     : 127.0.0.1
-        #      port   : 40404
+        #      port   : 41414
 
         # Should the discovered nodes and their reputations
         # be stored in DB and persisted between restarts

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hyperledger/fabric/core/container/ccintf"
 	"github.com/hyperledger/fabric/core/crypto"
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/hyperledger/fabric/core/system_chaincode"
 	"github.com/hyperledger/fabric/core/util"
 	"github.com/hyperledger/fabric/membersrvc/ca"
 	pb "github.com/hyperledger/fabric/protos"
@@ -1217,62 +1216,6 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 
 	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})
 	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec2})
-	closeListenerAndSleep(lis)
-}
-
-// Test deploy of a transaction.
-func TestExecuteDeploySysChaincode(t *testing.T) {
-	var opts []grpc.ServerOption
-	if viper.GetBool("peer.tls.enabled") {
-		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
-		if err != nil {
-			grpclog.Fatalf("Failed to generate credentials %v", err)
-		}
-		opts = []grpc.ServerOption{grpc.Creds(creds)}
-	}
-	grpcServer := grpc.NewServer(opts...)
-	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
-
-	//lis, err := net.Listen("tcp", viper.GetString("peer.address"))
-
-	//use a different address than what we usually use for "peer"
-	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
-	lis, err := net.Listen("tcp", peerAddress)
-	if err != nil {
-		t.Fail()
-		t.Logf("Error starting peer listener %s", err)
-		return
-	}
-
-	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
-		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
-	}
-
-	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
-	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
-
-	go grpcServer.Serve(lis)
-
-	var ctxt = context.Background()
-
-	system_chaincode.RegisterSysCCs()
-
-	url := "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
-
-	args := []string{"greeting", "hello world"}
-	cds := &pb.ChaincodeDeploymentSpec{ExecEnv: 1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Args: args}}}
-	_, err = deploy2(ctxt, cds)
-	chaincodeID := cds.ChaincodeSpec.ChaincodeID.Name
-	if err != nil {
-		GetChain(DefaultChain).Stop(ctxt, cds)
-		closeListenerAndSleep(lis)
-		t.Fail()
-		t.Logf("Error deploying <%s>: %s", chaincodeID, err)
-		return
-	}
-
-	GetChain(DefaultChain).Stop(ctxt, cds)
 	closeListenerAndSleep(lis)
 }
 

--- a/core/ledger/genesis/config.go
+++ b/core/ledger/genesis/config.go
@@ -25,8 +25,6 @@ import (
 var loadConfigOnce sync.Once
 
 var genesis map[string]interface{}
-var mode string
-var deploySystemChaincodeEnabled bool
 
 func initConfigs() {
 	loadConfigOnce.Do(func() { loadConfigs() })
@@ -35,29 +33,10 @@ func initConfigs() {
 func loadConfigs() {
 	genesisLogger.Info("Loading configurations...")
 	genesis = viper.GetStringMap("ledger.blockchain.genesisBlock")
-	mode = viper.GetString("chaincode.chaincoderunmode")
-	genesisLogger.Infof("Configurations loaded: genesis=%s, mode=[%s], deploySystemChaincodeEnabled=[%t]",
-		genesis, mode, deploySystemChaincodeEnabled)
-	if viper.IsSet("ledger.blockchain.deploy-system-chaincode") {
-		// If the deployment of system chaincode is enabled in the configuration file return the configured value
-		deploySystemChaincodeEnabled = viper.GetBool("ledger.blockchain.deploy-system-chaincode")
-	} else {
-		// Deployment of system chaincode is enabled by default if no configuration was specified.
-		deploySystemChaincodeEnabled = true
-	}
+	genesisLogger.Info("Configurations loaded: genesis=%s", genesis)
 }
 
 func getGenesis() map[string]interface{} {
 	initConfigs()
 	return genesis
-}
-
-func getMode() string {
-	initConfigs()
-	return mode
-}
-
-func isDeploySystemChaincodeEnabled() bool {
-	initConfigs()
-	return deploySystemChaincodeEnabled
 }

--- a/core/system_chaincode/api/sysccapi.go
+++ b/core/system_chaincode/api/sysccapi.go
@@ -37,8 +37,8 @@ var sysccLogger = logging.MustGetLogger("sysccapi")
 type SystemChaincode struct {
 	// Enabled a convenient switch to enable/disable system chaincode without
 	// having to remove entry from importsysccs.go
-
 	Enabled bool
+
 	//Unique name of the system chaincode
 	Name string
 

--- a/core/system_chaincode/api/sysccapi.go
+++ b/core/system_chaincode/api/sysccapi.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/container/inproccontroller"
+	"github.com/hyperledger/fabric/core/peer"
 	"github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
 )
@@ -49,10 +50,15 @@ type SystemChaincode struct {
 
 	// Chaincode is the actual chaincode object
 	Chaincode shim.Chaincode
+
 }
 
 // RegisterSysCC registers the given system chaincode with the peer
 func RegisterSysCC(syscc *SystemChaincode) error {
+	if peer.SecurityEnabled() {
+		sysccLogger.Warning(fmt.Sprintf("system chaincode not supported for security/privacy(%s,%s)", syscc.Name, syscc.Path))
+		return nil
+	}
 	if !syscc.Enabled {
 		sysccLogger.Info(fmt.Sprintf("system chaincode (%s,%s) disabled", syscc.Name, syscc.Path))
 		return nil

--- a/core/system_chaincode/api/sysccapi.go
+++ b/core/system_chaincode/api/sysccapi.go
@@ -19,24 +19,88 @@ package api
 import (
 	"fmt"
 
+	"golang.org/x/net/context"
+
+	"github.com/hyperledger/fabric/core/chaincode"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
-	inproc "github.com/hyperledger/fabric/core/container/inproccontroller"
+	"github.com/hyperledger/fabric/core/container/inproccontroller"
+	"github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
 )
 
 var sysccLogger = logging.MustGetLogger("sysccapi")
 
+// SystemChaincode defines the metadata needed to initialize system chaincode
+// when the fabric comes up. SystemChaincodes are installed by adding an
+// entry in importsysccs.go
+type SystemChaincode struct {
+	// Enabled a convenient switch to enable/disable system chaincode without
+	// having to remove entry from importsysccs.go
+
+	Enabled bool
+	//Unique name of the system chaincode
+	Name string
+
+	//Path to the system chaincode; currently not used
+	Path string
+
+	//InitArgs initialization arguments to startup the system chaincode
+	InitArgs []string
+
+	// Chaincode is the actual chaincode object
+	Chaincode shim.Chaincode
+}
+
 // RegisterSysCC registers the given system chaincode with the peer
-func RegisterSysCC(path string, o interface{}) error {
-	syscc := o.(shim.Chaincode)
-	if syscc == nil {
-		sysccLogger.Warningf("invalid chaincode %v", o)
-		return fmt.Errorf(fmt.Sprintf("invalid chaincode %v", o))
+func RegisterSysCC(syscc *SystemChaincode) error {
+	if !syscc.Enabled {
+		sysccLogger.Info(fmt.Sprintf("system chaincode (%s,%s) disabled", syscc.Name, syscc.Path))
+		return nil
 	}
-	err := inproc.Register(path, syscc)
+
+	err := inproccontroller.Register(syscc.Path, syscc.Chaincode)
 	if err != nil {
-		return fmt.Errorf(fmt.Sprintf("could not register (%s,%v): %s", path, syscc, err))
+		errStr := fmt.Sprintf("could not register (%s,%v): %s", syscc.Path, syscc, err)
+		sysccLogger.Error(errStr)
+		return fmt.Errorf(errStr)
 	}
-	sysccLogger.Debugf("system chaincode %s registered", path)
+
+	chaincodeID := &protos.ChaincodeID{Path: syscc.Path, Name: syscc.Name}
+	spec := protos.ChaincodeSpec{Type: protos.ChaincodeSpec_Type(protos.ChaincodeSpec_Type_value["GOLANG"]), ChaincodeID: chaincodeID, CtorMsg: &protos.ChaincodeInput{Args: syscc.InitArgs}}
+
+	if deployErr := deploySysCC(context.Background(), &spec); deployErr != nil {
+		errStr := fmt.Sprintf("deploy chaincode failed: %s", deployErr)
+		sysccLogger.Error(errStr)
+		return fmt.Errorf(errStr)
+	}
+
+	sysccLogger.Info("system chaincode %s(%s) registered", syscc.Name, syscc.Path)
+	return err
+}
+
+// buildLocal builds a given chaincode code
+func buildSysCC(context context.Context, spec *protos.ChaincodeSpec) (*protos.ChaincodeDeploymentSpec, error) {
+	var codePackageBytes []byte
+	chaincodeDeploymentSpec := &protos.ChaincodeDeploymentSpec{ExecEnv: protos.ChaincodeDeploymentSpec_SYSTEM, ChaincodeSpec: spec, CodePackage: codePackageBytes}
+	return chaincodeDeploymentSpec, nil
+}
+
+// deployLocal deploys the supplied chaincode image to the local peer
+func deploySysCC(ctx context.Context, spec *protos.ChaincodeSpec) error {
+	// First build and get the deployment spec
+	chaincodeDeploymentSpec, err := buildSysCC(ctx, spec)
+
+	if err != nil {
+		sysccLogger.Error(fmt.Sprintf("Error deploying chaincode spec: %v\n\n error: %s", spec, err))
+		return err
+	}
+
+	transaction, err := protos.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s ", err)
+	}
+
+	_, _, err = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+
 	return err
 }

--- a/core/system_chaincode/api/sysccapi.go
+++ b/core/system_chaincode/api/sysccapi.go
@@ -56,7 +56,7 @@ type SystemChaincode struct {
 // RegisterSysCC registers the given system chaincode with the peer
 func RegisterSysCC(syscc *SystemChaincode) error {
 	if peer.SecurityEnabled() {
-		sysccLogger.Warning(fmt.Sprintf("system chaincode not supported for security/privacy(%s,%s)", syscc.Name, syscc.Path))
+		sysccLogger.Warning(fmt.Sprintf("Currently system chaincode does support security(%s,%s)", syscc.Name, syscc.Path))
 		return nil
 	}
 	if !syscc.Enabled {

--- a/core/system_chaincode/config.go
+++ b/core/system_chaincode/config.go
@@ -1,0 +1,68 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system_chaincode
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
+)
+
+// Config the config wrapper structure
+type Config struct {
+}
+
+func init() {
+
+}
+
+// SetupTestLogging setup the logging during test execution
+func SetupTestLogging() {
+	level, err := logging.LogLevel(viper.GetString("logging.peer"))
+	if err == nil {
+		// No error, use the setting
+		logging.SetLevel(level, "main")
+		logging.SetLevel(level, "server")
+		logging.SetLevel(level, "peer")
+	} else {
+		logging.SetLevel(logging.ERROR, "main")
+		logging.SetLevel(logging.ERROR, "server")
+		logging.SetLevel(logging.ERROR, "peer")
+	}
+}
+
+// SetupTestConfig setup the config during test execution
+func SetupTestConfig() {
+	flag.Parse()
+
+	// Now set the configuration file
+	viper.SetEnvPrefix("CORE")
+	viper.AutomaticEnv()
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
+	viper.SetConfigName("core")        // name of config file (without extension)
+	viper.AddConfigPath("../../peer/") // path to look for the config file in
+	err := viper.ReadInConfig()        // Find and read the config file
+	if err != nil {                    // Handle errors reading the config file
+		panic(fmt.Errorf("Fatal error config file: %s \n", err))
+	}
+
+	SetupTestLogging()
+}

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -20,22 +20,14 @@ import (
 	"github.com/hyperledger/fabric/core/system_chaincode/api"
 
 	//import system chain codes here
-	"github.com/hyperledger/fabric/core/system_chaincode/samplesyscc"
 )
 
-var systemChaincodes = []*api.SystemChaincode{
-	{
-		Enabled:   true,
-		Name:      "sample_syscc",
-		Path:      "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc",
-		InitArgs:  []string{},
-		Chaincode: &samplesyscc.SampleSysCC{}},
-}
+//see systemchaincode_test.go for an example using "sample_syscc"
+var systemChaincodes = []*api.SystemChaincode{}
 
 //RegisterSysCCs is the hook for system chaincodes where system chaincodes are registered with the fabric
 //note the chaincode must still be deployed and launched like a user chaincode will be
 func RegisterSysCCs() {
-	//sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc", InitArgs: []string{}, Chaincode: &samplesyscc.SampleSysCC{}}
 	for _, sysCC := range systemChaincodes {
 		api.RegisterSysCC(sysCC)
 	}

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -19,12 +19,12 @@ package system_chaincode
 import (
 	//import system chain codes here
 	"github.com/hyperledger/fabric/core/system_chaincode/api"
-	"github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
+	"github.com/hyperledger/fabric/core/system_chaincode/samplesyscc"
 )
 
 //RegisterSysCCs is the hook for system chaincodes where system chaincodes are registered with the fabric
 //note the chaincode must still be deployed and launched like a user chaincode will be
 func RegisterSysCCs() {
-	sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc", InitArgs: []string{}, Chaincode: &sample_syscc.SampleSysCC{}}
+	sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc", InitArgs: []string{}, Chaincode: &samplesyscc.SampleSysCC{}}
 	api.RegisterSysCC(sampleCC)
 }

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -25,5 +25,6 @@ import (
 //RegisterSysCCs is the hook for system chaincodes where system chaincodes are registered with the fabric
 //note the chaincode must still be deployed and launched like a user chaincode will be
 func RegisterSysCCs() {
-	api.RegisterSysCC("github.com/hyperledger/fabric/core/system_chaincode/sample_syscc", &sample_syscc.SampleSysCC{})
+	sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc", InitArgs: []string{}, Chaincode: &sample_syscc.SampleSysCC{}}
+	api.RegisterSysCC(sampleCC)
 }

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -18,7 +18,6 @@ package system_chaincode
 
 import (
 	"github.com/hyperledger/fabric/core/system_chaincode/api"
-
 	//import system chain codes here
 )
 

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -23,9 +23,20 @@ import (
 	"github.com/hyperledger/fabric/core/system_chaincode/samplesyscc"
 )
 
+var systemChaincodes = []*api.SystemChaincode{
+	{
+		Enabled:   true,
+		Name:      "sample_syscc",
+		Path:      "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc",
+		InitArgs:  []string{},
+		Chaincode: &samplesyscc.SampleSysCC{}},
+}
+
 //RegisterSysCCs is the hook for system chaincodes where system chaincodes are registered with the fabric
 //note the chaincode must still be deployed and launched like a user chaincode will be
 func RegisterSysCCs() {
-	sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc", InitArgs: []string{}, Chaincode: &samplesyscc.SampleSysCC{}}
-	api.RegisterSysCC(sampleCC)
+	//sampleCC := &api.SystemChaincode{Enabled: true, Name: "sample_syscc", Path: "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc", InitArgs: []string{}, Chaincode: &samplesyscc.SampleSysCC{}}
+	for _, sysCC := range systemChaincodes {
+		api.RegisterSysCC(sysCC)
+	}
 }

--- a/core/system_chaincode/importsysccs.go
+++ b/core/system_chaincode/importsysccs.go
@@ -17,8 +17,9 @@ limitations under the License.
 package system_chaincode
 
 import (
-	//import system chain codes here
 	"github.com/hyperledger/fabric/core/system_chaincode/api"
+
+	//import system chain codes here
 	"github.com/hyperledger/fabric/core/system_chaincode/samplesyscc"
 )
 

--- a/core/system_chaincode/samplesyscc/samplesyscc.go
+++ b/core/system_chaincode/samplesyscc/samplesyscc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sample_syscc
+package samplesyscc
 
 import (
 	"errors"
@@ -29,20 +29,8 @@ type SampleSysCC struct {
 // Init initializes the sample system chaincode by storing the key and value
 // arguments passed in as parameters
 func (t *SampleSysCC) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
-	var key, val string // Entities
-
-	if len(args) != 2 {
-		return nil, errors.New("need 2 args (key and a value)")
-	}
-
-	// Initialize the chaincode
-	key = args[0]
-	val = args[1]
-	// Write the state to the ledger
-	err := stub.PutState(key, []byte(val))
-	if err != nil {
-		return nil, err
-	}
+	//as system chaincodes do not take part in consensus and are part of the system,
+	//best practice to do nothing (or very little) in Init.
 
 	return nil, nil
 }

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -93,7 +93,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
 	}
 
-	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, false, 1000, nil))
+	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, false, 30000, nil))
 
 	go grpcServer.Serve(lis)
 

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -93,7 +93,8 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
 	}
 
-	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, false, 30000, nil))
+	ccStartupTimeout := time.Duration(5000) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
 
 	go grpcServer.Serve(lis)
 

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system_chaincode
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric/core/chaincode"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/system_chaincode/api"
+	"github.com/hyperledger/fabric/core/system_chaincode/samplesyscc"
+	"github.com/hyperledger/fabric/core/util"
+	pb "github.com/hyperledger/fabric/protos"
+	"github.com/spf13/viper"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// Invoke or query a chaincode.
+func invoke(ctx context.Context, spec *pb.ChaincodeSpec, typ pb.Transaction_Type) (*pb.ChaincodeEvent, string, []byte, error) {
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
+
+	// Now create the Transactions message and send to Peer.
+	uuid := util.GenerateUUID()
+
+	var transaction *pb.Transaction
+	var err error
+	transaction, err = pb.NewChaincodeExecute(chaincodeInvocationSpec, uuid, typ)
+	if err != nil {
+		return nil, uuid, nil, fmt.Errorf("Error invoking chaincode: %s ", err)
+	}
+
+	var retval []byte
+	var execErr error
+	var ccevt *pb.ChaincodeEvent
+	if typ == pb.Transaction_CHAINCODE_QUERY {
+		retval, ccevt, execErr = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+	} else {
+		ledger, _ := ledger.GetLedger()
+		ledger.BeginTxBatch("1")
+		retval, ccevt, execErr = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+		if err != nil {
+			return nil, uuid, nil, fmt.Errorf("Error invoking chaincode: %s ", err)
+		}
+		ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+	}
+
+	return ccevt, uuid, retval, execErr
+}
+
+func closeListenerAndSleep(l net.Listener) {
+	if l != nil {
+		l.Close()
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// Test deploy of a transaction.
+func TestExecuteDeploySysChaincode(t *testing.T) {
+	var opts []grpc.ServerOption
+	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:40303"
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		t.Fail()
+		t.Logf("Error starting peer listener %s", err)
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, false, 1000, nil))
+
+	go grpcServer.Serve(lis)
+
+	var ctxt = context.Background()
+
+	//set systemChaincodes to sample
+	systemChaincodes = []*api.SystemChaincode{
+		{
+			Enabled:   true,
+			Name:      "sample_syscc",
+			Path:      "github.com/hyperledger/fabric/core/system_chaincode/samplesyscc",
+			InitArgs:  []string{},
+			Chaincode: &samplesyscc.SampleSysCC{},
+		},
+	}
+
+	RegisterSysCCs()
+
+	url := "github.com/hyperledger/fabric/core/system_chaincode/sample_syscc"
+	f := "putval"
+	args := []string{"greeting", "hey there"}
+
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_INVOKE)
+	if err != nil {
+		closeListenerAndSleep(lis)
+		t.Fail()
+		t.Logf("Error invoking sample_syscc: %s", err)
+		return
+	}
+
+	f = "getval"
+	args = []string{"greeting"}
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
+	if err != nil {
+		closeListenerAndSleep(lis)
+		t.Fail()
+		t.Logf("Error invoking sample_syscc: %s", err)
+		return
+	}
+
+	cds := &pb.ChaincodeDeploymentSpec{ExecEnv: 1, ChaincodeSpec: &pb.ChaincodeSpec{Type: 1, ChaincodeID: &pb.ChaincodeID{Name: "sample_syscc", Path: url}, CtorMsg: &pb.ChaincodeInput{Args: args}}}
+
+	chaincode.GetChain(chaincode.DefaultChain).Stop(ctxt, cds)
+
+	closeListenerAndSleep(lis)
+}
+
+func TestMain(m *testing.M) {
+	SetupTestConfig()
+	os.Exit(m.Run())
+}

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -81,7 +81,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:41726"
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
 		t.Fail()

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -318,21 +318,6 @@ ledger:
     # Define the genesis block
     genesisBlock:
 
-      # Deploy chaincodes into the genesis block
-      chaincodes:
-
-        #sample_syscc:
-        #  path: github.com/hyperledger/fabric/core/system_chaincode/sample_syscc
-        #  type: GOLANG
-        #  constructor:
-        #    args:
-        #      - greetings
-        #      - hello world
-
-    # Setting the deploy-system-chaincode property to false will prevent the
-    # deploying of system chaincode at genesis time.
-    deploy-system-chaincode: false
-
   state:
 
     # Control the number state deltas that are maintained. This takes additional

--- a/peer/main.go
+++ b/peer/main.go
@@ -717,7 +717,7 @@ func registerChaincodeSupport(chainname chaincode.ChainName, grpcServer *grpc.Se
 
 	ccSrv := chaincode.NewChaincodeSupport(chainname, peer.GetPeerEndpoint, userRunsCC, ccStartupTimeout, secHelper)
 
-	//Now that chaincode is initialized, register all system chaincodes. 
+	//Now that chaincode is initialized, register all system chaincodes.
 	system_chaincode.RegisterSysCCs()
 
 	pb.RegisterChaincodeSupportServer(grpcServer, ccSrv)

--- a/peer/main.go
+++ b/peer/main.go
@@ -401,9 +401,6 @@ func serve(args []string) error {
 		return err
 	}
 
-	//register all system chaincodes. This just registers chaincodes, they must be
-	//still be deployed and launched
-	system_chaincode.RegisterSysCCs()
 	peerEndpoint, err := peer.GetPeerEndpoint()
 	if err != nil {
 		err = fmt.Errorf("Failed to get Peer Endpoint: %s", err)
@@ -718,7 +715,12 @@ func registerChaincodeSupport(chainname chaincode.ChainName, grpcServer *grpc.Se
 	}
 	ccStartupTimeout := time.Duration(tOut) * time.Millisecond
 
-	pb.RegisterChaincodeSupportServer(grpcServer, chaincode.NewChaincodeSupport(chainname, peer.GetPeerEndpoint, userRunsCC, ccStartupTimeout, secHelper))
+	ccSrv := chaincode.NewChaincodeSupport(chainname, peer.GetPeerEndpoint, userRunsCC, ccStartupTimeout, secHelper)
+
+	//Now that chaincode is initialized, register all system chaincodes. 
+	system_chaincode.RegisterSysCCs()
+
+	pb.RegisterChaincodeSupportServer(grpcServer, ccSrv)
 }
 
 func checkChaincodeCmdParams(cmd *cobra.Command) (err error) {


### PR DESCRIPTION
Remove system chaincodes from genesis block and make them completely non-declarative.
# Description

System chaincodes should be treated as part of the fabric with all policies and rules applicable to upgrading/modifying the fabric applicable to the system chaincodes. It does not make sense to have them committed to the genesis block as user chaincodes would. This PR removes system chaincodes from genesis block
- remove system chaincode declaration from peer/core.yaml
- the system chaincodes are embedded into the fabric programmatically (see importsysccs.go and systemchaincode_test.go)

The registration of system chaincodes is currently disabled if security/privacy mode is on. A approach different from user chaincode treatment of security context is needed to address this correctly (the "user" is the "peer"). Working with @adecaro on this. Commit 3ad5fb1 commit will be removed with the PR for the fix.
## Motivation and Context

As highlighted by #1741, having system chaincodes  - whose deployment don't participate in consensus - committed to genesis block can give raise to problems if the transactions are not the same on all peers (even if the chaincode's context and states are identical). Furthermore, treating them as proper on-block transactions would complicated scenarios such as upgrade. These problems really show that system chaincodes should be considered as part of fabric code.

Fixes #1741
## How Has This Been Tested?

Removed a system chaincode unit test from chaincode folder and made it part of the system_chaincode package. This is the right approach now that system chaincodes are registered programmatically. The test case also serves as an example of registering system chaincodes (ie, the sample needs to be only part of the unit test and does not have to be imported/registered in importsysccs.go).
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com

Original PR #1826 
