### PR TITLE
Use the default google_protobuf package name

### DIFF
--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hyperledger/fabric/consensus/obcpbft/events"
 	pb "github.com/hyperledger/fabric/protos"
 
-	google_protobuf "google/protobuf"
+	"google/protobuf"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/spf13/viper"

--- a/core/admin.go
+++ b/core/admin.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 
-	google_protobuf "google/protobuf"
+	"google/protobuf"
 
 	pb "github.com/hyperledger/fabric/protos"
 )

--- a/core/crypto/node_eca.go
+++ b/core/crypto/node_eca.go
@@ -20,7 +20,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
-	protobuf "google/protobuf"
+	"google/protobuf"
 	"time"
 
 	membersrvc "github.com/hyperledger/fabric/membersrvc/protos"
@@ -362,7 +362,7 @@ func (node *nodeImpl) getEnrollmentCertificateFromECA(id, pw string) (interface{
 	}
 
 	req := &membersrvc.ECertCreateReq{
-		Ts:   &protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
+		Ts:   &google_protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
 		Id:   &membersrvc.Identity{Id: id},
 		Tok:  &membersrvc.Token{Tok: []byte(pw)},
 		Sign: &membersrvc.PublicKey{Type: membersrvc.CryptoType_ECDSA, Key: signPub},

--- a/core/rest/api.go
+++ b/core/rest/api.go
@@ -22,7 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	google_protobuf1 "google/protobuf"
+	"google/protobuf"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger"
@@ -75,7 +75,7 @@ func NewOpenchainServerWithPeerInfo(peerServer PeerInfo) (*ServerOpenchain, erro
 
 // GetBlockchainInfo returns information about the blockchain ledger such as
 // height, current block hash, and previous block hash.
-func (s *ServerOpenchain) GetBlockchainInfo(ctx context.Context, e *google_protobuf1.Empty) (*pb.BlockchainInfo, error) {
+func (s *ServerOpenchain) GetBlockchainInfo(ctx context.Context, e *google_protobuf.Empty) (*pb.BlockchainInfo, error) {
 	blockchainInfo, err := s.ledger.GetBlockchainInfo()
 	if blockchainInfo.Height == 0 {
 		return nil, fmt.Errorf("No blocks in blockchain.")
@@ -122,7 +122,7 @@ func (s *ServerOpenchain) GetBlockByNumber(ctx context.Context, num *pb.BlockNum
 
 // GetBlockCount returns the current number of blocks in the blockchain data
 // structure.
-func (s *ServerOpenchain) GetBlockCount(ctx context.Context, e *google_protobuf1.Empty) (*pb.BlockCount, error) {
+func (s *ServerOpenchain) GetBlockCount(ctx context.Context, e *google_protobuf.Empty) (*pb.BlockCount, error) {
 	// Total number of blocks in the blockchain.
 	size := s.ledger.GetBlockchainSize()
 
@@ -157,12 +157,12 @@ func (s *ServerOpenchain) GetTransactionByUUID(ctx context.Context, txUUID strin
 }
 
 // GetPeers returns a list of all peer nodes currently connected to the target peer.
-func (s *ServerOpenchain) GetPeers(ctx context.Context, e *google_protobuf1.Empty) (*pb.PeersMessage, error) {
+func (s *ServerOpenchain) GetPeers(ctx context.Context, e *google_protobuf.Empty) (*pb.PeersMessage, error) {
 	return s.peerInfo.GetPeers()
 }
 
 // GetPeerEndpoint returns PeerEndpoint info of target peer.
-func (s *ServerOpenchain) GetPeerEndpoint(ctx context.Context, e *google_protobuf1.Empty) (*pb.PeersMessage, error) {
+func (s *ServerOpenchain) GetPeerEndpoint(ctx context.Context, e *google_protobuf.Empty) (*pb.PeersMessage, error) {
 	peers := []*pb.PeerEndpoint{}
 	peerEndpoint, err := s.peerInfo.GetPeerEndpoint()
 	if err != nil {

--- a/membersrvc/ca/eca_test.go
+++ b/membersrvc/ca/eca_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	protobuf "google/protobuf"
+	"google/protobuf"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
@@ -82,7 +82,7 @@ func enrollUser(user *User) error {
 	}
 
 	req := &pb.ECertCreateReq{
-		Ts:   &protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
+		Ts:   &google_protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
 		Id:   &pb.Identity{Id: user.enrollID},
 		Tok:  &pb.Token{Tok: user.enrollPwd},
 		Sign: &pb.PublicKey{Type: pb.CryptoType_ECDSA, Key: signPub},
@@ -406,7 +406,7 @@ func TestCreateCertificatePairBadIdentity(t *testing.T) {
 	ecap := &ECAP{eca}
 
 	req := &pb.ECertCreateReq{
-		Ts:   &protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
+		Ts:   &google_protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
 		Id:   &pb.Identity{Id: "badIdentity"},
 		Tok:  &pb.Token{Tok: testUser.enrollPwd},
 		Sign: &pb.PublicKey{Type: pb.CryptoType_ECDSA, Key: []byte{0}},
@@ -425,7 +425,7 @@ func TestCreateCertificatePairBadToken(t *testing.T) {
 	ecap := &ECAP{eca}
 
 	req := &pb.ECertCreateReq{
-		Ts:   &protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
+		Ts:   &google_protobuf.Timestamp{Seconds: time.Now().Unix(), Nanos: 0},
 		Id:   &pb.Identity{Id: testUser.enrollID},
 		Tok:  &pb.Token{Tok: []byte("badPassword")},
 		Sign: &pb.PublicKey{Type: pb.CryptoType_ECDSA, Key: []byte{0}},

--- a/membersrvc/ca/tlsca_test.go
+++ b/membersrvc/ca/tlsca_test.go
@@ -32,7 +32,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
-	google_protobuf "google/protobuf"
+	"google/protobuf"
 	"path/filepath"
 
 	"github.com/golang/protobuf/proto"

--- a/peer/main.go
+++ b/peer/main.go
@@ -34,7 +34,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	google_protobuf "google/protobuf"
+	"google/protobuf"
 
 	"github.com/howeyc/gopass"
 	"github.com/op/go-logging"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Remove all aliases for `google/protobuf` imports and use the default package name (`google_protobuf`) across the board in Fabric.
## Motivation and Context

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1899
## How Has This Been Tested?

This PR does not contain a new test case, as it's a compile time/import fix.

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: JonathanLevi
