### PR TITLE
REST API: Fix JSON encoding

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -292,14 +292,16 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 	// Returns /var/hyperledger/production/client/
 	localStore := getRESTFilePath()
 
+	encoder := json.NewEncoder(rw)
+
 	// If the user is already logged in, return OK. Otherwise return error.
 	if _, err := os.Stat(localStore + "loginToken_" + enrollmentID); err == nil {
 		rw.WriteHeader(http.StatusOK)
-		fmt.Fprintf(rw, "{\"OK\": \"User %s is already logged in.\"}", enrollmentID)
+		encoder.Encode(restResult{OK: fmt.Sprintf("User %s is already logged in.", enrollmentID)})
 		restLogger.Infof("User '%s' is already logged in.\n", enrollmentID)
 	} else {
 		rw.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintf(rw, "{\"Error\": \"User %s must log in.\"}", enrollmentID)
+		encoder.Encode(restResult{Error: fmt.Sprintf("User %s must log in.", enrollmentID)})
 		restLogger.Infof("User '%s' must log in.\n", enrollmentID)
 	}
 

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -599,7 +599,7 @@ func (s *ServerOpenchainREST) GetBlockchainInfo(rw web.ResponseWriter, req *web.
 	if err != nil {
 		// Failure
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+		encoder.Encode(restResult{Error: err.Error()})
 	} else {
 		// Success
 		rw.WriteHeader(http.StatusOK)
@@ -613,11 +613,13 @@ func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.R
 	// Parse out the Block id
 	blockNumber, err := strconv.ParseUint(req.PathParams["id"], 10, 64)
 
+	encoder := json.NewEncoder(rw)
+
 	// Check for proper Block id syntax
 	if err != nil {
 		// Failure
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"Block id must be an integer (uint64).\"}")
+		encoder.Encode(restResult{Error: "Block id must be an integer (uint64)."})
 	} else {
 		// Retrieve Block from blockchain
 		block, err := s.server.GetBlockByNumber(context.Background(), &pb.BlockNumber{Number: blockNumber})
@@ -631,11 +633,10 @@ func (s *ServerOpenchainREST) GetBlockByNumber(rw web.ResponseWriter, req *web.R
 			default:
 				rw.WriteHeader(http.StatusInternalServerError)
 			}
-			fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
+			encoder.Encode(restResult{Error: err.Error()})
 		} else {
 			// Success
 			rw.WriteHeader(http.StatusOK)
-			encoder := json.NewEncoder(rw)
 			encoder.Encode(block)
 		}
 	}

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -1674,13 +1674,13 @@ func (s *ServerOpenchainREST) GetPeers(rw web.ResponseWriter, req *web.Request) 
 	if err != nil {
 		// Failure
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err)
-		restLogger.Errorf("{\"Error\": \"Querying network peers -- %s\"}", err)
+		encoder.Encode(restResult{Error: err.Error()})
+		restLogger.Errorf("Error: Querying network peers -- %s", err)
 	} else if err1 != nil {
 		// Failure
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(rw, "{\"Error\": \"%s\"}", err1)
-		restLogger.Errorf("{\"Error\": \"Accesing target peer endpoint data  -- %s\"}", err1)
+		encoder.Encode(restResult{Error: err1.Error()})
+		restLogger.Errorf("Error: Accesing target peer endpoint data -- %s", err1)
 	} else {
 		currentPeerFound := false
 		peersList := peers.Peers

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -1705,16 +1705,8 @@ func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
 	fmt.Fprintf(rw, "{\"Error\": \"Openchain endpoint not found.\"}")
 }
 
-// StartOpenchainRESTServer initializes the REST service and adds the required
-// middleware and routes.
-func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
-	// Initialize the REST service object
-	restLogger.Infof("Initializing the REST service on %s, TLS is %s.", viper.GetString("rest.address"), (map[bool]string{true: "enabled", false: "disabled"})[comm.TLSEnabled()])
+func buildOpenchainRESTRouter() *web.Router {
 	router := web.New(ServerOpenchainREST{})
-
-	// Record the pointer to the underlying ServerOpenchain and Devops objects.
-	serverOpenchain = server
-	serverDevops = devops
 
 	// Add middleware
 	router.Middleware((*ServerOpenchainREST).SetOpenchainServer)
@@ -1744,6 +1736,21 @@ func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
 
 	// Add not found page
 	router.NotFound((*ServerOpenchainREST).NotFound)
+
+	return router
+}
+
+// StartOpenchainRESTServer initializes the REST service and adds the required
+// middleware and routes.
+func StartOpenchainRESTServer(server *ServerOpenchain, devops *core.Devops) {
+	// Initialize the REST service object
+	restLogger.Infof("Initializing the REST service on %s, TLS is %s.", viper.GetString("rest.address"), (map[bool]string{true: "enabled", false: "disabled"})[comm.TLSEnabled()])
+
+	// Record the pointer to the underlying ServerOpenchain and Devops objects.
+	serverOpenchain = server
+	serverDevops = devops
+
+	router := buildOpenchainRESTRouter()
 
 	// Start server
 	if comm.TLSEnabled() {

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -647,21 +647,22 @@ func (s *ServerOpenchainREST) GetTransactionByUUID(rw web.ResponseWriter, req *w
 	// Retrieve the transaction matching the UUID
 	tx, err := s.server.GetTransactionByUUID(context.Background(), txUUID)
 
+	encoder := json.NewEncoder(rw)
+
 	// Check for Error
 	if err != nil {
 		switch err {
 		case ErrNotFound:
 			rw.WriteHeader(http.StatusNotFound)
-			fmt.Fprintf(rw, "{\"Error\": \"Transaction %s is not found.\"}", txUUID)
+			encoder.Encode(restResult{Error: fmt.Sprintf("Transaction %s is not found.", txUUID)})
 		default:
 			rw.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(rw, "{\"Error\": \"Error retrieving transaction %s: %s.\"}", txUUID, err)
-			restLogger.Errorf("{\"Error\": \"Error retrieving transaction %s: %s.\"}", txUUID, err)
+			encoder.Encode(restResult{Error: fmt.Sprintf("Error retrieving transaction %s: %s.", txUUID, err)})
+			restLogger.Errorf("Error retrieving transaction %s: %s", txUUID, err)
 		}
 	} else {
 		// Return existing transaction
 		rw.WriteHeader(http.StatusOK)
-		encoder := json.NewEncoder(rw)
 		encoder.Encode(tx)
 		restLogger.Infof("Successfully retrieved transaction: %s", txUUID)
 	}

--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -1666,7 +1666,7 @@ func (s *ServerOpenchainREST) GetPeers(rw web.ResponseWriter, req *web.Request) 
 // had not been defined.
 func (s *ServerOpenchainREST) NotFound(rw web.ResponseWriter, r *web.Request) {
 	rw.WriteHeader(http.StatusNotFound)
-	fmt.Fprintf(rw, "{\"Error\": \"Openchain endpoint not found.\"}")
+	json.NewEncoder(rw).Encode(restResult{Error: "Openchain endpoint not found."})
 }
 
 func buildOpenchainRESTRouter() *web.Router {

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -192,3 +192,24 @@ func TestServerOpenchainREST_API_GetTransactionByUUID(t *testing.T) {
 		t.Errorf("Expected a proper error when retrieive transaction with bad UUID")
 	}
 }
+
+func TestServerOpenchainREST_API_GetEnrollmentID(t *testing.T) {
+	initGlobalServerOpenchain(t)
+
+	// Start the HTTP REST test server
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+
+	body := performHTTPGet(t, httpServer.URL+"/registrar/NON-EXISTING-USER")
+	res := parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when retrieving non-existing user, but got none")
+	}
+
+	body = performHTTPGet(t, httpServer.URL+"/registrar/BAD-\"-CHARS")
+	res = parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when retrieving non-existing user, but got none")
+	}
+
+}

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -213,3 +213,24 @@ func TestServerOpenchainREST_API_GetEnrollmentID(t *testing.T) {
 	}
 
 }
+
+func TestServerOpenchainREST_API_GetPeers(t *testing.T) {
+	initGlobalServerOpenchain(t)
+
+	// Start the HTTP REST test server
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+
+	body := performHTTPGet(t, httpServer.URL+"/network/peers")
+	var msg protos.PeersMessage
+	err := json.Unmarshal(body, &msg)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if len(msg.Peers) != 1 {
+		t.Errorf("Expected a list of 1 peer but got %d peers", len(msg.Peers))
+	}
+	if msg.Peers[0].ID.Name != "jdoe" {
+		t.Errorf("Expected a 'jdoe' peer but got '%s'", msg.Peers[0].ID.Name)
+	}
+}

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -212,6 +212,13 @@ func TestServerOpenchainREST_API_GetBlockByNumber(t *testing.T) {
 	if res4.Error == "" {
 		t.Errorf("Expected an error when retrieving non-existing block, but got none")
 	}
+
+	// Illegal block number
+	body = performHTTPGet(t, httpServer.URL+"/chain/blocks/NOT_A_NUMBER")
+	res = parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when URL doesn't have a number, but got none")
+	}
 }
 
 func TestServerOpenchainREST_API_GetTransactionByUUID(t *testing.T) {

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -561,3 +561,13 @@ func TestServerOpenchainREST_API_Chaincode_Query(t *testing.T) {
 		t.Errorf("Expected 'get_owner_query_result' but got '%v'", res.Result.Message)
 	}
 }
+
+func TestServerOpenchainREST_API_NotFound(t *testing.T) {
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+	body := performHTTPGet(t, httpServer.URL+"/non-existing")
+	res := parseRESTResult(t, body)
+	if res.Error != "Openchain endpoint not found." {
+		t.Errorf("Expected an error when accessing non-existing endpoint, but got %#v", res.Error)
+	}
+}

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/protos"
+)
+
+func performHTTPGet(t *testing.T, url string) []byte {
+	response, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("Error attempt to access /chain: %v", err)
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	response.Body.Close()
+	if err != nil {
+		t.Fatalf("Error reading HTTP resposne body: %v", err)
+	}
+	return body
+}
+
+func parseRESTResult(t *testing.T, body []byte) restResult {
+	var res restResult
+	err := json.Unmarshal(body, &res)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	return res
+}
+
+func initGlobalServerOpenchain(t *testing.T) {
+	var err error
+	serverOpenchain, err = NewOpenchainServerWithPeerInfo(new(peerInfo))
+	if err != nil {
+		t.Fatalf("Error creating OpenchainServer: %s", err)
+	}
+}
+
+func TestServerOpenchainREST_API_GetBlockchainInfo(t *testing.T) {
+	// Construct a ledger with 0 blocks.
+	ledger := ledger.InitTestLedger(t)
+
+	initGlobalServerOpenchain(t)
+
+	// Start the HTTP REST test server
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+
+	body := performHTTPGet(t, httpServer.URL+"/chain")
+	res := parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when retrieving empty blockchain, but got none")
+	}
+
+	// add 3 blocks to the ledger
+	buildTestLedger1(ledger, t)
+
+	body3 := performHTTPGet(t, httpServer.URL+"/chain")
+	var blockchainInfo3 protos.BlockchainInfo
+	err := json.Unmarshal(body3, &blockchainInfo3)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if blockchainInfo3.Height != 3 {
+		t.Errorf("Expected blockchain height to be 3 but got %v", blockchainInfo3.Height)
+	}
+
+	// add 5 more blocks more to the ledger
+	buildTestLedger2(ledger, t)
+
+	body8 := performHTTPGet(t, httpServer.URL+"/chain")
+	var blockchainInfo8 protos.BlockchainInfo
+	err = json.Unmarshal(body8, &blockchainInfo8)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if blockchainInfo8.Height != 8 {
+		t.Errorf("Expected blockchain height to be 8 but got %v", blockchainInfo8.Height)
+	}
+}
+
+func TestServerOpenchainREST_API_GetBlockByNumber(t *testing.T) {
+	// Construct a ledger with 0 blocks.
+	ledger := ledger.InitTestLedger(t)
+
+	initGlobalServerOpenchain(t)
+
+	// Start the HTTP REST test server
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+
+	body := performHTTPGet(t, httpServer.URL+"/chain/blocks/0")
+	res := parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when retrieving block 0 of an empty blockchain, but got none")
+	}
+
+	// add 3 blocks to the ledger
+	buildTestLedger1(ledger, t)
+
+	// Retrieve the first block from the blockchain (block number = 0)
+	body0 := performHTTPGet(t, httpServer.URL+"/chain/blocks/0")
+	var block0 protos.Block
+	err := json.Unmarshal(body0, &block0)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+
+	// Retrieve the 3rd block from the blockchain (block number = 2)
+	body2 := performHTTPGet(t, httpServer.URL+"/chain/blocks/2")
+	var block2 protos.Block
+	err = json.Unmarshal(body2, &block2)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if len(block2.Transactions) != 2 {
+		t.Errorf("Expected block to contain 2 transactions but got %v", len(block2.Transactions))
+	}
+
+	// Retrieve the 5th block from the blockchain (block number = 4), which
+	// should fail because the ledger has only 3 blocks.
+	body4 := performHTTPGet(t, httpServer.URL+"/chain/blocks/4")
+	res4 := parseRESTResult(t, body4)
+	if res4.Error == "" {
+		t.Errorf("Expected an error when retrieving non-existing block, but got none")
+	}
+}
+
+func TestServerOpenchainREST_API_GetTransactionByUUID(t *testing.T) {
+	startTime := time.Now().Unix()
+
+	// Construct a ledger with 3 blocks.
+	ledger := ledger.InitTestLedger(t)
+	buildTestLedger1(ledger, t)
+
+	initGlobalServerOpenchain(t)
+
+	// Start the HTTP REST test server
+	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
+	defer httpServer.Close()
+
+	body := performHTTPGet(t, httpServer.URL+"/transactions/NON-EXISTING-UUID")
+	res := parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when retrieving non-existing transaction, but got none")
+	}
+
+	block1, err := ledger.GetBlockByNumber(1)
+	if err != nil {
+		t.Fatalf("Can't fetch first block from ledger: %v", err)
+	}
+	firstTx := block1.Transactions[0]
+
+	body1 := performHTTPGet(t, httpServer.URL+"/transactions/"+firstTx.Uuid)
+	var tx1 protos.Transaction
+	err = json.Unmarshal(body1, &tx1)
+	if err != nil {
+		t.Fatalf("Invalid JSON response: %v", err)
+	}
+	if tx1.Uuid != firstTx.Uuid {
+		t.Errorf("Expected transaction uuid to be '%v' but got '%v'", firstTx.Uuid, tx1.Uuid)
+	}
+	if tx1.Timestamp.Seconds < startTime {
+		t.Errorf("Expected transaction timestamp (%v) to be after the start time (%v)", tx1.Timestamp.Seconds, startTime)
+	}
+}

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -185,4 +185,10 @@ func TestServerOpenchainREST_API_GetTransactionByUUID(t *testing.T) {
 	if tx1.Timestamp.Seconds < startTime {
 		t.Errorf("Expected transaction timestamp (%v) to be after the start time (%v)", tx1.Timestamp.Seconds, startTime)
 	}
+
+	badBody := performHTTPGet(t, httpServer.URL+"/transactions/with-\"-chars-in-the-URL")
+	badRes := parseRESTResult(t, badBody)
+	if badRes.Error == "" {
+		t.Errorf("Expected a proper error when retrieive transaction with bad UUID")
+	}
 }


### PR DESCRIPTION
Use proper JSON encoder when building responses of the REST API. This PR fixes all the endpoints **except**:
-  `/registrar/*` endpoints - still in progress (I'd appreciate feedback before I keep working on those)
- `/devops/*` endpoints - these are deprecated, so I skipped them.
## Description

See #1475 for the original problem of hand-crafting JSON responses. This PR adds unit-tests of the REST API, and fixes the JSON encoding to use a proper JSON encoder even for simple `{"Error": "..."}` responses.

Note that in order to add unit-tests for the REST API (which were non-existing) I did some small refactoring in `rest_api.go`.

The changes are split into several commits, each commit fixing (and testing) only one endpoint. It will therefore makes sense to read this review commit-by-commit. (Let me know if this should be broken to separate PRs.)
## Motivation and Context

Fixes #1475 
## How Has This Been Tested?

Added unit tests to the REST API, except the deprecated `/devops/*` endpoints (and currently also misses the `/registrar/*` - still in progress).

Also ran a peer and tried the problematic curl request from #1475 and verified that the response is indeed valid JSON (the error string is properly escaped).
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Dov Murik <dmurik@us.ibm.com>
