### PR TITLE
skip @issue_1874 behave test until code fix is merged

### DIFF
--- a/bddtests/.behaverc
+++ b/bddtests/.behaverc
@@ -4,3 +4,4 @@ tags=~@issue_724
 			~@issueUtxo
 			~@issue_477
 			~@issue_680
+			~@issue_1874

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -907,7 +907,7 @@ Feature: lanching 3 peers
         When I query chaincode "example2" function name "query" with value "a" on peers:
             | vp0  | vp1 | vp2 |
 	    Then I should get a JSON response from peers with "OK" = "21"
-            | vp0  | vp1 | vp2 | 
+            | vp0  | vp1 | vp2 |
         When I unconditionally query chaincode "example2" function name "query" with value "a" on peers:
             | vp3  |
 	    Then I should get a JSON response from peers with "Error" = "Error: state may be inconsistent, cannot query"
@@ -964,6 +964,7 @@ Feature: lanching 3 peers
 
 #    @doNotDecompose
 #    @wip
+     @issue_1874
     Scenario: chaincode example02 with 4 peers, two stopped
         Given we compose "docker-compose-4-consensus-batch.yml"
 	    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:


### PR DESCRIPTION
## Description

Behave test is for #1874 for which the code is not merged yet. Skip test for now
## Motivation and Context

Let CI runs complete until we have #1874 fix.
## How Has This Been Tested?

Ran behave test with updated .behavevrc file. @issue_1874 test is skipped
## Checklist:
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Tuan Dang tdang@us.ibm.com
