### PR TITLE
Issue 1844 (multi-account with TCert attributes) workaround

### DIFF
--- a/examples/chaincode/go/asset_management02/asset.yaml
+++ b/examples/chaincode/go/asset_management02/asset.yaml
@@ -1,0 +1,505 @@
+# CA server parameters
+#
+server:
+        # current version of the CA
+        version: "0.1"
+
+        # limits the number of operating system threads used by the CA
+        gomaxprocs: 2
+
+        # path to the OBC state directory and CA state subdirectory
+        rootpath: "/tmp/hyperledger/production"
+        cadir: ".membersrvc"
+
+        # port the CA services are listening on
+        port: ":50051"
+
+        # TLS certificate and key file paths
+        tls:
+#              certfile: "/var/hyperledger/production/.ca/tlsca.cert"
+#              keyfile: "/var/hyperledger/production/.ca/tlsca.priv"
+
+security:
+    # Can be 256 or 384
+    # Must be the same as in core.yaml
+    level: 256
+
+# Enabling/disabling different logging levels of the CA.
+#
+logging:
+        trace: 0
+        info: 1
+        warning: 1
+        error: 1
+        panic: 1
+
+# TCA configuration for attribute encryption
+tca:
+    # Enabling/disabling attributes encryption, if is enabled attributes within the certificate will be encrypted using a specific key for each attribute,
+    # in otherwise cleartext attribute value will be added into the certificate.
+    attribute-encryption:
+        enabled: false
+
+# Default attributes for Attribute Certificate Authority
+aca:
+    attributes:
+        attribute-entry-0: admin;bank_a;role;issuer;2015-01-01T00:00:00-03:00;;
+        attribute-entry-1: alice;bank_a;role;client;2016-01-01T00:00:00-03:00;;		
+        attribute-entry-2: alice;bank_a;account1;22222-00001;2016-01-01T00:00:00-03:00;;
+        attribute-entry-3: alice;bank_a;account2;22222-00002;2016-01-01T00:00:00-03:00;;
+        attribute-entry-4: alice;bank_a;account3;22222-00003;2016-01-01T00:00:00-03:00;;
+        attribute-entry-5: alice;bank_a;account4;22222-00004;2016-01-01T00:00:00-03:00;;
+        attribute-entry-6: alice;bank_a;contactInfo;alice@gmail.com;2016-01-01T00:00:00-03:00;;
+        attribute-entry-7: bob;bank_a;role;client;2015-02-02T00:00:00-03:00;;
+        attribute-entry-8: bob;bank_a;account1;11111-00001;2016-01-01T00:00:00-03:00;;
+        attribute-entry-9: bob;bank_a;account2;11111-00002;2015-02-02T00:00:00-03:00;;
+        attribute-entry-10: bob;bank_a;account3;11111-00003;2015-02-02T00:00:00-03:00;;
+        attribute-entry-11: bob;bank_a;contactInfo;bob@yahoo.com;2015-02-02T00:00:00-03:00;;
+
+    address: localhost:50051
+    server-name: acap
+    enabled: true
+
+# Default users to be registered with the CA on first launch.  The role is a binary OR
+# of the different roles a user can have:
+#
+# - simple client such as a wallet: CLIENT
+# - non-validating peer: PEER
+# - validating client: VALIDATOR
+# - auditing client: AUDITOR
+#
+eca:
+        affiliations:
+           banks_and_institutions:
+              banks:
+                  - bank_a
+                  - bank_b
+                  - bank_c
+              institutions:
+                  - institution_a
+        users:
+                # <EnrollmentID>: <role (1:client, 2: peer, 4: validator, 8: auditor)> <EnrollmentPWD> <Affiliation> <Affiliation_Role>
+                alice: 1 NPKYL39uKbkj bank_a	00001
+                bob: 1 DRJ23pEQl16a bank_a	00002
+                admin: 1 6avZQLwcUe9b bank_a	00003
+
+                vp: 4 f3489fy98ghf
+
+pki:
+          validity-period:
+                 # Setting the update property will prevent the invocation of the update_validity_period system chaincode to update the validity period.
+                 update: false
+                 chaincodeHash: 6091c3abd07c18edd6ef48ae24cfe409522f7defb51e4103dfa61ca3012386380c1b179f904375e253f20f4b2c5c848299988e65d8b80cb3f6b3d848b6fb2230
+                 # TLS Settings for communications to update the validity period
+                 tls:
+                         enabled: false
+                         cert:
+                                file: testdata/server1.pem
+                         key:
+                                file: testdata/server1.key
+                         # The server name use to verify the hostname returned by TLS handshake
+                         server-host-override:
+                 devops-address: 0.0.0.0:40404
+
+
+###############################################################################
+#
+#    CLI section
+#
+###############################################################################
+cli:
+
+    # The address that the cli process will use for callbacks from chaincodes
+    address: 0.0.0.0:30304
+
+
+
+###############################################################################
+#
+#    REST section
+#
+###############################################################################
+rest:
+
+    # Enable/disable setting for the REST service. It is recommended to disable
+    # REST service on validators in production deployment and use non-validating
+    # nodes to host REST service
+    enabled: true
+
+    # The address that the REST service will listen on for incoming requests.
+    address: 0.0.0.0:5000
+
+
+###############################################################################
+#
+#    LOGGING section
+#
+###############################################################################
+logging:
+
+    # Valid logging levels are case-insensitive strings chosen from
+
+    #     CRITICAL | ERROR | WARNING | NOTICE | INFO | DEBUG
+
+    # Logging 'module' names are also strings, however valid module names are
+    # defined at runtime and are not checked for validity during option
+    # processing.
+
+    # Default logging levels are specified here for each of the obc-peer
+    # commands. For commands that have subcommands, the defaults also apply to
+    # all subcommands of the command. These logging levels can be overridden
+    # on the command line using the --logging-level command-line option, or by
+    # setting the CORE_LOGGING_LEVEL environment variable.
+
+    # The logging level specification is of the form
+
+    #     [<module>[,<module>...]=]<level>[:[<module>[,<module>...]=]<level>...]
+
+    # A logging level by itself is taken as the overall default. Otherwise,
+    # overrides for individual or groups of modules can be specified using the
+    # <module>[,<module>...]=<level> syntax.
+
+    # Examples:
+    #   info                                       - Set default to INFO
+    #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
+    #   chaincode=info:main=debug:db=debug:warning - Same as above
+    peer:      debug
+    crypto:    debug
+    status:    warning
+    stop:      warning
+    login:     warning
+    vm:        warning
+    chaincode: warning
+
+
+###############################################################################
+#
+#    Peer section
+#
+###############################################################################
+peer:
+
+    # Peer Version following version semantics as described here http://semver.org/
+    # The Peer supplies this version in communications with other Peers
+    version:  0.1.0
+
+    # The Peer id is used for identifying this Peer instance.
+    id: jdoe
+
+    # The privateKey to be used by this peer
+    # privateKey: 794ef087680e2494fa4918fd8fb80fb284b50b57d321a31423fe42b9ccf6216047cea0b66fe8365a8e3f2a8140c6866cc45852e63124668bee1daa9c97da0c2a
+
+    # The networkId allows for logical seperation of networks
+    # networkId: dev
+    # networkId: test
+    networkId: dev
+
+    Dockerfile:  |
+        from golang:1.6
+        # Install RocksDB
+        RUN cd /opt  && git clone --branch v4.1 --single-branch --depth 1 https://github.com/facebook/rocksdb.git && cd rocksdb
+        WORKDIR /opt/rocksdb
+        RUN make shared_lib
+        ENV LD_LIBRARY_PATH=/opt/rocksdb:$LD_LIBRARY_PATH
+        RUN apt-get update && apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev
+        # Copy GOPATH src and install Peer
+        COPY src $GOPATH/src
+        RUN mkdir -p /var/hyperledger/db
+        WORKDIR $GOPATH/src/github.com/hyperledger/fabric/
+        RUN CGO_CFLAGS="-I/opt/rocksdb/include" CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy" go install && cp $GOPATH/src/github.com/hyperledger/fabric/core.yaml $GOPATH/bin
+
+    # The Address this Peer will listen on
+    listenAddress: 0.0.0.0:40404
+    # The Address this Peer will bind to for providing services
+    address: 0.0.0.0:40404
+    # Whether the Peer should programmatically determine the address to bind to.
+    # This case is useful for docker containers.
+    addressAutoDetect: false
+
+    # Peer port to accept connections on
+    port:    40404
+    # Peer's setting for GOMAXPROCS
+    gomaxprocs: 2
+    workers: 2
+
+    # Sync related configuration
+    sync:
+        blocks:
+            # Channel size for readonly SyncBlocks messages channel for receiving
+            # blocks from oppositie Peer Endpoints.
+            # NOTE: currently messages are not stored and forwarded, but rather
+            # lost if the channel write blocks.
+            channelSize: 10
+        state:
+            snapshot:
+                # Channel size for readonly syncStateSnapshot messages channel
+                # for receiving state deltas for snapshot from oppositie Peer Endpoints.
+                # NOTE: currently messages are not stored and forwarded, but
+                # rather lost if the channel write blocks.
+                channelSize: 50
+            deltas:
+                # Channel size for readonly syncStateDeltas messages channel for
+                # receiving state deltas for a syncBlockRange from oppositie
+                # Peer Endpoints.
+                # NOTE: currently messages are not stored and forwarded,
+                # but rather lost if the channel write blocks.
+                channelSize: 20
+
+    # Validator defines whether this peer is a validating peer or not, and if
+    # it is enabled, what consensus plugin to load
+    validator:
+        enabled: true
+
+        # Consensus plugin to use. The value is the name of the plugin, e.g. obcpbft, noops
+        # if the given value is not recognized, we will default to noops
+        consensus: noops
+
+        events:
+            # The address that the Event service will be enabled on the validator
+            address: 0.0.0.0:31315
+
+            # total number of events that could be buffered without blocking the
+            # validator sends
+            buffersize: 100
+
+            # milliseconds timeout for producer to send an event.
+            # if < 0, if buffer full, unblocks immediately and not send
+            # if 0, if buffer full, will block and guarantee the event will be sent out
+            # if > 0, if buffer full, blocks till timeout
+            timeout: 10
+        # Setting the validity-period.verification to false will disable the verification
+        # of the validity period in the validator
+        validity-period:
+            verification: false
+
+    # TLS Settings for p2p communications
+    tls:
+        enabled:  false
+        cert:
+            file: testdata/server1.pem
+        key:
+            file: testdata/server1.key
+        # The server name use to verify the hostname returned by TLS handshake
+        server-host-override:
+
+    # PKI member services properties
+    pki:
+        eca:
+            paddr: localhost:50051
+        tca:
+            paddr: localhost:50051
+        tlsca:
+            paddr: localhost:50051
+        tls:
+            enabled: false
+            rootcert:
+                file: tlsca.cert
+            # The server name use to verify the hostname returned by TLS handshake
+            server-host-override:
+
+    # Peer discovery settings.  Controls how this peer discovers other peers
+    discovery:
+
+        # The root nodes are used for bootstrapping purposes, and generally
+        # supplied through ENV variables
+        rootnode:
+
+        # The duration of time between attempts to asks peers for their connected peers
+        period:  5s
+
+        ## leaving this in for example of sub map entry
+        # testNodes:
+        #    - node   : 1
+        #      ip     : 127.0.0.1
+        #      port   : 40404
+        #    - node   : 2
+        #      ip     : 127.0.0.1
+        #      port   : 40404
+
+        # Should the discovered nodes and their reputations
+        # be stored in DB and persisted between restarts
+        persist:    true
+
+        # if peer discovery is off
+        # the peer window will show
+        # only what retrieved by active
+        # peer [true/false]
+        enabled:    true
+
+        # number of workers that
+        # tastes the peers for being
+        # online [1..10]
+        workers: 8
+
+        # the period in seconds with which the discovery
+        # tries to reconnect to successful nodes
+        # 0 means the nodes are not reconnected
+        touchPeriod: 600
+
+        # the maximum nuber of nodes to reconnect to
+        # -1 for unlimited
+        touchMaxNodes: 100
+
+    # Path on the file system where peer will store data
+    # fileSystemPath: .hyperledger/production
+
+    # Path on the file system where peer will store data
+    fileSystemPath: /tmp/hyperledger/production
+
+###############################################################################
+#
+#    VM section
+#
+###############################################################################
+vm:
+
+    # Endpoint of the vm management system.  For docker can be one of the following in general
+    # unix:///var/run/docker.sock
+    # http://localhost:2375
+    # https://localhost:2376
+    endpoint: unix:///var/run/docker.sock
+
+    # settings for docker vms
+    docker:
+        tls:
+            enabled: false
+            cert:
+                file: /path/to/server.pem
+            ca:
+                file: /path/to/ca.pem
+            key:
+                file: /path/to/server-key.pem
+
+###############################################################################
+#
+#    Chaincode section
+#
+###############################################################################
+chaincode:
+
+    # The id is used by the Chaincode stub to register the executing Chaincode
+    # ID with the Peerand is generally supplied through ENV variables
+    # the Path form of ID is provided when deploying the chaincode. The name is
+    # used for all other requests. The name is really a hashcode
+    # returned by the system in response to the deploy transaction. In
+    # development mode where user runs the chaincode, the name can be any string
+    id:
+        path:
+        name: mycc
+
+    golang:
+
+        # This is the basis for the Golang Dockerfile.  Additional commands will
+        # be appended depedendent upon the chaincode specification.
+        Dockerfile:  |
+            from golang:1.6
+            COPY src $GOPATH/src
+            WORKDIR $GOPATH
+
+    # timeout in millisecs for starting up a container and waiting for Register
+    # to come through. 1sec should be plenty for chaincode unit tests
+    startuptimeout: 1000
+
+    #timeout in millisecs for deploying chaincode from a remote repository.
+    deploytimeout: 30000
+
+    #mode - options are "dev", "net"
+    #dev - in dev mode, user runs the chaincode after starting validator from
+    # command line on local machine
+    #net - in net mode validator will run chaincode in a docker container
+
+    mode: net
+
+    installpath: /go/bin/
+
+###############################################################################
+#
+#    Ledger section - ledger configuration encompases both the blockchain
+#    and the state
+#
+###############################################################################
+ledger:
+
+  blockchain:
+
+    # Define the genesis block
+    genesisBlock:
+
+      # Deploy chaincodes into the genesis block
+      # chaincode:
+      #     path: github.com/hyperledger/fabric/core/example/chaincode/chaincode_example01
+      #     type: GOLANG
+      #     constructor:
+      #       func: init
+      #       args:
+      #         - alice
+      #         - "4"
+      #         - bob
+      #         - "10"
+
+    # Setting the deploy-system-chaincode property to false will prevent the
+    # deploying of system chaincode at genesis time.
+    deploy-system-chaincode: false
+
+  state:
+
+    # Control the number state deltas that are maintained. This takes additional
+    # disk space, but allow the state to be rolled backwards and forwards
+    # without the need to replay transactions.
+    deltaHistorySize: 500
+
+    # The data structure in which the state will be stored. Different data
+    # structures may offer different performance characteristics. Options are
+    # 'buckettree' and 'trie'. If not set, the default data structure is the
+    # 'buckettree'. This CANNOT be changed after the DB has been created.
+    dataStructure:
+      # The name of the data structure is for storing the state
+      name: buckettree
+      # The data structure specific configurations
+      configs:
+        # configurations for 'bucketree'. These CANNOT be changed after the DB
+        # has been created. 'numBuckets' defines the number of bins that the
+        # state key-values are to be divided
+        numBuckets: 10009
+        # 'maxGroupingAtEachLevel' defines the number of bins that are grouped
+        #together to construct next level of the merkle-tree (this is applied
+        # repeatedly for constructing the entire tree).
+        maxGroupingAtEachLevel: 10
+
+        # configurations for 'trie'
+        # 'tire' has no additional configurations exposed as yet
+
+
+###############################################################################
+#
+#    Security section - Applied to all entities (client, NVP, VP)
+#
+###############################################################################
+security:
+    # Enable security will force every entity on the network to enroll with obc-ca
+    # and maintain a valid set of certificates in order to communicate with
+    # other peers
+    enabled: true
+    # To enroll NVP or VP with membersrvc. These parameters are for 1 time use.
+    # They will not be valid on subsequent times without un-enroll first.
+    # The values come from off-line registration with obc-ca. For testing, make
+    # sure the values are in membersrvc/membersrvc.yaml file eca.users
+    enrollID: vp
+    enrollSecret: f3489fy98ghf
+    # To enable privacy of transactions (requires security to be enabled). This
+    # encrypts the transaction content during transit and at rest. The state
+    # data is also encrypted
+    privacy: true
+
+    # Can be 256 or 384. If you change here, you have to change also
+    # the same property in membersrvc.yaml to the same value
+    level: 256
+
+    # TCerts related configuration
+    tcert:
+      batch:
+        # The size of the batch of TCerts
+        size:  2
+
+    attributes:
+      enabled: true

--- a/examples/chaincode/go/asset_management02/asset_management02.go
+++ b/examples/chaincode/go/asset_management02/asset_management02.go
@@ -1,0 +1,230 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/op/go-logging"
+)
+
+var myLogger = logging.MustGetLogger("asset_mgm")
+
+var certHandler = NewCertHandler()
+var despositoryHandler = NewDepositoryHandler()
+
+type AssetManagementChaincode struct {
+}
+
+// Assigns assets to a given account ID, only entities with the "issuer" are allowed to call this function
+// Note: this issuer can only allocate balance to one account ID at a time
+// args[0]: investor's TCert
+// args[1]: attribute name inside the investor's TCert that contains investor's account ID
+// args[2]: amount to be assigned to this investor's account ID
+func (t *AssetManagementChaincode) assignOwnership(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
+	myLogger.Debugf("+++++++++++++++++++++++++++++++++++assignOwnership+++++++++++++++++++++++++++++++++")
+
+	if len(args) != 3 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 0")
+	}
+
+	//check is invoker has the correct role, only invokers with the "issuer" role is allowed to
+	//assign asset to owners
+	isAuthorized, err := certHandler.isAuthorized(stub, "issuer")
+	if !isAuthorized {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("user is not aurthorized to assign assets")
+	}
+
+	owner := []byte(args[0])
+	accountAttribute := args[1]
+
+	amount, err := strconv.ParseUint(args[2], 10, 64)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to parse amount" + args[2])
+	}
+
+	//retrieve account IDs from investor's TCert
+	accountIds, err := certHandler.getAccountIDsFromAttribute(owner, []string{accountAttribute})
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to retrieve account Ids from user certificate " + args[1])
+	}
+
+	//retreive investors' contact info (e.g. phone number, email, home address)
+	//from investors' TCert. Ideally, this information shall be encrypted with issuer's pub key or KA key
+	//between investor and issuer, so that only issuer can view such information
+	contactInfo, err := certHandler.getContactInfo(owner)
+	if err != nil {
+		return nil, errors.New("Unable to retrieve contact info from user certificate " + args[1])
+	}
+
+	//call DeposistoryHandler.assign function to put the "amount" and "contact info" under this account ID
+	return nil, despositoryHandler.assign(stub, accountIds[0], contactInfo, amount)
+}
+
+// Moves x number of assets from account A to account B
+// args[0]: Investor TCert that has account IDs which will their balances deducted
+// args[1]: attribute names inside TCert (arg[0]) that countain the account IDs
+// args[2]: Investor TCert that has account IDs which will have their balances increased
+// args[3]: attribute names inside TCert (arg[2]) that countain the account IDs
+func (t *AssetManagementChaincode) transferOwnership(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
+	myLogger.Debugf("+++++++++++++++++++++++++++++++++++transferOwnership+++++++++++++++++++++++++++++++++")
+
+	if len(args) != 5 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 0")
+	}
+
+	fromOwner := []byte(args[0])
+	fromAccountAttributes := strings.Split(args[1], ",")
+
+	toOwner := []byte(args[2])
+	toAccountAttributes := strings.Split(args[3], ",")
+
+	amount, err := strconv.ParseUint(args[4], 10, 64)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to parse amount" + args[4])
+	}
+
+	// retrieve account IDs from "transfer from" TCert
+	fromAccountIds, err := certHandler.getAccountIDsFromAttribute(fromOwner, fromAccountAttributes)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to retrieve contact info from user certificate" + args[1])
+	}
+
+	// retrieve account IDs from "transfer to" TCert
+	toAccountIds, err := certHandler.getAccountIDsFromAttribute(toOwner, toAccountAttributes)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to retrieve contact info from user certificate" + args[3])
+	}
+
+	// retrieve contact info from "transfer to" TCert
+	contactInfo, err := certHandler.getContactInfo(toOwner)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return nil, errors.New("Unable to retrieve contact info from user certificate" + args[4])
+	}
+
+	// call DespositoryHandler.transfer to transfer to transfer "amount" from "from account" IDs to "to account" IDs
+	return nil, despositoryHandler.transfer(stub, fromAccountIds, toAccountIds[0], contactInfo, amount)
+}
+
+// Retrieve the contact information of the investor that owns a particular account ID
+// Note: user contact information shall be encrypted with issuer's pub key or KA key
+// between investor and issuer, so that only issuer can decrypt such information
+// args[0]: one of the many account IDs owned by "some" investor
+func (t *AssetManagementChaincode) getOwnerContactInformation(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
+	myLogger.Debugf("+++++++++++++++++++++++++++++++++++getOwnerContactInformation+++++++++++++++++++++++++++++++++")
+
+	if len(args) != 1 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 0")
+	}
+
+	accountId := args[0]
+
+	email, err := despositoryHandler.QueryContactInfo(stub, accountId)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(email), nil
+}
+
+// Retrieve the account balance information of the investor that owns a particular account ID
+// args[0]: one of the many account IDs owned by "some" investor
+func (t *AssetManagementChaincode) getBalance(stub *shim.ChaincodeStub, args []string) ([]byte, error) {
+	myLogger.Debugf("+++++++++++++++++++++++++++++++++++getBalance+++++++++++++++++++++++++++++++++")
+
+	if len(args) != 1 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 0")
+	}
+
+	accountId := args[0]
+
+	balance, err := despositoryHandler.QueryBalance(stub, accountId)
+	if err != nil {
+		return nil, err
+	}
+
+	//convert balance (uint64) to []byte (Big Endian)
+	ret := make([]byte, 8)
+	binary.BigEndian.PutUint64(ret, balance)
+
+	return ret, nil
+}
+
+// Init initialization, this method will create asset despository in the chaincode state
+func (t *AssetManagementChaincode) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	myLogger.Debugf("********************************Init****************************************")
+
+	myLogger.Info("[AssetManagementChaincode] Init")
+	if len(args) != 0 {
+		return nil, errors.New("Incorrect number of arguments. Expecting 0")
+	}
+
+	return nil, despositoryHandler.createTable(stub)
+}
+
+// Invoke; this method is the interceptor of all invocation transactions, its job is to direct
+// invocation transactions to intended APIs
+func (t *AssetManagementChaincode) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	myLogger.Debugf("********************************Invoke****************************************")
+
+	//	 Handle different functions
+	if function == "assignOwnership" {
+		// Assign ownership
+		return t.assignOwnership(stub, args)
+	} else if function == "transferOwnership" {
+		// Transfer ownership
+		return t.transferOwnership(stub, args)
+	}
+
+	return nil, errors.New("Received unknown function invocation")
+}
+
+// Query; this method is the interceptor of all invocation transactions, its job is to direct
+// query transactions to intended APIs, and return the result back to callers
+func (mp *AssetManagementChaincode) Query(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	myLogger.Debugf("********************************Query****************************************")
+
+	// Handle different functions
+	if function == "getOwnerContactInformation" {
+		return mp.getOwnerContactInformation(stub, args)
+	} else if function == "getBalance" {
+		return mp.getBalance(stub, args)
+	}
+
+	return nil, errors.New("Received unknown function query invocation with function " + function)
+}
+
+func main() {
+
+	//	primitives.SetSecurityLevel("SHA3", 256)
+	err := shim.Start(new(AssetManagementChaincode))
+	if err != nil {
+		myLogger.Debugf("Error starting AssetManagementChaincode: %s", err)
+	}
+
+}

--- a/examples/chaincode/go/asset_management02/asset_management02_test.go
+++ b/examples/chaincode/go/asset_management02/asset_management02_test.go
@@ -1,0 +1,683 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/hyperledger/fabric/core/chaincode"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/chaincode/shim/crypto/attr"
+	"github.com/hyperledger/fabric/core/container"
+	"github.com/hyperledger/fabric/core/crypto"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/membersrvc/ca"
+	pb "github.com/hyperledger/fabric/protos"
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
+)
+
+const (
+	chaincodeStartupTimeoutDefault int = 5000
+)
+
+var (
+	testLogger = logging.MustGetLogger("test")
+
+	lis net.Listener
+
+	administrator crypto.Client
+	alice         crypto.Client
+	bob           crypto.Client
+
+	server *grpc.Server
+	aca    *ca.ACA
+	eca    *ca.ECA
+	tca    *ca.TCA
+	tlsca  *ca.TLSCA
+)
+
+func TestMain(m *testing.M) {
+	removeFolders()
+	setup()
+	go initMembershipSrvc()
+
+	fmt.Println("Wait for some secs for OBCCA")
+	time.Sleep(1 * time.Second)
+
+	go initVP()
+
+	fmt.Println("Wait for some secs for VP")
+	time.Sleep(1 * time.Second)
+
+	go initAssetManagementChaincode()
+
+	fmt.Println("Wait for some secs for Chaincode")
+	time.Sleep(1 * time.Second)
+
+	if err := initClients(); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Wait for 10 secs for chaincode to be started")
+	time.Sleep(1 * time.Second)
+
+	ret := m.Run()
+
+	closeListenerAndSleep(lis)
+
+	defer removeFolders()
+	os.Exit(ret)
+}
+
+//test attribute based role access control
+func TestAuthorization(t *testing.T) {
+	// test authorization, alice is not the issuer so she must not be allowed to
+
+	// create certs carring account IDs for Alice
+	aliceCert, err := alice.GetTCertificateHandlerNext("role", "account1", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//assign assets (This must fail)
+	if err := assignOwnership(alice, aliceCert, "account1", "1000"); err == nil {
+		t.Fatal("Alice doesn't have the assigner role. Assignment should fail.")
+	} else {
+		fmt.Println("------------------------------------------------------------")
+		fmt.Println("------------------------------------------------------------")
+		fmt.Println("------------------------------PASS -------------------------")
+		fmt.Println("------------------------------------------------------------")
+		fmt.Println("------------------------------------------------------------")
+	}
+}
+
+//test the ability to assign assets accounts stored in TCerts
+func TestAssigningAssets(t *testing.T) {
+	// Administrator deploy the chaicode
+	adminCert, err := administrator.GetTCertificateHandlerNext("role")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := deploy(adminCert); err != nil {
+		t.Fatal(err)
+	}
+
+	// create certs carring account IDs for Alice and Bob
+	aliceCert1, err := alice.GetTCertificateHandlerNext("role", "account1", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aliceCert2, err := alice.GetTCertificateHandlerNext("role", "account2", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aliceCert3, err := alice.GetTCertificateHandlerNext("role", "account3", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bobCert1, err := bob.GetTCertificateHandlerNext("role", "account1", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//issuer assign balances to assets to first batch of owners
+	if err := assignOwnership(administrator, aliceCert1, "account1", "100"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assignOwnership(administrator, aliceCert2, "account2", "200"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assignOwnership(administrator, aliceCert3, "account3", "300"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assignOwnership(administrator, bobCert1, "account1", "1000"); err != nil {
+		t.Fatal(err)
+	}
+
+	aliceAccountId1, err := attr.GetValueFrom("account1", aliceCert1.GetCertificate())
+	aliceAccountId2, err := attr.GetValueFrom("account2", aliceCert2.GetCertificate())
+	aliceAccountId3, err := attr.GetValueFrom("account3", aliceCert3.GetCertificate())
+	bobAccountId1, err := attr.GetValueFrom("account1", bobCert1.GetCertificate())
+
+	// Check if balances are assigned correctly
+	alice1BalanceRaw, err := getBalance(string(aliceAccountId1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alicebalance1 := binary.BigEndian.Uint64(alice1BalanceRaw)
+	if alicebalance1 != 100 {
+		t.Fatal("retreived balance does not equal to 100")
+	}
+
+	alice2BalanceRaw, err := getBalance(string(aliceAccountId2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alicebalance2 := binary.BigEndian.Uint64(alice2BalanceRaw)
+	if alicebalance2 != 200 {
+		t.Fatal("retreived balance does not equal to 200")
+	}
+
+	alice3BalanceRaw, err := getBalance(string(aliceAccountId3))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alicebalance3 := binary.BigEndian.Uint64(alice3BalanceRaw)
+	if alicebalance3 != 300 {
+		t.Fatal("retreived balance does not equal to 300")
+	}
+
+	bob1BalanceRaw, err := getBalance(string(bobAccountId1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bobbalance1 := binary.BigEndian.Uint64(bob1BalanceRaw)
+	if bobbalance1 != 1000 {
+		t.Fatal("retreived balance does not equal to 1000")
+	}
+
+	//check if contact info is correctly saved into the chaincode state ledger
+	aliceContactInfo, err := getOwnerContactInformation(string(aliceAccountId1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(aliceContactInfo) != "alice@gmail.com" {
+		t.Fatal("retreived contact info does not equal to alice@gmail.com")
+	}
+
+	bobContactInfo, err := getOwnerContactInformation(string(bobAccountId1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(bobContactInfo) != "bob@yahoo.com" {
+		t.Fatal("retreived contact info does not equal to bob@gmail.com")
+	}
+}
+
+//test the ability to transfer assets from owner account IDs to new owner account ID
+func TestAssetTransfer(t *testing.T) {
+
+	//test transfer
+	// create a new cert for alice used to transfer assets
+	// (note this cert include multiple account Ids belong to alice)
+	aliceCert, err := alice.GetTCertificateHandlerNext("role", "account1", "account2", "account3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a new cert for bob to recieve transfer from Alice
+	// note "account2" is a new account ID that was never used before. Since this new account ID
+	// will create a new record on the account ledger, you must also pass in all required parameters
+	// required to create a new account record in chaincode state (such as user contact info)
+	bobCert, err := bob.GetTCertificateHandlerNext("role", "account2", "contactInfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//transfer 200 assets from Alice to Bob
+	if nil != transferOwnership(alice, aliceCert, "account1,account2,account3", bobCert, "account2", "200") {
+		t.Fatal(err)
+	}
+
+	/***********************
+		Codes below check if assets are correctly transfered, first find the actual
+		account IDs from cert attributes, then call the getBalance method on the
+		chaincode for each account ID
+	***********************/
+
+	// check that 200 assets have been transfered to Bob; first step is to collect account Ids
+	aliceAccountId1, err := attr.GetValueFrom("account1", aliceCert.GetCertificate())
+	aliceAccountId2, err := attr.GetValueFrom("account2", aliceCert.GetCertificate())
+	aliceAccountId3, err := attr.GetValueFrom("account3", aliceCert.GetCertificate())
+	bobAccountId2, err := attr.GetValueFrom("account2", bobCert.GetCertificate())
+
+	//account1 of alice shouldn't have any balance left, and the account should have been
+	//deleted from the asset depository
+	alice1BalanceRaw, err := getBalance(string(aliceAccountId1))
+	fmt.Println("alice balance", alice1BalanceRaw)
+
+	if alice1BalanceRaw != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("alice balance", alice1BalanceRaw)
+
+	// account2 of alice should still have 100 left on its balance
+	alice2BalanceRaw, err := getBalance(string(aliceAccountId2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alicebalance2 := binary.BigEndian.Uint64(alice2BalanceRaw)
+	if alicebalance2 != 100 {
+		t.Fatal("retreived balance for account1 (alice) does not equal to 100")
+	}
+
+	// account3 of alice should still have 300 left on its balance
+	alice3BalanceRaw, err := getBalance(string(aliceAccountId3))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alicebalance3 := binary.BigEndian.Uint64(alice3BalanceRaw)
+	if alicebalance3 != 300 {
+		t.Fatal("retreived balance for account1 (alice) does not equal to 300")
+	}
+
+	// account2 of bob should now have 200 on its balance
+	bobBalanceRaw, err := getBalance(string(bobAccountId2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bobbalance := binary.BigEndian.Uint64(bobBalanceRaw)
+	if bobbalance != 200 {
+		t.Fatal("retreived balance for account2 (bob) does not equal to 200")
+	}
+
+}
+
+func deploy(admCert crypto.CertificateHandler) error {
+	// Prepare the spec. The metadata includes the role of the users allowed to assign assets
+	spec := &pb.ChaincodeSpec{
+		Type:                 1,
+		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
+		CtorMsg:              &pb.ChaincodeInput{Function: "init", Args: []string{}},
+		Metadata:             []byte("issuer"),
+		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
+	}
+
+	// First build and get the deployment spec
+	var ctx = context.Background()
+	chaincodeDeploymentSpec, err := getDeploymentSpec(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	tid := chaincodeDeploymentSpec.ChaincodeSpec.ChaincodeID.Name
+
+	// Now create the Transactions message and send to Peer.
+	transaction, err := administrator.NewChaincodeDeployTransaction(chaincodeDeploymentSpec, tid)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s ", err)
+	}
+
+	ledger, err := ledger.GetLedger()
+	ledger.BeginTxBatch("1")
+	_, _, err = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s", err)
+	}
+	ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+
+	return err
+}
+
+func assignOwnership(assigner crypto.Client, newOwnerCert crypto.CertificateHandler, attributeName string, amount string) error {
+	// Get a transaction handler to be used to submit the execute transaction
+	// and bind the chaincode access control logic using the binding
+	submittingCertHandler, err := assigner.GetTCertificateHandlerNext("role")
+	if err != nil {
+		return err
+	}
+	txHandler, err := submittingCertHandler.GetTransactionHandler()
+	if err != nil {
+		return err
+	}
+
+	chaincodeInput := &pb.ChaincodeInput{Function: "assignOwnership", Args: []string{string(newOwnerCert.GetCertificate()), attributeName, amount}}
+
+	// Prepare spec and submit
+	spec := &pb.ChaincodeSpec{
+		Type:                 1,
+		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
+		CtorMsg:              chaincodeInput,
+		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
+	}
+
+	var ctx = context.Background()
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
+
+	tid := chaincodeInvocationSpec.ChaincodeSpec.ChaincodeID.Name
+
+	// Now create the Transactions message and send to Peer.
+	transaction, err := txHandler.NewChaincodeExecute(chaincodeInvocationSpec, tid)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s ", err)
+	}
+
+	ledger, err := ledger.GetLedger()
+	ledger.BeginTxBatch("1")
+	_, _, err = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s", err)
+	}
+	ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+
+	return err
+}
+
+func transferOwnership(owner crypto.Client, ownerCert crypto.CertificateHandler, fromAttributes string,
+	newOwnerCert crypto.CertificateHandler, toAttributes string, amount string) error {
+	// Get a transaction handler to be used to submit the execute transaction
+	// and bind the chaincode access control logic using the binding
+
+	submittingCertHandler, err := owner.GetTCertificateHandlerNext("role")
+	if err != nil {
+		return err
+	}
+	txHandler, err := submittingCertHandler.GetTransactionHandler()
+	if err != nil {
+		return err
+	}
+
+	args := []string{string(ownerCert.GetCertificate()), fromAttributes, string(newOwnerCert.GetCertificate()), toAttributes, amount}
+	chaincodeInput := &pb.ChaincodeInput{Function: "transferOwnership", Args: args}
+
+	// Prepare spec and submit
+	spec := &pb.ChaincodeSpec{
+		Type:                 1,
+		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
+		CtorMsg:              chaincodeInput,
+		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
+	}
+
+	var ctx = context.Background()
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
+
+	tid := chaincodeInvocationSpec.ChaincodeSpec.ChaincodeID.Name
+
+	// Now create the Transactions message and send to Peer.
+	transaction, err := txHandler.NewChaincodeExecute(chaincodeInvocationSpec, tid)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s ", err)
+	}
+
+	ledger, err := ledger.GetLedger()
+	ledger.BeginTxBatch("1")
+	_, _, err = chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+	if err != nil {
+		return fmt.Errorf("Error deploying chaincode: %s", err)
+	}
+	ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+
+	return err
+
+}
+
+func getOwnerContactInformation(accountId string) ([]byte, error) {
+	return Query("getOwnerContactInformation", accountId)
+}
+
+func getBalance(accountId string) ([]byte, error) {
+	return Query("getBalance", accountId)
+}
+
+func Query(function, accountId string) ([]byte, error) {
+	chaincodeInput := &pb.ChaincodeInput{Function: function, Args: []string{accountId}}
+
+	// Prepare spec and submit
+	spec := &pb.ChaincodeSpec{
+		Type:                 1,
+		ChaincodeID:          &pb.ChaincodeID{Name: "mycc"},
+		CtorMsg:              chaincodeInput,
+		ConfidentialityLevel: pb.ConfidentialityLevel_PUBLIC,
+	}
+
+	var ctx = context.Background()
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{ChaincodeSpec: spec}
+
+	tid := chaincodeInvocationSpec.ChaincodeSpec.ChaincodeID.Name
+
+	// Now create the Transactions message and send to Peer.
+	transaction, err := administrator.NewChaincodeQuery(chaincodeInvocationSpec, tid)
+	if err != nil {
+		return nil, fmt.Errorf("Error deploying chaincode: %s ", err)
+	}
+
+	ledger, err := ledger.GetLedger()
+	ledger.BeginTxBatch("1")
+	result, _, err := chaincode.Execute(ctx, chaincode.GetChain(chaincode.DefaultChain), transaction)
+	if err != nil {
+		return nil, fmt.Errorf("Error deploying chaincode: %s", err)
+	}
+	ledger.CommitTxBatch("1", []*pb.Transaction{transaction}, nil, nil)
+
+	return result, err
+}
+
+func setup() {
+	// Conf
+	viper.SetConfigName("asset") // name of config file (without extension)
+	viper.AddConfigPath(".")     // path to look for the config file in
+	err := viper.ReadInConfig()  // Find and read the config file
+	if err != nil {              // Handle errors reading the config file
+		panic(fmt.Errorf("Fatal error config file [%s] \n", err))
+	}
+
+	// Logging
+	var formatter = logging.MustStringFormatter(
+		`%{color}[%{module}] %{shortfunc} [%{shortfile}] -> %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+	)
+	logging.SetFormatter(formatter)
+
+	logging.SetLevel(logging.DEBUG, "peer")
+	logging.SetLevel(logging.DEBUG, "chaincode")
+	logging.SetLevel(logging.DEBUG, "cryptochain")
+
+	// Init the crypto layer
+	if err := crypto.Init(); err != nil {
+		panic(fmt.Errorf("Failed initializing the crypto layer [%s]", err))
+	}
+
+	removeFolders()
+}
+
+func initMembershipSrvc() {
+	ca.LogInit(ioutil.Discard, os.Stdout, os.Stdout, os.Stderr, os.Stdout)
+
+	aca = ca.NewACA()
+	eca = ca.NewECA()
+	tca = ca.NewTCA(eca)
+	tlsca = ca.NewTLSCA(eca)
+
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.pki.tls.enabled") {
+		// TLS configuration
+		creds, err := credentials.NewServerTLSFromFile(
+			filepath.Join(viper.GetString("server.rootpath"), "tlsca.cert"),
+			filepath.Join(viper.GetString("server.rootpath"), "tlsca.priv"),
+		)
+		if err != nil {
+			panic("Failed creating credentials for Membersrvc: " + err.Error())
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+
+	fmt.Printf("open socket...\n")
+	sockp, err := net.Listen("tcp", viper.GetString("server.port"))
+	if err != nil {
+		panic("Cannot open port: " + err.Error())
+	}
+	fmt.Printf("open socket...done\n")
+
+	server = grpc.NewServer(opts...)
+
+	aca.Start(server)
+	eca.Start(server)
+	tca.Start(server)
+	tlsca.Start(server)
+
+	fmt.Printf("start serving...\n")
+	server.Serve(sockp)
+}
+
+func initVP() {
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			grpclog.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+
+	//lis, err := net.Listen("tcp", viper.GetString("peer.address"))
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:40404"
+	var err error
+	lis, err = net.Listen("tcp", peerAddress)
+	if err != nil {
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	userRunsCC := true
+
+	// Install security object for peer
+	var secHelper crypto.Peer
+	if viper.GetBool("security.enabled") {
+		enrollID := viper.GetString("security.enrollID")
+		enrollSecret := viper.GetString("security.enrollSecret")
+		var err error
+
+		if viper.GetBool("peer.validator.enabled") {
+			testLogger.Debugf("Registering validator with enroll ID: %s", enrollID)
+			if err = crypto.RegisterValidator(enrollID, nil, enrollID, enrollSecret); nil != err {
+				panic(err)
+			}
+			testLogger.Debugf("Initializing validator with enroll ID: %s", enrollID)
+			secHelper, err = crypto.InitValidator(enrollID, nil)
+			if nil != err {
+				panic(err)
+			}
+		} else {
+			testLogger.Debugf("Registering non-validator with enroll ID: %s", enrollID)
+			if err = crypto.RegisterPeer(enrollID, nil, enrollID, enrollSecret); nil != err {
+				panic(err)
+			}
+			testLogger.Debugf("Initializing non-validator with enroll ID: %s", enrollID)
+			secHelper, err = crypto.InitPeer(enrollID, nil)
+			if nil != err {
+				panic(err)
+			}
+		}
+	}
+
+	pb.RegisterChaincodeSupportServer(grpcServer,
+		chaincode.NewChaincodeSupport(chaincode.DefaultChain, getPeerEndpoint, userRunsCC,
+			ccStartupTimeout, secHelper))
+
+	grpcServer.Serve(lis)
+}
+
+func initAssetManagementChaincode() {
+	err := shim.Start(new(AssetManagementChaincode))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initClients() error {
+	// Administrator
+	if err := crypto.RegisterClient("admin", nil, "admin", "6avZQLwcUe9b"); err != nil {
+		return err
+	}
+	var err error
+	administrator, err = crypto.InitClient("admin", nil)
+	if err != nil {
+		return err
+	}
+
+	// Alice
+	if err := crypto.RegisterClient("alice", nil, "alice", "NPKYL39uKbkj"); err != nil {
+		return err
+	}
+	alice, err = crypto.InitClient("alice", nil)
+	if err != nil {
+		return err
+	}
+
+	// Bob
+	if err := crypto.RegisterClient("bob", nil, "bob", "DRJ23pEQl16a"); err != nil {
+		return err
+	}
+	bob, err = crypto.InitClient("bob", nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func closeListenerAndSleep(l net.Listener) {
+	l.Close()
+	time.Sleep(2 * time.Second)
+}
+
+func getDeploymentSpec(context context.Context, spec *pb.ChaincodeSpec) (*pb.ChaincodeDeploymentSpec, error) {
+	fmt.Printf("getting deployment spec for chaincode spec: %v\n", spec)
+	var codePackageBytes []byte
+	//if we have a name, we don't need to deploy (we are in userRunsCC mode)
+	if spec.ChaincodeID.Name == "" {
+		var err error
+		codePackageBytes, err = container.GetChaincodePackageBytes(spec)
+		if err != nil {
+			return nil, err
+		}
+	}
+	chaincodeDeploymentSpec := &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec, CodePackage: codePackageBytes}
+	return chaincodeDeploymentSpec, nil
+}
+
+func removeFolders() {
+	fmt.Println("-------------------------")
+	if err := os.RemoveAll(viper.GetString("peer.fileSystemPath")); err != nil {
+		fmt.Printf("Failed removing [%s] [%s]\n", "hyperledger", err)
+	}
+}

--- a/examples/chaincode/go/asset_management02/asset_management02_test.go
+++ b/examples/chaincode/go/asset_management02/asset_management02_test.go
@@ -168,13 +168,13 @@ func TestAssigningAssets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	aliceAccountId1, err := attr.GetValueFrom("account1", aliceCert1.GetCertificate())
-	aliceAccountId2, err := attr.GetValueFrom("account2", aliceCert2.GetCertificate())
-	aliceAccountId3, err := attr.GetValueFrom("account3", aliceCert3.GetCertificate())
-	bobAccountId1, err := attr.GetValueFrom("account1", bobCert1.GetCertificate())
+	aliceAccountID1, err := attr.GetValueFrom("account1", aliceCert1.GetCertificate())
+	aliceAccountID2, err := attr.GetValueFrom("account2", aliceCert2.GetCertificate())
+	aliceAccountID3, err := attr.GetValueFrom("account3", aliceCert3.GetCertificate())
+	bobAccountID1, err := attr.GetValueFrom("account1", bobCert1.GetCertificate())
 
 	// Check if balances are assigned correctly
-	alice1BalanceRaw, err := getBalance(string(aliceAccountId1))
+	alice1BalanceRaw, err := getBalance(string(aliceAccountID1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestAssigningAssets(t *testing.T) {
 		t.Fatal("retreived balance does not equal to 100")
 	}
 
-	alice2BalanceRaw, err := getBalance(string(aliceAccountId2))
+	alice2BalanceRaw, err := getBalance(string(aliceAccountID2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestAssigningAssets(t *testing.T) {
 		t.Fatal("retreived balance does not equal to 200")
 	}
 
-	alice3BalanceRaw, err := getBalance(string(aliceAccountId3))
+	alice3BalanceRaw, err := getBalance(string(aliceAccountID3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestAssigningAssets(t *testing.T) {
 		t.Fatal("retreived balance does not equal to 300")
 	}
 
-	bob1BalanceRaw, err := getBalance(string(bobAccountId1))
+	bob1BalanceRaw, err := getBalance(string(bobAccountID1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestAssigningAssets(t *testing.T) {
 	}
 
 	//check if contact info is correctly saved into the chaincode state ledger
-	aliceContactInfo, err := getOwnerContactInformation(string(aliceAccountId1))
+	aliceContactInfo, err := getOwnerContactInformation(string(aliceAccountID1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestAssigningAssets(t *testing.T) {
 		t.Fatal("retreived contact info does not equal to alice@gmail.com")
 	}
 
-	bobContactInfo, err := getOwnerContactInformation(string(bobAccountId1))
+	bobContactInfo, err := getOwnerContactInformation(string(bobAccountID1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,14 +265,14 @@ func TestAssetTransfer(t *testing.T) {
 	***********************/
 
 	// check that 200 assets have been transfered to Bob; first step is to collect account Ids
-	aliceAccountId1, err := attr.GetValueFrom("account1", aliceCert.GetCertificate())
-	aliceAccountId2, err := attr.GetValueFrom("account2", aliceCert.GetCertificate())
-	aliceAccountId3, err := attr.GetValueFrom("account3", aliceCert.GetCertificate())
-	bobAccountId2, err := attr.GetValueFrom("account2", bobCert.GetCertificate())
+	aliceAccountID1, err := attr.GetValueFrom("account1", aliceCert.GetCertificate())
+	aliceAccountID2, err := attr.GetValueFrom("account2", aliceCert.GetCertificate())
+	aliceAccountID3, err := attr.GetValueFrom("account3", aliceCert.GetCertificate())
+	bobAccountID2, err := attr.GetValueFrom("account2", bobCert.GetCertificate())
 
 	//account1 of alice shouldn't have any balance left, and the account should have been
 	//deleted from the asset depository
-	alice1BalanceRaw, err := getBalance(string(aliceAccountId1))
+	alice1BalanceRaw, err := getBalance(string(aliceAccountID1))
 	fmt.Println("alice balance", alice1BalanceRaw)
 
 	if alice1BalanceRaw != nil {
@@ -281,7 +281,7 @@ func TestAssetTransfer(t *testing.T) {
 	fmt.Println("alice balance", alice1BalanceRaw)
 
 	// account2 of alice should still have 100 left on its balance
-	alice2BalanceRaw, err := getBalance(string(aliceAccountId2))
+	alice2BalanceRaw, err := getBalance(string(aliceAccountID2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +292,7 @@ func TestAssetTransfer(t *testing.T) {
 	}
 
 	// account3 of alice should still have 300 left on its balance
-	alice3BalanceRaw, err := getBalance(string(aliceAccountId3))
+	alice3BalanceRaw, err := getBalance(string(aliceAccountID3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestAssetTransfer(t *testing.T) {
 	}
 
 	// account2 of bob should now have 200 on its balance
-	bobBalanceRaw, err := getBalance(string(bobAccountId2))
+	bobBalanceRaw, err := getBalance(string(bobAccountID2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,16 +443,16 @@ func transferOwnership(owner crypto.Client, ownerCert crypto.CertificateHandler,
 
 }
 
-func getOwnerContactInformation(accountId string) ([]byte, error) {
-	return Query("getOwnerContactInformation", accountId)
+func getOwnerContactInformation(accountID string) ([]byte, error) {
+	return Query("getOwnerContactInformation", accountID)
 }
 
-func getBalance(accountId string) ([]byte, error) {
-	return Query("getBalance", accountId)
+func getBalance(accountID string) ([]byte, error) {
+	return Query("getBalance", accountID)
 }
 
-func Query(function, accountId string) ([]byte, error) {
-	chaincodeInput := &pb.ChaincodeInput{Function: function, Args: []string{accountId}}
+func Query(function, accountID string) ([]byte, error) {
+	chaincodeInput := &pb.ChaincodeInput{Function: function, Args: []string{accountID}}
 
 	// Prepare spec and submit
 	spec := &pb.ChaincodeSpec{

--- a/examples/chaincode/go/asset_management02/cert_handler.go
+++ b/examples/chaincode/go/asset_management02/cert_handler.go
@@ -29,9 +29,11 @@ const (
 	contactInfo = "contactInfo"
 )
 
+//CertHandler provides APIs used to perform operations on incoming TCerts
 type CertHandler struct {
 }
 
+// NewCertHandler create a new reference to CertHandler
 func NewCertHandler() *CertHandler {
 	return &CertHandler{}
 }
@@ -66,7 +68,7 @@ func (t *CertHandler) getContactInfo(cert []byte) (string, error) {
 // attributeNames: attribute names inside TCert that stores the entity's account IDs
 func (t *CertHandler) getAccountIDsFromAttribute(cert []byte, attributeNames []string) ([]string, error) {
 	if cert == nil || attributeNames == nil {
-		return nil, errors.New("cert or accountIds list is empty")
+		return nil, errors.New("cert or accountIDs list is empty")
 	}
 
 	//decleare return object (slice of account IDs)
@@ -77,13 +79,13 @@ func (t *CertHandler) getAccountIDsFromAttribute(cert []byte, attributeNames []s
 	for _, attributeName := range attributeNames {
 		myLogger.Debugf("get value from attribute = v%", attributeName)
 		//get the attribute value from the corresbonding attribute name
-		accountId, err := attr.GetValueFrom(attributeName, cert)
+		accountID, err := attr.GetValueFrom(attributeName, cert)
 		if err != nil {
 			myLogger.Errorf("system error %v", err)
 			return nil, errors.New("unable to find user contact information")
 		}
 
-		acctIds = append(acctIds, string(accountId))
+		acctIds = append(acctIds, string(accountID))
 	}
 
 	myLogger.Debugf("ids = %v", acctIds)

--- a/examples/chaincode/go/asset_management02/cert_handler.go
+++ b/examples/chaincode/go/asset_management02/cert_handler.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/chaincode/shim/crypto/attr"
+)
+
+// consts associated with TCert
+const (
+	role        = "role"
+	contactInfo = "contactInfo"
+)
+
+type CertHandler struct {
+}
+
+func NewCertHandler() *CertHandler {
+	return &CertHandler{}
+}
+
+// Check if the transaction invoker has the appropriate role
+// stub: chaincodestub
+// requiredRole: required role; this function will return true if invoker has this role
+func (t *CertHandler) isAuthorized(stub *shim.ChaincodeStub, requiredRole string) (bool, error) {
+	//read transaction invoker's role, and verify that is the same as the required role passed in
+	return stub.VerifyAttribute(role, []byte(requiredRole))
+}
+
+// Retrieve the contact info stored as an attribute in a Tcert
+// cert: TCert
+func (t *CertHandler) getContactInfo(cert []byte) (string, error) {
+	if len(cert) == 0 {
+		return "", errors.New("cert is empty")
+	}
+
+	contactInfo, err := attr.GetValueFrom(contactInfo, cert)
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return "", errors.New("unable to find user contact information")
+	}
+
+	return string(contactInfo), err
+
+}
+
+// get account IDs stored in  TCert attributes
+// cert: TCert to read account IDs from
+// attributeNames: attribute names inside TCert that stores the entity's account IDs
+func (t *CertHandler) getAccountIDsFromAttribute(cert []byte, attributeNames []string) ([]string, error) {
+	if cert == nil || attributeNames == nil {
+		return nil, errors.New("cert or accountIds list is empty")
+	}
+
+	//decleare return object (slice of account IDs)
+	var acctIds []string
+
+	// for each attribute name, look for that attribute name inside TCert,
+	// the correspounding value of that attribute is the account ID
+	for _, attributeName := range attributeNames {
+		myLogger.Debugf("get value from attribute = v%", attributeName)
+		//get the attribute value from the corresbonding attribute name
+		accountId, err := attr.GetValueFrom(attributeName, cert)
+		if err != nil {
+			myLogger.Errorf("system error %v", err)
+			return nil, errors.New("unable to find user contact information")
+		}
+
+		acctIds = append(acctIds, string(accountId))
+	}
+
+	myLogger.Debugf("ids = %v", acctIds)
+	return acctIds, nil
+}

--- a/examples/chaincode/go/asset_management02/depository_handler.go
+++ b/examples/chaincode/go/asset_management02/depository_handler.go
@@ -1,0 +1,234 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+// consts associated with chaincode table
+const (
+	tableColumn       = "AssetsOwnership"
+	columnAccountID   = "Account"
+	columnContactInfo = "ContactInfo"
+	columnAmount      = "Amount"
+)
+
+//DepositoryHandler provides APIs used to perform operations on CC's KV store
+type DepositoryHandler struct {
+}
+
+// NewDepositoryHandler create a new reference to CertHandler
+func NewDepositoryHandler() *DepositoryHandler {
+	return &DepositoryHandler{}
+}
+
+// Create a new asset depository table in the chaincode state
+// stub: chaincodestub
+func (t *DepositoryHandler) createTable(stub *shim.ChaincodeStub) error {
+
+	// Create asset depository table
+	err := stub.CreateTable(tableColumn, []*shim.ColumnDefinition{
+		&shim.ColumnDefinition{columnAccountID, shim.ColumnDefinition_STRING, true},
+		&shim.ColumnDefinition{columnContactInfo, shim.ColumnDefinition_STRING, false},
+		&shim.ColumnDefinition{columnAmount, shim.ColumnDefinition_UINT64, false},
+	})
+
+	return err
+}
+
+// assign allocates assets to account IDs in the chaincode state for each of the
+// account ID passed in.
+// accountID: account ID to be allocated with requested amount
+// contactInfo: contact information of the owner of the account ID passed in
+// amount: amount to be allocated to this account ID
+func (t *DepositoryHandler) assign(stub *shim.ChaincodeStub,
+	accountID string,
+	contactInfo string,
+	amount uint64) error {
+
+	myLogger.Debugf("insert accountID= %v", accountID)
+
+	//insert a new row for this account ID that includes contact information and balance
+	ok, err := stub.InsertRow(tableColumn, shim.Row{
+		Columns: []*shim.Column{
+			&shim.Column{Value: &shim.Column_String_{String_: accountID}},
+			&shim.Column{Value: &shim.Column_String_{String_: contactInfo}},
+			&shim.Column{Value: &shim.Column_Uint64{Uint64: amount}}},
+	})
+
+	// you can only assign balances to new account IDs
+	if !ok && err == nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("Asset was already assigned.")
+	}
+
+	return nil
+}
+
+// updateAccountBalance updates the balance amount of an account ID
+// stub: chaincodestub
+// accountID: account will be updated with the new balance
+// contactInfo: contact information associated with the account owner (chaincode table does not allow me to perform updates on specific columns)
+// amount: new amount to be udpated with
+func (t *DepositoryHandler) updateAccountBalance(stub *shim.ChaincodeStub,
+	accountID string,
+	contactInfo string,
+	amount uint64) error {
+
+	myLogger.Debugf("insert accountID= %v", accountID)
+
+	//replace the old record row associated with the account ID with the new record row
+	ok, err := stub.ReplaceRow(tableColumn, shim.Row{
+		Columns: []*shim.Column{
+			&shim.Column{Value: &shim.Column_String_{String_: accountID}},
+			&shim.Column{Value: &shim.Column_String_{String_: contactInfo}},
+			&shim.Column{Value: &shim.Column_Uint64{Uint64: amount}}},
+	})
+
+	if !ok && err == nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("failed to replace row with account Id." + accountID)
+	}
+	return nil
+}
+
+// deleteAccountRecord deletes the record row associated with an account ID on the chaincode state table
+// stub: chaincodestub
+// accountID: account ID (record matching this account ID will be deleted after calling this method)
+func (t *DepositoryHandler) deleteAccountRecord(stub *shim.ChaincodeStub, accountID string) error {
+
+	myLogger.Debugf("insert accountID= %v", accountID)
+
+	//delete record matching account ID passed in
+	err := stub.DeleteRow(
+		"AssetsOwnership",
+		[]shim.Column{shim.Column{Value: &shim.Column_String_{String_: accountID}}},
+	)
+
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("error in deleting account record")
+	}
+	return nil
+}
+
+// transfer transfers X amount of assets from "from account IDs" to a new account ID
+// stub: chaincodestub
+// fromAccounts: from account IDs with assets to be transferred
+// toAccount: a new account ID on the table that will get assets transfered to
+// toContact: contact information of the owner of "to account ID"
+func (t *DepositoryHandler) transfer(stub *shim.ChaincodeStub, fromAccounts []string, toAccount string, toContact string, amount uint64) error {
+
+	myLogger.Debugf("insert params= %v , %v , %v , %v ", fromAccounts, toAccount, toContact, amount)
+
+	//collecting assets need to be transfered
+	remaining := amount
+	for i := range fromAccounts {
+		contactInfo, acctBalance, err := t.QueryAccount(stub, fromAccounts[i])
+		if err != nil {
+			myLogger.Errorf("system error %v", err)
+			return errors.New("error in deleting account record")
+		}
+
+		if remaining > 0 {
+			//check if this account need to be spent entirely; if so, delete the
+			//account record row, otherwise just take out what' needed
+			if remaining >= acctBalance {
+				remaining -= acctBalance
+				//delete accounts with 0 balance, this step is optional
+				t.deleteAccountRecord(stub, fromAccounts[i])
+			} else {
+				acctBalance -= remaining
+				remaining = 0
+				t.updateAccountBalance(stub, fromAccounts[i], contactInfo, acctBalance)
+				break
+			}
+		}
+	}
+
+	//check if toAccount already exist
+	acctBalance, err := t.QueryBalance(stub, toAccount)
+	if err == nil || acctBalance > 0 {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("error in deleting account record")
+	}
+
+	//create new toAccount in the Chaincode state table, and assign the total amount
+	//to its balance
+	return t.assign(stub, toAccount, toContact, amount)
+
+}
+
+// QueryContactInfo queries the contact information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountID: account ID
+func (t *DepositoryHandler) QueryContactInfo(stub *shim.ChaincodeStub, accountID string) (string, error) {
+	row, err := t.queryTable(stub, accountID)
+	if err != nil {
+		return "", err
+	}
+
+	return row.Columns[1].GetString_(), nil
+}
+
+// QueryBalance queries the balance information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountID: account ID
+func (t *DepositoryHandler) QueryBalance(stub *shim.ChaincodeStub, accountID string) (uint64, error) {
+
+	myLogger.Debugf("insert accountID= %v", accountID)
+
+	row, err := t.queryTable(stub, accountID)
+	if err != nil {
+		return 0, err
+	}
+	if len(row.Columns) == 0 || row.Columns[2] == nil {
+		return 0, errors.New("row or column value not found")
+	}
+
+	return row.Columns[2].GetUint64(), nil
+}
+
+// QueryAccount queries the balance and contact information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountID: account ID
+func (t *DepositoryHandler) QueryAccount(stub *shim.ChaincodeStub, accountID string) (string, uint64, error) {
+	row, err := t.queryTable(stub, accountID)
+	if err != nil {
+		return "", 0, err
+	}
+	if len(row.Columns) == 0 || row.Columns[2] == nil {
+		return "", 0, errors.New("row or column value not found")
+	}
+
+	return row.Columns[1].GetString_(), row.Columns[2].GetUint64(), nil
+}
+
+// Return the record row matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountID: account ID
+func (t *DepositoryHandler) queryTable(stub *shim.ChaincodeStub, accountID string) (shim.Row, error) {
+
+	var columns []shim.Column
+	col1 := shim.Column{Value: &shim.Column_String_{String_: accountID}}
+	columns = append(columns, col1)
+
+	return stub.GetRow(tableColumn, columns)
+}

--- a/examples/chaincode/go/asset_management02/state_handler.go
+++ b/examples/chaincode/go/asset_management02/state_handler.go
@@ -1,0 +1,232 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+// consts associated with chaincode table
+const (
+	tableColumn       = "AssetsOwnership"
+	columnAccountId   = "Account"
+	columnContactInfo = "ContactInfo"
+	columnAmount      = "Amount"
+)
+
+type DepositoryHandler struct {
+}
+
+func NewDepositoryHandler() *DepositoryHandler {
+	return &DepositoryHandler{}
+}
+
+// Create a new asset depository table in the chaincode state
+// stub: chaincodestub
+func (t *DepositoryHandler) createTable(stub *shim.ChaincodeStub) error {
+
+	// Create asset depository table
+	err := stub.CreateTable(tableColumn, []*shim.ColumnDefinition{
+		&shim.ColumnDefinition{columnAccountId, shim.ColumnDefinition_STRING, true},
+		&shim.ColumnDefinition{columnContactInfo, shim.ColumnDefinition_STRING, false},
+		&shim.ColumnDefinition{columnAmount, shim.ColumnDefinition_UINT64, false},
+	})
+
+	return err
+}
+
+// Allocate assets to account IDs in the chaincode state for each of the
+// account ID passed in.
+// accountId: account ID to be allocated with requested amount
+// contactInfo: contact information of the owner of the account ID passed in
+// amount: amount to be allocated to this account ID
+func (t *DepositoryHandler) assign(stub *shim.ChaincodeStub,
+	accountId string,
+	contactInfo string,
+	amount uint64) error {
+
+	myLogger.Debugf("insert accountId= %v", accountId)
+
+	//insert a new row for this account ID that includes contact information and balance
+	ok, err := stub.InsertRow(tableColumn, shim.Row{
+		Columns: []*shim.Column{
+			&shim.Column{Value: &shim.Column_String_{String_: accountId}},
+			&shim.Column{Value: &shim.Column_String_{String_: contactInfo}},
+			&shim.Column{Value: &shim.Column_Uint64{Uint64: amount}}},
+	})
+
+	// you can only assign balances to new account IDs
+	if !ok && err == nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("Asset was already assigned.")
+	}
+
+	return nil
+}
+
+// Update the balance amount of an account ID
+// stub: chaincodestub
+// accountId: account will be updated with the new balance
+// contactInfo: contact information associated with the account owner (chaincode table does not allow me to perform updates on specific columns)
+// amount: new amount to be udpated with
+func (t *DepositoryHandler) updateAccountBalance(stub *shim.ChaincodeStub,
+	accountId string,
+	contactInfo string,
+	amount uint64) error {
+
+	myLogger.Debugf("insert accountId= %v", accountId)
+
+	//replace the old record row associated with the account ID with the new record row
+	ok, err := stub.ReplaceRow(tableColumn, shim.Row{
+		Columns: []*shim.Column{
+			&shim.Column{Value: &shim.Column_String_{String_: accountId}},
+			&shim.Column{Value: &shim.Column_String_{String_: contactInfo}},
+			&shim.Column{Value: &shim.Column_Uint64{Uint64: amount}}},
+	})
+
+	if !ok && err == nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("failed to replace row with account Id." + accountId)
+	}
+	return nil
+}
+
+// Delete the record row associated with an account ID on the chaincode state table
+// stub: chaincodestub
+// accountId: account ID (record matching this account ID will be deleted after calling this method)
+func (t *DepositoryHandler) deleteAccountRecord(stub *shim.ChaincodeStub, accountId string) error {
+
+	myLogger.Debugf("insert accountId= %v", accountId)
+
+	//delete record matching account ID passed in
+	err := stub.DeleteRow(
+		"AssetsOwnership",
+		[]shim.Column{shim.Column{Value: &shim.Column_String_{String_: accountId}}},
+	)
+
+	if err != nil {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("error in deleting account record.")
+	}
+	return nil
+}
+
+// Transfer X amount of assets from "from account IDs" to a new account ID
+// stub: chaincodestub
+// fromAccounts: from account IDs with assets to be transferred
+// toAccount: a new account ID on the table that will get assets transfered to
+// toContact: contact information of the owner of "to account ID"
+func (t *DepositoryHandler) transfer(stub *shim.ChaincodeStub, fromAccounts []string, toAccount string, toContact string, amount uint64) error {
+
+	myLogger.Debugf("insert params= %v , %v , %v , %v ", fromAccounts, toAccount, toContact, amount)
+
+	//collecting assets need to be transfered
+	remaining := amount
+	for i, _ := range fromAccounts {
+		contactInfo, acctBalance, err := t.QueryAccount(stub, fromAccounts[i])
+		if err != nil {
+			myLogger.Errorf("system error %v", err)
+			return errors.New("error in deleting account record.")
+		}
+
+		if remaining > 0 {
+			//check if this account need to be spent entirely; if so, delete the
+			//account record row, otherwise just take out what' needed
+			if remaining >= acctBalance {
+				remaining -= acctBalance
+				//delete accounts with 0 balance, this step is optional
+				t.deleteAccountRecord(stub, fromAccounts[i])
+			} else {
+				acctBalance -= remaining
+				remaining = 0
+				t.updateAccountBalance(stub, fromAccounts[i], contactInfo, acctBalance)
+				break
+			}
+		}
+	}
+
+	//check if toAccount already exist
+	acctBalance, err := t.QueryBalance(stub, toAccount)
+	if err == nil || acctBalance > 0 {
+		myLogger.Errorf("system error %v", err)
+		return errors.New("error in deleting account record.")
+	}
+
+	//create new toAccount in the Chaincode state table, and assign the total amount
+	//to its balance
+	return t.assign(stub, toAccount, toContact, amount)
+
+}
+
+// Query the contact information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountId: account ID
+func (t *DepositoryHandler) QueryContactInfo(stub *shim.ChaincodeStub, accountId string) (string, error) {
+	row, err := t.queryTable(stub, accountId)
+	if err != nil {
+		return "", err
+	}
+
+	return row.Columns[1].GetString_(), nil
+}
+
+// Query the balance information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountId: account ID
+func (t *DepositoryHandler) QueryBalance(stub *shim.ChaincodeStub, accountId string) (uint64, error) {
+
+	myLogger.Debugf("insert accountId= %v", accountId)
+
+	row, err := t.queryTable(stub, accountId)
+	if err != nil {
+		return 0, err
+	}
+	if len(row.Columns) == 0 || row.Columns[2] == nil {
+		return 0, errors.New("row or column value not found")
+	}
+
+	return row.Columns[2].GetUint64(), nil
+}
+
+// Query the balance and contact information matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountId: account ID
+func (t *DepositoryHandler) QueryAccount(stub *shim.ChaincodeStub, accountId string) (string, uint64, error) {
+	row, err := t.queryTable(stub, accountId)
+	if err != nil {
+		return "", 0, err
+	}
+	if len(row.Columns) == 0 || row.Columns[2] == nil {
+		return "", 0, errors.New("row or column value not found")
+	}
+
+	return row.Columns[1].GetString_(), row.Columns[2].GetUint64(), nil
+}
+
+// Return the record row matching a correponding account ID on the chaincode state table
+// stub: chaincodestub
+// accountId: account ID
+func (t *DepositoryHandler) queryTable(stub *shim.ChaincodeStub, accountId string) (shim.Row, error) {
+
+	var columns []shim.Column
+	col1 := shim.Column{Value: &shim.Column_String_{String_: accountId}}
+	columns = append(columns, col1)
+
+	return stub.GetRow(tableColumn, columns)
+}


### PR DESCRIPTION
Demonstrate a work-around option to support multi-account per user (each user with multiple account IDs) with the TCert attributes 
## Description

The current tcert-attribute based design allows user to select which attribute to include in the TCert. However, the attributes are pre-defined. So for any given attribute (e.g. account IDs), user can only choose to either include or not include in his TCert.

This strategy works if attribute values are static. However, account IDs are expected to be dynamic overtime in many use cases (for obfuscation purposes .... e.g. bitcoin addresses are dynamically created from pub keys generated/managed by wallets).

This commit demonstrate a work-around option to support multi-account option with what's there in the fabric today
## Motivation and Context

Current attribute samples does not provide a blueprint on supporting dynamically supporting multi-account per user. This is a sample code that offers a work around to the issue described in #1844  

Fixes #1844 
## How Has This Been Tested?

Example code does not alter the behavior of the fabric. The example code is tested with Unit test which is also part of this commit
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

reverify jenkins

Signed-off-by: Frank Lu fylu@us.ibm.com
