### PR TITLE
Turn off test parallelism - issue #1926

### DIFF
--- a/scripts/goUnitTests.sh
+++ b/scripts/goUnitTests.sh
@@ -16,4 +16,4 @@ trap cleanup 0
 echo "DONE!"
 
 echo "Running tests..."
-go test -cover -timeout=20m $PKGS
+go test -cover -p 1 -timeout=20m $PKGS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Turns of test parallelism while running `make unit-test`
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1926 
Failures are starting to pop-up due to Go running package tests in parallel by default. This has generally been caused by two processes accessing the database at the same time which is not supported
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

Ran `make checks`. No new tests are required as this does not alter functionality.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
