### PR TITLE
Fix Issue 1796

### DIFF
--- a/examples/chaincode/go/asset_management_with_roles/asset.yaml
+++ b/examples/chaincode/go/asset_management_with_roles/asset.yaml
@@ -16,8 +16,10 @@ server:
 
         # TLS certificate and key file paths
         tls:
-#              certfile: "/var/hyperledger/production/.ca/tlsca.cert"
-#              keyfile: "/var/hyperledger/production/.ca/tlsca.priv"
+              cert:
+#                    file: "/var/hyperledger/production/.ca/tlsca.cert"
+              key:
+#                    file: "/var/hyperledger/production/.ca/tlsca.priv"
 
 security:
     # Can be 256 or 384

--- a/membersrvc/ca/ca_test.yaml
+++ b/membersrvc/ca/ca_test.yaml
@@ -6,8 +6,10 @@ server:
         port: ":50951"
 
         tls:
-                certfile: ".ca/tlsca.cert"
-                keyfile: ".ca/tlsca.priv"
+                cert:
+                    file: ".ca/tlsca.cert"
+                key:
+                    file: ".ca/tlsca.priv"
 
 ###############################################################################
 #

--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -69,7 +69,7 @@ func startTLSCA(t *testing.T) {
 	tlscaS = NewTLSCA(ecaS)
 
 	var opts []grpc.ServerOption
-	creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.certfile"), viper.GetString("server.tls.keyfile"))
+	creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.cert.file"), viper.GetString("server.tls.key.file"))
 	if err != nil {
 		t.Logf("Failed creating credentials for TLS-CA service: %s", err)
 		t.Fail()
@@ -94,7 +94,7 @@ func startTLSCA(t *testing.T) {
 func requestTLSCertificate(t *testing.T) {
 	var opts []grpc.DialOption
 
-	creds, err := credentials.NewClientTLSFromFile(viper.GetString("server.tls.certfile"), "tlsca")
+	creds, err := credentials.NewClientTLSFromFile(viper.GetString("server.tls.cert.file"), "tlsca")
 	if err != nil {
 		t.Logf("Failed creating credentials for TLS-CA client: %s", err)
 		t.Fail()

--- a/membersrvc/membersrvc.yaml
+++ b/membersrvc/membersrvc.yaml
@@ -17,8 +17,10 @@ server:
 
         # TLS certificate and key file paths
         tls:
-#              certfile: "/var/hyperledger/production/.membersrvc/tlsca.cert"
-#              keyfile: "/var/hyperledger/production/.membersrvc/tlsca.priv"
+            cert:
+                file: "/var/hyperledger/production/.membersrvc/tlsca.cert"
+            key:
+                file: "/var/hyperledger/production/.membersrvc/tlsca.priv"
 
 security:
     # Can be 256 or 384

--- a/membersrvc/membersrvc.yaml
+++ b/membersrvc/membersrvc.yaml
@@ -18,9 +18,9 @@ server:
         # TLS certificate and key file paths
         tls:
             cert:
-#                file: "/var/hyperledger/production/.membersrvc/tlsca.cert"
+                file:
             key:
-#                file: "/var/hyperledger/production/.membersrvc/tlsca.priv"
+                file:
 
 security:
     # Can be 256 or 384

--- a/membersrvc/membersrvc.yaml
+++ b/membersrvc/membersrvc.yaml
@@ -18,9 +18,9 @@ server:
         # TLS certificate and key file paths
         tls:
             cert:
-                file: "/var/hyperledger/production/.membersrvc/tlsca.cert"
+#                file: "/var/hyperledger/production/.membersrvc/tlsca.cert"
             key:
-                file: "/var/hyperledger/production/.membersrvc/tlsca.priv"
+#                file: "/var/hyperledger/production/.membersrvc/tlsca.priv"
 
 security:
     # Can be 256 or 384

--- a/membersrvc/server.go
+++ b/membersrvc/server.go
@@ -105,8 +105,8 @@ func main() {
 	runtime.GOMAXPROCS(viper.GetInt("server.gomaxprocs"))
 
 	var opts []grpc.ServerOption
-	if viper.GetString("server.tls.certfile") != "" {
-		creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.certfile"), viper.GetString("server.tls.keyfile"))
+	if viper.GetString("server.tls.cert.file") != "" {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("server.tls.cert.file"), viper.GetString("server.tls.key.file"))
 		if err != nil {
 			panic(err)
 		}

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -194,8 +194,10 @@ If you wish to activate TLS connection with the member services the following ac
 ```
 server:
      tls:
-        certfile: "/var/hyperledger/production/.membersrvc/tlsca.cert"
-        keyfile: "/var/hyperledger/production/.membersrvc/tlsca.priv"
+        cert:
+            file: "/var/hyperledger/production/.membersrvc/tlsca.cert"
+        key:
+            file: "/var/hyperledger/production/.membersrvc/tlsca.priv"
 ```
 
 This is needed to instruct the member services on which tls cert and key to use.  

--- a/sdk/node/doc/index.html
+++ b/sdk/node/doc/index.html
@@ -219,8 +219,10 @@ var testChaincodePath = <span class="hljs-string">"github.com/chaincode_example0
 				</ul>
 				<pre><code><span class="hljs-attribute">server</span>:
      <span class="hljs-attribute">tls</span>:
-        <span class="hljs-attribute">certfile</span>: <span class="hljs-string">"/var/hyperledger/production/.membersrvc/tlsca.cert"</span>
-        <span class="hljs-attribute">keyfile</span>: <span class="hljs-string">"/var/hyperledger/production/.membersrvc/tlsca.priv"</span>
+		<span class="hljs-attribute">cert</span>:
+			<span class="hljs-attribute">file</span>: <span class="hljs-string">"/var/hyperledger/production/.membersrvc/tlsca.cert"</span>
+        <span class="hljs-attribute">key</span>:
+			<span class="hljs-attribute">file</span>: <span class="hljs-string">"/var/hyperledger/production/.membersrvc/tlsca.priv"</span>
 </code></pre><p>This is needed to instruct the member services on which tls cert and key to use.  </p>
 				<ul>
 					<li>Modify <code>$GOPATH/src/github.com/hyperledger/fabric/peer/core.yaml</code> as follows:</li>


### PR DESCRIPTION
## Description

Make TLS config consitent between membersrvc and peer. 
@JonathanLevi  I still comment this config as before, because current bddtest does not support membersrvc service using TLS. I cannot find a easy way to fix this problem.
https://github.com/hyperledger/fabric/blob/master/bddtests/peer_basic.feature#L575
https://github.com/hyperledger/fabric/blob/master/bddtests/steps/peer_basic_impl.py#L105-L109 
## Motivation and Context

Fixes #1796 
## How Has This Been Tested?

All test passed
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:Kai Chen ckaiwh@cn.ibm.com
