### PR TITLE
Make enhancements 20160621 v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ node-sdk:
 .PHONY: clean
 clean: images-clean
 	-@rm -rf build ||:
-	-@rm -f $(GOTOOLS_BIN) ||:
 
 .PHONY: dist-clean
 dist-clean: clean
 	-@rm -rf /var/hyperledger/* ||:
+	-@rm -f $(GOTOOLS_BIN) ||:

--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,8 @@ base-image-clean:
 
 %-image-clean:
 	$(eval TARGET = ${patsubst %-image-clean,%,${@}})
-	-@rm -rf build/image/$(TARGET) ||:
 	-docker rmi -f $(PROJECT_NAME)-$(TARGET)
+	-@rm -rf build/image/$(TARGET) ||:
 
 images-clean: $(patsubst %,%-image-clean, $(IMAGES))
 

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ build/image/%/.dummy: build/image/src/.dummy build/docker/bin/%
 	@touch $@
 
 .PHONY: protos
-protos:
+protos: gotools
 	./devenv/compile_protos.sh
 
 base-image-clean:


### PR DESCRIPTION
Minor enhancements to the build system including a fix for #1732 
## Description

Minor fixes/cleanups for the build.
- ab01135 "make protos" should depend on gotools so we ensure protoc-gen-go exists
- b5cf3c7 Make the *-image-clean targets consistent
- 136340f Do not clean up gotools with default 'make clean'
## Motivation and Context

Aside from the cosmetic changes, we were seeing some problems related to the availability of protoc-gen-go due to the handling of dependencies.  For one, the dep wasn't properly represented for targets like 'make protos' and this was exacerbated by the fact that we cleaned up gotools with "make clean".  It is probably best to decouple cleanup of our custom artifacts with upstream tooling.  Therefore, we move the clean up of gotools to "make dist-clean" and properly dep "make protos" such that it will ensure the tooling is built before proceeding.

Fixes #1732
## How Has This Been Tested?

Ran "make checks" and also ensured that "make clean", "make protos", and "make dist-clean" perform as expected.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [ ] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
