### PR TITLE
Fix asset management test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ images-clean: $(patsubst %,%-image-clean, $(IMAGES))
 node-sdk:
 	cp ./protos/*.proto ./sdk/node/lib/protos
 	cp ./membersrvc/protos/*.proto ./sdk/node/lib/protos
-	cd ./sdk/node && npm install && sudo npm install -g typescript && sudo npm install typings --global && typings install
+	cd ./sdk/node && sudo apt-get install npm && npm install && sudo npm install -g typescript && sudo npm install typings --global && typings install
 	cd ./sdk/node && tsc
 	cd ./sdk/node && ./makedoc.sh
 

--- a/sdk/node/bin/run-unit-tests.sh
+++ b/sdk/node/bin/run-unit-tests.sh
@@ -29,12 +29,28 @@ init() {
    # Initialize variables
    FABRIC=$GOPATH/src/github.com/hyperledger/fabric
    LOGDIR=/tmp/node-sdk-unit-test
-   MSEXE=$FABRIC/membersrvc/membersrvc
+   MSEXE=$FABRIC/build/bin/membersrvc
    MSLOGFILE=$LOGDIR/membersrvc.log
-   PEEREXE=$FABRIC/peer/peer
+   PEEREXE=$FABRIC/build/bin/peer
    PEERLOGFILE=$LOGDIR/peer.log
    UNITTEST=$FABRIC/sdk/node/test/unit
    EXAMPLES=$FABRIC/examples/chaincode/go
+
+   # If the executables don't exist where they belong, build them now in place
+   if [ ! -f $MSEXE ]; then
+      cd $FABRIC/membersrvc
+      go build
+      MSEXE=`pwd`/membersrvc
+   fi
+   if [ ! -f $PEEREXE ]; then
+      cd $FABRIC/peer
+      go build
+      PEEREXE=`pwd`/peer
+   fi
+
+   # Always run peer with security and privacy enabled
+   export CORE_SECURITY_ENABLED=true
+   export CORE_SECURITY_PRIVACY=true
 
    # Clean up if anything remaining from previous run
    stopMemberServices


### PR DESCRIPTION
Change unit test script to enable security and privacy in the peer.
## Description

Enable security and privacy when starting peer.
Also, if the membersrvc and peer executable does not exist in the expected place, just go ahead and build them manually.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixing automated tests for node-sdk

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1872 
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

By running "make node-sdk-unit-tests"

<!--- If this PR does not contain a new test case, explain why. -->

Fixing a test case
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [N/A] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Keith Smith bksmith@us.ibm.com
