### PR TITLE
Stabilize PBFT under stress with periodic viewchange

### DIFF
--- a/bddtests/.behaverc
+++ b/bddtests/.behaverc
@@ -4,4 +4,3 @@ tags=~@issue_724
 			~@issueUtxo
 			~@issue_477
 			~@issue_680
-			~@issue_1874

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -1014,3 +1014,55 @@ Feature: lanching 3 peers
              | vp0  | vp1 | vp3 |
              Then I should get a JSON response from peers with "OK" = "0"
              | vp0  | vp1 | vp3 |
+#@doNotDecompose
+#    @wip
+@issue_1873
+       Scenario Outline: 4 peers and 1 membersrvc, consensus works if vp0 is stopped TTT3
+            Given we compose "<ComposeFile>"
+            And I use the following credentials for querying peers:
+               | peer |   username  |    secret    |
+               | vp0  |  test_user0 | MS9qrN8hFjlE |
+               | vp1  |  test_user1 | jGlNl6ImkuDo |
+               | vp2  |  test_user2 | zMflqOKezFiA |
+               | vp3  |  test_user3 | vWdLCE00vJy0 |
+            And I register with CA supplying username "test_user0" and secret "MS9qrN8hFjlE" on peers:
+               | vp0 |
+
+            When requesting "/chain" from "vp0"
+            Then I should get a JSON response with "height" = "1"
+
+            # Deploy
+            When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+               | arg1 |  arg2 | arg3 | arg4 |
+               |  a   |  100  |  b   |  200 |
+            Then I should have received a chaincode name
+            Then I wait up to "<WaitTime>" seconds for transaction to be committed to peers:
+               | vp0  | vp1 | vp2 | vp3 |
+
+            When requesting "/chain" from "vp0"
+            Then I should get a JSON response with "height" = "2"
+
+            # STOP vp0
+            Given I stop peers:
+               | vp0  |
+            And I wait "5" seconds
+
+            And I register with CA supplying username "test_user1" and secret "jGlNl6ImkuDo" on peers:
+               | vp1 |
+
+            When I invoke chaincode "example2" function name "invoke" on "vp1" "5" times
+               |arg1|arg2|arg3|
+               | a  | b  | 1 |
+            Then I should have received a transactionID
+            #Then I wait up to "120" seconds for transaction to be committed to peers:
+            #      | vp0  | vp1 | vp2 | vp3 |
+            And I wait "120" seconds
+            When I query chaincode "example2" function name "query" with value "a" on peers:
+               | vp1 | vp2 | vp3 |
+            Then I should get a JSON response from peers with "OK" = "95"
+               | vp1 | vp2 | vp3 |
+            Examples: Consensus Options
+               |          ComposeFile                       |   WaitTime   |
+              #    |   docker-compose-4-consensus-classic.yml   |      60      |
+               |   docker-compose-4-consensus-batch.yml     |      60      |
+              #    |   docker-compose-4-consensus-sieve.yml     |      60

--- a/consensus/executor/executor.go
+++ b/consensus/executor/executor.go
@@ -97,6 +97,8 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 
 		info := co.rawExecutor.GetBlockchainInfo()
 
+		logger.Debugf("Committed block %d with hash %x to chain", info.Height-1, info.CurrentBlockHash)
+
 		co.consumer.Committed(et.tag, info)
 	case rollbackEvent:
 		logger.Debug("Executor is processing an rollbackEvent")

--- a/consensus/executor/executor.go
+++ b/consensus/executor/executor.go
@@ -138,7 +138,7 @@ func (co *coordinatorImpl) ProcessEvent(event events.Event) events.Event {
 				co.consumer.StateUpdated(et.tag, nil)
 				return nil
 			}
-			logger.Warning("State transfer did not complete successfully but is recoverable, trying again: %s", err)
+			logger.Warningf("State transfer did not complete successfully but is recoverable, trying again: %s", err)
 			et.peers = nil // Broaden the peers included in recover to all connected
 		}
 	default:

--- a/consensus/helper/helper.go
+++ b/consensus/helper/helper.go
@@ -226,7 +226,7 @@ func (h *Helper) CommitTxBatch(id interface{}, metadata []byte) (*pb.Block, erro
 		return nil, fmt.Errorf("Failed to get the block at the head of the chain: %v", err)
 	}
 
-	logger.Debug("Committed block with %d transactions, intended to include %d", len(block.Transactions), len(h.curBatch))
+	logger.Debugf("Committed block with %d transactions, intended to include %d", len(block.Transactions), len(h.curBatch))
 
 	return block, nil
 }

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -129,11 +129,11 @@ func (op *obcBatch) submitToLeader(req *Request) events.Event {
 	leader := op.pbft.primary(op.pbft.view)
 	if leader == op.pbft.id && op.pbft.activeView {
 		return op.leaderProcReq(req)
-	} else {
-		logger.Debugf("Replica %d add request %v to its outstanding store", op.pbft.id, req)
-		op.outstandingReqs[req] = struct{}{}
-		op.startTimerIfOutstandingRequests()
 	}
+
+	logger.Debugf("Replica %d add request %v to its outstanding store", op.pbft.id, req)
+	op.outstandingReqs[req] = struct{}{}
+	op.startTimerIfOutstandingRequests()
 
 	return nil
 }

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -204,7 +204,20 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	b.broadcaster.Wait()
 
 	if len(b.outstandingReqs) != 0 {
-		t.Fatalf("All requests should have been resubmitted")
+		t.Fatalf("All requests should have been resubmitted after exec")
+	}
+
+	// Add two more requests
+	b.outstandingReqs[createPbftRequestWithChainTx(3, 0)] = struct{}{}
+	b.outstandingReqs[createPbftRequestWithChainTx(4, 0)] = struct{}{}
+
+	b.pbft.currentExec = nil
+
+	b.manager.Queue() <- viewChangedEvent{}
+	b.manager.Queue() <- nil
+
+	if len(b.outstandingReqs) != 0 {
+		t.Fatalf("All requests should have been resubmitted after view change")
 	}
 }
 

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -378,6 +378,8 @@ func (instance *pbftCore) ProcessEvent(e events.Event) events.Event {
 		if instance.skipInProgress {
 			instance.retryStateTransfer(nil)
 		}
+		// We will delay new view processing sometimes
+		return instance.processNewView()
 	case nullRequestEvent:
 		instance.nullRequestHandler()
 	case workEvent:

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1449,13 +1449,143 @@ func TestNetworkPeriodicViewChangeMissing(t *testing.T) {
 	}
 }
 
+// TestViewChangeCannotExecuteToCheckpoint tests a replica mid-execution, which receives a view change to a checkpoint above its watermarks
+// but does _not_ have enough commit certificates to reach the checkpoint. state should transfer
+func TestViewChangeCannotExecuteToCheckpoint(t *testing.T) {
+	instance := newPbftCore(3, loadConfig(), &omniProto{
+		broadcastImpl:       func(b []byte) {},
+		getStateImpl:        func() []byte { return []byte("state") },
+		signImpl:            func(b []byte) ([]byte, error) { return b, nil },
+		verifyImpl:          func(senderID uint64, signature []byte, message []byte) error { return nil },
+		invalidateStateImpl: func() {},
+	}, &inertTimerFactory{})
+	instance.activeView = false
+	instance.view = 1
+	newViewBaseSeqNo := uint64(10)
+	nextExec := uint64(6)
+	instance.currentExec = &nextExec
+
+	for i := instance.lastExec; i < newViewBaseSeqNo; i++ {
+		commit := &Commit{View: 0, SequenceNumber: i}
+		prepare := &Prepare{View: 0, SequenceNumber: i}
+		instance.certStore[msgID{v: 0, n: i}] = &msgCert{
+			digest:     "", // null request
+			prePrepare: &PrePrepare{View: 0, SequenceNumber: i},
+			prepare:    []*Prepare{prepare, prepare, prepare},
+			commit:     []*Commit{commit, commit, commit},
+		}
+	}
+
+	vset := make([]*ViewChange, 3)
+
+	cset := []*ViewChange_C{
+		{
+			SequenceNumber: newViewBaseSeqNo,
+			Id:             base64.StdEncoding.EncodeToString([]byte("Ten")),
+		},
+	}
+
+	for i := 0; i < 3; i++ {
+		// Replica 0 sent checkpoints for 100
+		vset[i] = &ViewChange{
+			H:    newViewBaseSeqNo,
+			Cset: cset,
+		}
+	}
+
+	xset := make(map[uint64]string)
+	xset[11] = ""
+
+	instance.lastExec = 9
+
+	instance.newViewStore[1] = &NewView{
+		View:      1,
+		Vset:      vset,
+		Xset:      xset,
+		ReplicaId: 1,
+	}
+
+	if _, ok := instance.processNewView().(viewChangedEvent); !ok {
+		t.Fatalf("Should have processed the new view")
+	}
+
+	if !instance.skipInProgress {
+		t.Fatalf("Should have done state transfer")
+	}
+}
+
+// TestViewChangeCanExecuteToCheckpoint tests a replica mid-execution, which receives a view change to a checkpoint above its watermarks
+// but which has enough commit certificates to reach the checkpoint. State should not transfer and executions should trigger the view change
+func TestViewChangeCanExecuteToCheckpoint(t *testing.T) {
+	instance := newPbftCore(3, loadConfig(), &omniProto{
+		broadcastImpl: func(b []byte) {},
+		getStateImpl:  func() []byte { return []byte("state") },
+		signImpl:      func(b []byte) ([]byte, error) { return b, nil },
+		verifyImpl:    func(senderID uint64, signature []byte, message []byte) error { return nil },
+		skipToImpl: func(s uint64, id []byte, replicas []uint64) {
+			t.Fatalf("Should not have performed state transfer, should have caught up via execution")
+		},
+	}, &inertTimerFactory{})
+	instance.activeView = false
+	instance.view = 1
+	instance.lastExec = 5
+	newViewBaseSeqNo := uint64(10)
+	nextExec := uint64(6)
+	instance.currentExec = &nextExec
+
+	for i := instance.lastExec + 1; i <= newViewBaseSeqNo; i++ {
+		commit := &Commit{View: 0, SequenceNumber: i}
+		prepare := &Prepare{View: 0, SequenceNumber: i}
+		instance.certStore[msgID{v: 0, n: i}] = &msgCert{
+			digest:     "", // null request
+			prePrepare: &PrePrepare{View: 0, SequenceNumber: i},
+			prepare:    []*Prepare{prepare, prepare, prepare},
+			commit:     []*Commit{commit, commit, commit},
+		}
+	}
+
+	vset := make([]*ViewChange, 3)
+
+	cset := []*ViewChange_C{
+		{
+			SequenceNumber: newViewBaseSeqNo,
+			Id:             base64.StdEncoding.EncodeToString([]byte("Ten")),
+		},
+	}
+
+	for i := 0; i < 3; i++ {
+		// Replica 0 sent checkpoints for 100
+		vset[i] = &ViewChange{
+			H:    newViewBaseSeqNo,
+			Cset: cset,
+		}
+	}
+
+	xset := make(map[uint64]string)
+	xset[11] = ""
+
+	instance.lastExec = 9
+
+	instance.newViewStore[1] = &NewView{
+		View:      1,
+		Vset:      vset,
+		Xset:      xset,
+		ReplicaId: 1,
+	}
+
+	if instance.processNewView() != nil {
+		t.Fatalf("Should not have processed the new view")
+	}
+
+	events.SendEvent(instance, execDoneEvent{})
+
+	if !instance.activeView {
+		t.Fatalf("Should have finished processing new view after executions")
+	}
+}
+
 func TestViewWithOldSeqNos(t *testing.T) {
 	instance := newPbftCore(3, loadConfig(), &omniProto{
-		//viewChangeImpl: func(v uint64) {},
-		//skipToImpl: func(s uint64, id []byte, replicas []uint64) {
-		//skipped = true
-		//},
-		//invalidateStateImpl: func() {},
 		broadcastImpl: func(b []byte) {},
 		signImpl:      func(b []byte) ([]byte, error) { return b, nil },
 		verifyImpl:    func(senderID uint64, signature []byte, message []byte) error { return nil },

--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1533,7 +1533,7 @@ func TestViewChangeCanExecuteToCheckpoint(t *testing.T) {
 	nextExec := uint64(6)
 	instance.currentExec = &nextExec
 
-	for i := instance.lastExec + 1; i <= newViewBaseSeqNo; i++ {
+	for i := nextExec + 1; i <= newViewBaseSeqNo; i++ {
 		commit := &Commit{View: 0, SequenceNumber: i}
 		prepare := &Prepare{View: 0, SequenceNumber: i}
 		instance.certStore[msgID{v: 0, n: i}] = &msgCert{

--- a/consensus/obcpbft/requeststore.go
+++ b/consensus/obcpbft/requeststore.go
@@ -1,0 +1,160 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import (
+	"reflect"
+	"sort"
+	"time"
+)
+
+type orderedRequests []*Request
+
+func (a *orderedRequests) Len() int {
+	return len(*a)
+}
+func (a *orderedRequests) Swap(i, j int) {
+	(*a)[i], (*a)[j] = (*a)[j], (*a)[i]
+}
+func (a *orderedRequests) Less(i, j int) bool {
+	if (*a)[i].Timestamp == nil {
+		// a[i] has no timestamp, handle it later, TODO, eventually this should be an error
+		return false
+	}
+
+	if (*a)[j].Timestamp == nil {
+		// a[j] has no timestamp, handle it later, TODO, eventually this should be an error
+		return true
+	}
+
+	iTime := time.Unix((*a)[i].Timestamp.Seconds, int64((*a)[i].Timestamp.Nanos))
+	jTime := time.Unix((*a)[j].Timestamp.Seconds, int64((*a)[j].Timestamp.Nanos))
+
+	return jTime.After(iTime)
+}
+
+func (a *orderedRequests) add(request *Request) {
+	for _, req := range *a {
+		if reflect.DeepEqual(req, request) {
+			return
+		}
+	}
+
+	*a = append(*a, request)
+	sort.Sort(a)
+}
+
+func (a *orderedRequests) adds(requests []*Request) {
+	for _, req := range requests {
+		a.add(req)
+	}
+}
+
+func (a *orderedRequests) remove(request *Request) bool {
+	if len(*a) == 0 {
+		return false
+	}
+	defer sort.Sort(a)
+	var lastReq *Request
+	for i, req := range *a {
+		(*a)[i] = lastReq
+		if reflect.DeepEqual(req, request) {
+			*a = (*a)[1:]
+			return true
+		}
+		lastReq = req
+	}
+	// This isn't the most efficient, but this should be a degenerate case
+	(*a)[0] = lastReq
+	return false
+}
+
+func (a *orderedRequests) removes(requests []*Request) bool {
+	allSuccess := true
+	for _, req := range requests {
+		if !a.remove(req) {
+			allSuccess = false
+		}
+	}
+
+	return allSuccess
+}
+
+func (a *orderedRequests) empty() {
+	*a = nil
+}
+
+type requestStore struct {
+	outstandingRequests *orderedRequests
+	pendingRequests     *orderedRequests
+}
+
+// newRequestStore creates a new requestStore.
+func newRequestStore() *requestStore {
+	return &requestStore{
+		outstandingRequests: &orderedRequests{},
+		pendingRequests:     &orderedRequests{},
+	}
+}
+
+// storeOutstanding adds a request to the outstanding request list
+func (rs *requestStore) storeOutstanding(request *Request) {
+	rs.outstandingRequests.add(request)
+}
+
+// storePending adds a request to the pending request list
+func (rs *requestStore) storePending(request *Request) {
+	rs.pendingRequests.add(request)
+}
+
+// storePending adds a slice of requests to the pending request list
+func (rs *requestStore) storePendings(requests []*Request) {
+	rs.pendingRequests.adds(requests)
+}
+
+// remove deletes the request from both the outstanding and pending lists, it returns whether it was found in each list respectively
+func (rs *requestStore) remove(request *Request) (outstanding, pending bool) {
+	outstanding = rs.outstandingRequests.remove(request)
+	pending = rs.pendingRequests.remove(request)
+	return
+}
+
+// getNextNonPending returns up to the next n outstanding, but not pending requests
+func (rs *requestStore) hasNonPending() bool {
+	return len(*(rs.outstandingRequests)) > len(*(rs.pendingRequests))
+}
+
+// getNextNonPending returns up to the next n outstanding, but not pending requests
+func (rs *requestStore) getNextNonPending(n int) []*Request {
+	result := make([]*Request, n)
+	i := 0
+outer:
+	for _, oreq := range *(rs.outstandingRequests) {
+		if i == n {
+			break
+		}
+		for _, preq := range *(rs.pendingRequests) {
+			if reflect.DeepEqual(preq, oreq) {
+				continue outer
+			}
+		}
+		result[i] = oreq
+		i++
+	}
+
+	return result[:i]
+}

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -468,10 +468,16 @@ func (instance *pbftCore) processNewView2(nv *NewView) events.Event {
 		if n <= instance.h {
 			continue
 		}
+
+		req, ok := instance.reqStore[d]
+		if !ok {
+			logger.Criticalf("Replica %d is missing request for assigned prepare after fetching, this indicates a serious bug", instance.id)
+		}
 		preprep := &PrePrepare{
 			View:           instance.view,
 			SequenceNumber: n,
 			RequestDigest:  d,
+			Request:        req,
 			ReplicaId:      instance.id,
 		}
 		cert := instance.getCert(instance.view, n)

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -342,7 +342,7 @@ func (instance *pbftCore) processNewView() events.Event {
 	if speculativeLastExec < cp.SequenceNumber {
 		canExecuteToTarget := true
 	outer:
-		for seqNo := speculativeLastExec; seqNo <= cp.SequenceNumber; seqNo++ {
+		for seqNo := speculativeLastExec + 1; seqNo <= cp.SequenceNumber; seqNo++ {
 			found := false
 			for idx, cert := range instance.certStore {
 				if idx.n != seqNo {

--- a/core/ledger/test/ledger_test.go
+++ b/core/ledger/test/ledger_test.go
@@ -469,7 +469,7 @@ var _ = Describe("Ledger", func() {
 		It("verifies the blockchain", func() {
 			// Verify the chain
 			for lowBlock := uint64(0); lowBlock < ledgerPtr.GetBlockchainSize()-1; lowBlock++ {
-				Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(uint64(0)))
+				Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(lowBlock))
 			}
 			for highBlock := ledgerPtr.GetBlockchainSize() - 1; highBlock > 0; highBlock-- {
 				Expect(ledgerPtr.VerifyChain(highBlock, 0)).To(Equal(uint64(0)))
@@ -483,23 +483,19 @@ var _ = Describe("Ledger", func() {
 				goodBlock, _ := ledgerPtr.GetBlockByNumber(i)
 				ledgerPtr.PutRawBlock(badBlock, i)
 				for lowBlock := uint64(0); lowBlock < ledgerPtr.GetBlockchainSize()-1; lowBlock++ {
-					if i >= lowBlock {
-						expected := uint64(i + 1)
-						if i == ledgerPtr.GetBlockchainSize()-1 {
-							expected--
-						}
-						Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(expected))
+					if i == ledgerPtr.GetBlockchainSize()-1 {
+						Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(uint64(i)))
+					} else if i >= lowBlock {
+						Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(uint64(i + 1)))
 					} else {
-						Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(uint64(0)))
+						Expect(ledgerPtr.VerifyChain(ledgerPtr.GetBlockchainSize()-1, lowBlock)).To(Equal(lowBlock))
 					}
 				}
 				for highBlock := ledgerPtr.GetBlockchainSize() - 1; highBlock > 0; highBlock-- {
-					if i <= highBlock {
-						expected := uint64(i + 1)
-						if i == highBlock {
-							expected--
-						}
-						Expect(ledgerPtr.VerifyChain(highBlock, 0)).To(Equal(expected))
+					if i == highBlock {
+						Expect(ledgerPtr.VerifyChain(highBlock, 0)).To(Equal(uint64(i)))
+					} else if i < highBlock {
+						Expect(ledgerPtr.VerifyChain(highBlock, 0)).To(Equal(uint64(i + 1)))
 					} else {
 						Expect(ledgerPtr.VerifyChain(highBlock, 0)).To(Equal(uint64(0)))
 					}
@@ -510,8 +506,6 @@ var _ = Describe("Ledger", func() {
 		// Test edge cases
 		It("tests some edge cases", func() {
 			_, err := ledgerPtr.VerifyChain(2, 10)
-			Expect(err).To(Equal(ledger.ErrOutOfBounds))
-			_, err = ledgerPtr.VerifyChain(2, 2)
 			Expect(err).To(Equal(ledger.ErrOutOfBounds))
 			_, err = ledgerPtr.VerifyChain(0, 100)
 			Expect(err).To(Equal(ledger.ErrOutOfBounds))

--- a/core/peer/statetransfer/statetransfer.go
+++ b/core/peer/statetransfer/statetransfer.go
@@ -551,7 +551,7 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 	logger.Debugf("%v verified chain from %d to %d, with target of %d", sts.id, lowBlock, lastGoodBlockNumber, targetBlock)
 
 	if err != nil {
-		logger.Criticalf("%v had something go wrong while validating the blockchain, not sure if we will recover: %s", sts.id)
+		logger.Criticalf("%v had something go wrong while validating the blockchain, not sure if we will recover: %s", sts.id, err)
 		return false
 	}
 

--- a/core/peer/statetransfer/statetransfer_mock_test.go
+++ b/core/peer/statetransfer/statetransfer_mock_test.go
@@ -551,15 +551,15 @@ func (mock *MockLedger) GetCurrentStateHash() ([]byte, error) {
 
 func (mock *MockLedger) VerifyBlockchain(start, finish uint64) (uint64, error) {
 	current := start
+
+	cb, err := mock.GetBlock(current)
+	if nil != err {
+		return current, err
+	}
+
 	for {
 		if current == finish {
-			return 0, nil
-		}
-
-		cb, err := mock.GetBlock(current)
-
-		if nil != err {
-			return current, err
+			return finish, nil
 		}
 
 		next := current
@@ -573,19 +573,20 @@ func (mock *MockLedger) VerifyBlockchain(start, finish uint64) (uint64, error) {
 		nb, err := mock.GetBlock(next)
 
 		if nil != err {
-			return current, err
+			return current, nil
 		}
 
 		nbh, err := mock.HashBlock(nb)
 
 		if nil != err {
-			return current, err
+			return current, nil
 		}
 
 		if !bytes.Equal(nbh, cb.PreviousBlockHash) {
 			return current, nil
 		}
 
+		cb = nb
 		current = next
 	}
 }


### PR DESCRIPTION
## Description

This changeset contains three new commits, to accomplish three things.
1. If a view change occurs and selects an initial checkpoint which is higher than our lastExec, but which can be reached via commit certificates, we delay processing of the new view until execution completes.
2. On view change, resubmit the outstanding requests, and enhance the per transaction logging by printing transaction UUID when debugging is enabled.
3. Changes the ledger's `VerifyChain` function to consistently return the lowest validated block number consistently. @srderson If you especially could take a look at the last commit to this change.
## Motivation and Context

This changeset is motivated by the busywork stress2b test.  The problems were observed with the following environmental configuration:

```
CORE_PBFT_GENERAL_TIMEOUT_REQUEST=10s
CORE_PBFT_GENERAL_TIMEOUT_VIEWCHANGE=10s
CORE_PBFT_GENERAL_VIEWCHANGEPERIOD=1
CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=1s
```

This causes the network to change views at every checkpoint, resulting in over 1000 view changes during the execution.

This causes frequent small state transfers, and revealed a bug in the ledger's `VerifyChain` function.  This function would typically return the lowest block number in the range whose hash could be validated, but under other error conditions, like missing blocks, failing hashes, etc., the function would return the block number which had the error, sometimes leading state transfer to believe that a particular block was valid, when in fact it was otherwise corrupt.
## How Has This Been Tested?

These changes were tested against the stress2b busywork test as described above.  As issues were revealed, new unit tests were added for each.
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
