### PR TITLE
Post processing source links in generated typedoc

### DIFF
--- a/sdk/node/makedoc.sh
+++ b/sdk/node/makedoc.sh
@@ -51,3 +51,8 @@ typedoc -m amd \
 --excludeNotExported \
 --out doc \
 src/hlc.ts typedoc-special.d.ts
+
+# Typedoc generates links to working GIT repo which is fixed
+# below to use an official release URI.
+DOCURI="https://github.com/hyperledger/fabric/tree/master/sdk/node/"
+find doc -name '*.html' -exec sed -i 's!href="http.*sdk/node/!href="'$DOCURI'!' {} \;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Post processing source links in generated typedoc
## Description

<!--- Describe your changes in detail. -->

The shell script which generates the Node.js SDK API documentation now does some postprocessing to change the source code links. The typedoc tools by default inserts the git repository of the developer at the time of execution. The shell script has a variable DOCURI which needs to be adjusted to the final URI when the code is released. The default value just points to the current master branch which might from the release source code eventually. Upon release the should be generated with a URI using the respective release branch.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Source code links in generated API doc for Node.js SDK point to developers git repo.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Regenerated doc (run sdk/node/makedoc.sh) and checked that links point to master branch on github and not my developer repo
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [n/a] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Thomas Eirich eir@zurich.ibm.com
