### PR TITLE
use a different db for system chaincode UT than chaincode UTs

### DIFF
--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -77,7 +77,13 @@ func closeListenerAndSleep(l net.Listener) {
 func TestExecuteDeploySysChaincode(t *testing.T) {
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
-	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	db := "/var/hyperledger/test/syscctmpdb"
+	defer func() {
+		os.RemoveAll(db)
+	}()
+		
+	viper.Set("peer.fileSystemPath", db)
 
 	//use a different address than what we usually use for "peer"
 	//we override the peerAddress set in chaincode_support.go

--- a/core/system_chaincode/systemchaincode_test.go
+++ b/core/system_chaincode/systemchaincode_test.go
@@ -82,7 +82,7 @@ func TestExecuteDeploySysChaincode(t *testing.T) {
 	defer func() {
 		os.RemoveAll(db)
 	}()
-		
+
 	viper.Set("peer.fileSystemPath", db)
 
 	//use a different address than what we usually use for "peer"


### PR DESCRIPTION
Make unit test for system chaincode use a different ledger DB than those used for chaincode UTs.
## Description

We have seen errors with following signature recently

```
Error opening DB IO error: lock /var/hyperledger/test/tmpdb/db/LOCK: Resource temporarily unavailable
--- FAIL: TestExecuteDeploySysChaincode (0.00s)
panic: Could not open openchain db error = [IO error: lock /var/hyperledger/test/tmpdb/db/LOCK: Resource temporarily unavailable] [recovered]
    panic: Could not open openchain db error = [IO error: lock /var/hyperledger/test/tmpdb/db/LOCK: Resource temporarily unavailable]
```

While we don't know what the underlying reason is - best we have is somehow tests are run in parallel causing DB contention - it is not a bad idea to run tests under different test dbs.

This PR does this for just the system chaincode UT to see if this takes us past the recent errors in this Unit Test case. We could do the same for other tests in the chaincode UT suite as well in a future PR.
## Motivation and Context

Fixes #1921
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: muralisr@us.ibm.com
