### PR TITLE
Fix remaining go vet errors. Resolves #1858

### DIFF
--- a/consensus/obcpbft/broadcast_test.go
+++ b/consensus/obcpbft/broadcast_test.go
@@ -51,7 +51,7 @@ func (m *mockComm) GetNetworkInfo() (*pb.PeerEndpoint, []*pb.PeerEndpoint, error
 func (m *mockComm) GetNetworkHandles() (*pb.PeerID, []*pb.PeerID, error) {
 	var h []*pb.PeerID
 	for n := uint64(0); n < m.n; n++ {
-		h = append(h, &pb.PeerID{fmt.Sprintf("vp%d", n)})
+		h = append(h, &pb.PeerID{Name: fmt.Sprintf("vp%d", n)})
 	}
 	return h[m.self], h, nil
 }
@@ -84,7 +84,7 @@ func TestBroadcast(t *testing.T) {
 	}
 
 	if sentCount < 2 {
-		t.Error("broadcast did not send to all peers: %v", sent)
+		t.Errorf("broadcast did not send to all peers: %v", sent)
 	}
 }
 
@@ -183,6 +183,6 @@ func TestBroadcastUnicast(t *testing.T) {
 	}
 
 	if sentCount != 1 {
-		t.Error("broadcast did not send to dest peer: %v", sent)
+		t.Errorf("broadcast did not send to dest peer: %v", sent)
 	}
 }

--- a/consensus/obcpbft/mock_ledger_test.go
+++ b/consensus/obcpbft/mock_ledger_test.go
@@ -43,7 +43,7 @@ func (hd *HashLedgerDirectory) GetLedgerByPeerID(peerID *protos.PeerID) (consens
 
 func (hd *HashLedgerDirectory) GetPeers() (*protos.PeersMessage, error) {
 	_, network, err := hd.GetNetworkInfo()
-	return &protos.PeersMessage{network}, err
+	return &protos.PeersMessage{Peers: network}, err
 }
 
 func (hd *HashLedgerDirectory) GetPeerEndpoint() (*protos.PeerEndpoint, error) {

--- a/consensus/obcpbft/mock_network_test.go
+++ b/consensus/obcpbft/mock_network_test.go
@@ -64,7 +64,7 @@ func (ep *testEndpoint) getID() uint64 {
 }
 
 func (ep *testEndpoint) getHandle() *pb.PeerID {
-	return &pb.PeerID{fmt.Sprintf("vp%d", ep.id)}
+	return &pb.PeerID{Name: fmt.Sprintf("vp%d", ep.id)}
 }
 
 func (ep *testEndpoint) GetNetworkInfo() (self *pb.PeerEndpoint, network []*pb.PeerEndpoint, err error) {

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -112,14 +112,14 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 			omni.UnicastImpl = func(ocMsg *pb.Message, peer *pb.PeerID) error {
 				dest, _ := getValidatorID(peer)
 				if dest == 0 || dest == 2 {
-					bs[dest].RecvMsg(ocMsg, &pb.PeerID{"vp1"})
+					bs[dest].RecvMsg(ocMsg, &pb.PeerID{Name: "vp1"})
 				}
 				return nil
 			}
 		}
 	}
 
-	err := bs[1].RecvMsg(createOcMsgWithChainTx(1), &pb.PeerID{"vp1"})
+	err := bs[1].RecvMsg(createOcMsgWithChainTx(1), &pb.PeerID{Name: "vp1"})
 	if err != nil {
 		t.Fatalf("External request was not processed by backup: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestViewChangeOnPrimarySilence(t *testing.T) {
 	defer b.Close()
 
 	// Send a request, which will be ignored, triggering view change
-	b.manager.Queue() <- batchMessageEvent{createOcMsgWithChainTx(1), &pb.PeerID{"vp0"}}
+	b.manager.Queue() <- batchMessageEvent{createOcMsgWithChainTx(1), &pb.PeerID{Name: "vp0"}}
 	time.Sleep(time.Second)
 	b.manager.Queue() <- nil
 

--- a/core/crypto/attributes/attributes.go
+++ b/core/crypto/attributes/attributes.go
@@ -204,12 +204,12 @@ func GetValueForAttribute(attributeName string, preK0 []byte, cert *x509.Certifi
 
 func createAttributesHeaderEntry(preK0 []byte) *pb.AttributesMetadataEntry {
 	attKey := getAttributeKey(preK0, HeaderAttributeName)
-	return &pb.AttributesMetadataEntry{HeaderAttributeName, attKey}
+	return &pb.AttributesMetadataEntry{AttributeName: HeaderAttributeName, AttributeKey: attKey}
 }
 
 func createAttributesMetadataEntry(attributeName string, preK0 []byte) *pb.AttributesMetadataEntry {
 	attKey := getAttributeKey(preK0, attributeName)
-	return &pb.AttributesMetadataEntry{attributeName, attKey}
+	return &pb.AttributesMetadataEntry{AttributeName: attributeName, AttributeKey: attKey}
 }
 
 //CreateAttributesMetadataObjectFromCert creates an AttributesMetadata object from certificate "cert", metadata and the attributes keys.
@@ -226,7 +226,7 @@ func CreateAttributesMetadataObjectFromCert(cert *x509.Certificate, metadata []b
 	headerEntry := createAttributesHeaderEntry(preK0)
 	entries = append(entries, headerEntry)
 
-	return &pb.AttributesMetadata{metadata, entries}
+	return &pb.AttributesMetadata{Metadata: metadata, Entries: entries}
 }
 
 //CreateAttributesMetadataFromCert creates the AttributesMetadata from the original metadata and certificate "cert".
@@ -257,7 +257,7 @@ func GetAttributesMetadata(metadata []byte) (*pb.AttributesMetadata, error) {
 func BuildAttributesHeader(attributesHeader map[string]int) ([]byte, error) {
 	var header []byte
 	var headerString string
-	var positions map[int]bool = make(map[int]bool)
+	var positions = make(map[int]bool)
 
 	for k, v := range attributesHeader {
 		if positions[v] {

--- a/core/peer/statetransfer/statetransfer.go
+++ b/core/peer/statetransfer/statetransfer.go
@@ -155,7 +155,7 @@ func NewCoordinatorImpl(stack PartialStack) Coordinator {
 
 	if nil != err {
 		logger.Debug("Error resolving our own PeerID, this shouldn't happen")
-		sts.id = &protos.PeerID{"ERROR_RESOLVING_ID"}
+		sts.id = &protos.PeerID{Name: "ERROR_RESOLVING_ID"}
 	}
 
 	sts.id = ep.ID
@@ -849,7 +849,7 @@ func (sts *coordinatorImpl) syncStateSnapshot(minBlockNumber uint64, peerIDs []*
 				sts.stack.ApplyStateDelta(piece, umDelta)
 				currentStateBlock = piece.BlockNumber
 				if err := sts.stack.CommitStateDelta(piece); nil != err {
-					return fmt.Errorf("%v could not commit state delta from %v after %d deltas: %s", sts.id, counter, peerID, err)
+					return fmt.Errorf("%v could not commit state delta from %v after %d deltas: %s", sts.id, peerID, counter, err)
 				}
 				counter++
 			case <-timer.C:

--- a/core/peer/statetransfer/statetransfer_mock_test.go
+++ b/core/peer/statetransfer/statetransfer_mock_test.go
@@ -74,7 +74,7 @@ func (hd *HashLedgerDirectory) GetLedgerByPeerID(peerID *protos.PeerID) (peer.Bl
 
 func (hd *HashLedgerDirectory) GetPeers() (*protos.PeersMessage, error) {
 	_, network, err := hd.GetNetworkInfo()
-	return &protos.PeersMessage{network}, err
+	return &protos.PeersMessage{Peers: network}, err
 }
 
 func (hd *HashLedgerDirectory) GetPeerEndpoint() (*protos.PeerEndpoint, error) {
@@ -501,7 +501,7 @@ func (mock *MockLedger) ApplyStateDelta(id interface{}, delta *statemgmt.StateDe
 
 	d, r := binary.Uvarint(SimpleStateDeltaToBytes(delta))
 	if r <= 0 {
-		return fmt.Errorf("State delta could not be applied, was not a uint64, %x", delta)
+		return fmt.Errorf("State delta could not be applied, was not a uint64, %x", d)
 	}
 	if !delta.RollBackwards {
 		mock.state += d

--- a/events/producer/eventhelper.go
+++ b/events/producer/eventhelper.go
@@ -22,10 +22,10 @@ import (
 
 //CreateBlockEvent creates a Event from a Block
 func CreateBlockEvent(te *ehpb.Block) *ehpb.Event {
-	return &ehpb.Event{&ehpb.Event_Block{Block: te}}
+	return &ehpb.Event{Event: &ehpb.Event_Block{Block: te}}
 }
 
 //CreateChaincodeEvent creates a Event from a ChaincodeEvent
 func CreateChaincodeEvent(te *ehpb.ChaincodeEvent) *ehpb.Event {
-	return &ehpb.Event{&ehpb.Event_ChaincodeEvent{ChaincodeEvent: te}}
+	return &ehpb.Event{Event: &ehpb.Event_ChaincodeEvent{ChaincodeEvent: te}}
 }

--- a/membersrvc/ca/eca_test.go
+++ b/membersrvc/ca/eca_test.go
@@ -367,7 +367,7 @@ func TestReadUserSet(t *testing.T) {
 		t.Errorf("Failed to read user set: [%s]", err.Error())
 	}
 
-	t.Logf("number of users: [%s]", len(resp.Users))
+	t.Logf("number of users: [%d]", len(resp.Users))
 
 }
 

--- a/membersrvc/ca/tlsca.go
+++ b/membersrvc/ca/tlsca.go
@@ -83,7 +83,7 @@ func (tlsca *TLSCA) startTLSCAA(srv *grpc.Server) {
 func (tlscap *TLSCAP) ReadCACertificate(ctx context.Context, in *pb.Empty) (*pb.Cert, error) {
 	Trace.Println("grpc TLSCAP:ReadCACertificate")
 
-	return &pb.Cert{tlscap.tlsca.raw}, nil
+	return &pb.Cert{Cert: tlscap.tlsca.raw}, nil
 }
 
 // CreateCertificate requests the creation of a new enrollment certificate by the TLSCA.
@@ -134,7 +134,7 @@ func (tlscap *TLSCAP) ReadCertificate(ctx context.Context, in *pb.TLSCertReadReq
 		return nil, err
 	}
 
-	return &pb.Cert{raw}, nil
+	return &pb.Cert{Cert: raw}, nil
 }
 
 // RevokeCertificate revokes a certificate from the TLSCA.  Not yet implemented.

--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -127,12 +127,12 @@ func requestTLSCertificate(t *testing.T) {
 	timestamp := google_protobuf.Timestamp{Seconds: int64(now.Second()), Nanos: int32(now.Nanosecond())}
 
 	req := &membersrvc.TLSCertCreateReq{
-		&timestamp,
-		&membersrvc.Identity{Id: id + "-" + uuid},
-		&membersrvc.PublicKey{
+		Ts: &timestamp,
+		Id: &membersrvc.Identity{Id: id + "-" + uuid},
+		Pub: &membersrvc.PublicKey{
 			Type: membersrvc.CryptoType_ECDSA,
 			Key:  pubraw,
-		}, nil}
+		}, Sig: nil}
 
 	rawreq, _ := proto.Marshal(req)
 	r, s, err := ecdsa.Sign(rand.Reader, priv, primitives.Hash(rawreq))
@@ -144,7 +144,7 @@ func requestTLSCertificate(t *testing.T) {
 
 	R, _ := r.MarshalText()
 	S, _ := s.MarshalText()
-	req.Sig = &membersrvc.Signature{membersrvc.CryptoType_ECDSA, R, S}
+	req.Sig = &membersrvc.Signature{Type: membersrvc.CryptoType_ECDSA, R: R, S: S}
 
 	resp, err := tlscaP.CreateCertificate(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This fixes the remaining go vet errors as identified by running `go vet ./... | grep -v '^vendor\/' | grep -v '^exit\ status\ 1'`
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1858 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Ran `make checks`. No new tests as there is no new functionality.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
