### PR TITLE
path correction for both membersrvc and peer binaries

### DIFF
--- a/sdk/node/bin/run-unit-tests.sh
+++ b/sdk/node/bin/run-unit-tests.sh
@@ -29,9 +29,9 @@ init() {
    # Initialize variables
    FABRIC=$GOPATH/src/github.com/hyperledger/fabric
    LOGDIR=/tmp/node-sdk-unit-test
-   MSEXE=$FABRIC/membersrvc/membersrvc
+   MSEXE=$FABRIC/build/bin/membersrvc
    MSLOGFILE=$LOGDIR/membersrvc.log
-   PEEREXE=$FABRIC/peer/peer
+   PEEREXE=$FABRIC/build/bin/peer
    PEERLOGFILE=$LOGDIR/peer.log
    UNITTEST=$FABRIC/sdk/node/test/unit
    EXAMPLES=$FABRIC/examples/chaincode/go


### PR DESCRIPTION
## Description

Path correction in node-sdk unit test script 
## Motivation and Context

As per the Makefile changes,  membersrv and peer binaries will be generated and placed  under $FABRIC/build/bin folder, hence changing the paths for those binaries
## How Has This Been Tested?

Ran node-sdk unit tests (Though few tests were failing , raise another issue #1872 for the same )
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [] Either no new documentation is required by this change, OR I added new documentation
- [] Either no new tests are required by this change, OR I added new tests
- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: rasara@us.ibm.com
