### PR TITLE
Add config to avoid chaincode logging fills up the disk space.

### DIFF
--- a/core/container/dockercontroller/dockercontroller_test.go
+++ b/core/container/dockercontroller/dockercontroller_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockercontroller
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/hyperledger/fabric/core/config"
+	"github.com/hyperledger/fabric/core/ledger/testutil"
+)
+
+func TestHostConfig(t *testing.T) {
+	config.SetupTestConfig("./../../../peer")
+	var hostConfig = new(docker.HostConfig)
+	err := viper.UnmarshalKey("vm.docker.hostConfig", hostConfig)
+	if err != nil {
+		t.Fatalf("Load docker HostConfig wrong, error: %s", err.Error())
+	}
+	testutil.AssertNotEquals(t, hostConfig.LogConfig, nil)
+	testutil.AssertEquals(t, hostConfig.LogConfig.Type, "json-file")
+	testutil.AssertEquals(t, hostConfig.LogConfig.Config["max-size"], "50m")
+	testutil.AssertEquals(t, hostConfig.LogConfig.Config["max-file"], "5")
+}

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -257,10 +257,17 @@ vm:
         # NetworkMode Sets the networking mode for the container. Supported standard values are: `host`(default),`bridge`,`ipvlan`,`none`
         # dns A list of DNS servers for the container to use.
         # note: not support customize for `Privileged` 
+        # LogConfig sets the logging driver (Type) and related options (Config) for Docker
+        # you can refer https://docs.docker.com/engine/admin/logging/overview/ for more detail configruation.
         hostConfig:
             NetworkMode: host
             Dns:
                # - 192.168.0.1
+            LogConfig:
+                Type: json-file
+                Config:
+                    max-size: "50m"
+                    max-file: "5"
             
 ###############################################################################
 #


### PR DESCRIPTION
## Description

We need set the default log settings for the docker container to avoid logging file fills up the disk space.
## Motivation and Context

Fixes #709 
## How Has This Been Tested?

Only the configuration file has been updated, no code related.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: David Geng david@esse.io
