### PR TITLE
dont use high range ephemeral ports

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -12,7 +12,7 @@ server:
         # cadir: ".ca"
 
         # port the CA services are listening on
-        port: ":50051"
+        port: ":20051"
 
         # TLS certificate and key file paths
         tls:
@@ -44,7 +44,7 @@ aca:
         attribute-entry-2: user1;bank_a;position;Software Engineer;2015-07-13T00:00:00-03:00;;
         attribute-entry-3: user2;bank_a;company;ACompany;2001-02-02T00:00:00-03:00;;
         attribute-entry-4: user2;bank_a;position;Project Manager;2001-02-02T00:00:00-03:00;;
-    address: localhost:50051
+    address: localhost:20051
     server-name: acap
     enabled: true
 
@@ -175,15 +175,15 @@ peer:
 
 
     # The Address this Peer will listen on
-    listenAddress: 0.0.0.0:41414
+    listenAddress: 0.0.0.0:21212
     # The Address this Peer will bind to for providing services
-    address: 0.0.0.0:41414
+    address: 0.0.0.0:21212
     # Whether the Peer should programmatically determine the address to bind to.
     # This case is useful for docker containers.
     addressAutoDetect: false
 
     # Peer port to accept connections on
-    port:    41414
+    port:    21212
     # Setting for runtime.GOMAXPROCS(n). If n < 1, it does not change the current setting
     gomaxprocs: -1
     workers: 2
@@ -251,11 +251,11 @@ peer:
     # PKI member services properties
     pki:
         eca:
-            paddr: localhost:50051
+            paddr: localhost:20051
         tca:
-            paddr: localhost:50051
+            paddr: localhost:20051
         tlsca:
-            paddr: localhost:50051
+            paddr: localhost:20051
         tls:
             enabled: false
             rootcert:
@@ -277,10 +277,10 @@ peer:
         # testNodes:
         #    - node   : 1
         #      ip     : 127.0.0.1
-        #      port   : 41414
+        #      port   : 21212
         #    - node   : 2
         #      ip     : 127.0.0.1
-        #      port   : 41414
+        #      port   : 21212
 
         # Should the discovered nodes and their reputations
         # be stored in DB and persisted between restarts

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -316,7 +316,7 @@ func executeDeployTransaction(t *testing.T, url string) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
 		t.Fail()
@@ -478,7 +478,7 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -576,7 +576,7 @@ func TestExecuteQuery(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -659,7 +659,7 @@ func TestExecuteInvokeInvalidTransaction(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -720,7 +720,7 @@ func TestExecuteInvalidQuery(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -791,7 +791,7 @@ func TestChaincodeInvokeChaincode(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -904,7 +904,7 @@ func TestChaincodeInvokeChaincodeErrorCase(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -1125,7 +1125,7 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -1288,7 +1288,7 @@ func TestRangeQuery(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
@@ -1358,7 +1358,7 @@ func TestGetEvent(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:40303"
+	peerAddress := "0.0.0.0:21212"
 
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -81,7 +81,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go
-	peerAddress := "0.0.0.0:41726"
+	peerAddress := "0.0.0.0:21726"
 	lis, err := net.Listen("tcp", peerAddress)
 	if err != nil {
 		t.Fail()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Tests were failing with port conflicts likely due to high ephemeral port selection.
## Motivation and Context

Choosing lower order ports will lessen/avoid port conflicts.

Fixes #1884
## How Has This Been Tested?

Ran unit and behave tests after the port changes.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by:muralisr@us.ibm.com
