### PR TITLE
Fix viper flags binding so that command line options work Issue-578

### DIFF
--- a/peer/main.go
+++ b/peer/main.go
@@ -247,11 +247,11 @@ func main() {
 
 	flags.BoolVarP(&chaincodeDevMode, "peer-chaincodedev", "", false, "Whether peer in chaincode development mode")
 
-	viper.BindPFlag("peer_tls_enabled", flags.Lookup("peer-tls-enabled"))
-	viper.BindPFlag("peer_tls_cert_file", flags.Lookup("peer-tls-cert-file"))
-	viper.BindPFlag("peer_tls_key_file", flags.Lookup("peer-tls-key-file"))
-	viper.BindPFlag("peer_gomaxprocs", flags.Lookup("peer-gomaxprocs"))
-	viper.BindPFlag("peer_discovery_enabled", flags.Lookup("peer-discovery-enabled"))
+	viper.BindPFlag("peer.tls.enabled", flags.Lookup("peer-tls-enabled"))
+	viper.BindPFlag("peer.tls.cert.file", flags.Lookup("peer-tls-cert-file"))
+	viper.BindPFlag("peer.tls.key.file", flags.Lookup("peer-tls-key-file"))
+	viper.BindPFlag("peer.gomaxprocs", flags.Lookup("peer-gomaxprocs"))
+	viper.BindPFlag("peer.discovery.enabled", flags.Lookup("peer-discovery-enabled"))
 
 	// Now set the configuration file.
 	viper.SetConfigName(cmdRoot) // Name of config file (without extension)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

This fixes the viper flag bindings so that settings via yaml configuration can be overridden using command line options (aka flags).
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #578
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Before:

```
$ peer node start --peer-chaincodedev --peer-tls-enabled=true --peer-tls-cert-file=./bddtests/tlsca.cert --peer-tls-key-file=./bddtests/tlsca.priv
18:17:55.995 [crypto] main -> INFO 001 Log level recognized 'info', set to INFO
18:17:55.998 [main] serve -> INFO 002 Running in chaincode development mode
...
18:17:56.203 [rest] StartOpenchainRESTServer -> INFO 017 Initializing the REST service on 0.0.0.0:5000, TLS is disabled.

```

After:

```
$ peer node start --peer-chaincodedev --peer-tls-enabled=true --peer-tls-cert-file=./bddtests/tlsca.cert --peer-tls-key-file=./bddtests/tlsca.priv
18:20:54.909 [crypto] main -> INFO 001 Log level recognized 'info', set to INFO
18:20:54.914 [main] serve -> INFO 002 Running in chaincode development mode
...
18:20:55.073 [rest] StartOpenchainRESTServer -> INFO 018 Initializing the REST service on 0.0.0.0:5000, TLS is enabled.

```

Note: Several people have argued that the broken flags should simply be removed rather than fixed but not all flags can be removed because some settings can only be set using flags so I've concluded that until we do a complete overall of the configuration framework it is better to minimize the changes by simply fixing what's broken and leaving it at that for now.

Credits go to @kchristidis for finding the bug.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Arnaud J Le Hors lehors@us.ibm.com
