### PR TITLE
Ensure message order of broadcasts

### DIFF
--- a/consensus/obcpbft/broadcast.go
+++ b/consensus/obcpbft/broadcast.go
@@ -41,7 +41,7 @@ type broadcaster struct {
 
 type sendRequest struct {
 	msg  *pb.Message
-	done chan struct{}
+	done chan bool
 }
 
 func newBroadcaster(self uint64, N int, f int, c communicator) *broadcaster {
@@ -75,7 +75,6 @@ func (b *broadcaster) Wait() {
 
 func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidatorNotFound bool) bool {
 	defer func() {
-		send.done <- struct{}{}
 		b.closed.Done()
 	}()
 	h, err := getValidatorHandle(dest)
@@ -84,6 +83,7 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 			logger.Warningf("could not get handle for replica %d", dest)
 		}
 		time.Sleep(time.Second)
+		send.done <- false
 		return true
 	}
 
@@ -95,6 +95,9 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 	err = b.comm.Unicast(send.msg, h)
 	if err != nil {
 		logger.Warningf("could not send to replica %d: %v", dest, err)
+		send.done <- false
+	} else {
+		send.done <- true
 	}
 
 	return false
@@ -110,7 +113,7 @@ func (b *broadcaster) drainer(dest uint64) {
 				// Drain the message channel to free calling waiters before we shut down
 				select {
 				case send := <-b.msgChans[dest]:
-					send.done <- struct{}{}
+					send.done <- false
 					b.closed.Done()
 				default:
 					return
@@ -122,7 +125,7 @@ func (b *broadcaster) drainer(dest uint64) {
 	}
 }
 
-func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{}) {
+func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan bool) {
 	select {
 	case b.msgChans[dest] <- &sendRequest{
 		msg:  msg,
@@ -130,7 +133,7 @@ func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{
 	}:
 	default:
 		// If this channel is full, we must discard the message and flag it as done
-		wait <- struct{}{}
+		wait <- false
 		b.closed.Done()
 	}
 }
@@ -152,7 +155,7 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		required = destCount - b.f
 	}
 
-	wait := make(chan struct{}, destCount)
+	wait := make(chan bool, destCount)
 
 	if dest != nil {
 		b.closed.Add(1)
@@ -164,8 +167,29 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		}
 	}
 
-	for i := 0; i < required; i++ {
-		<-wait
+	succeeded := 0
+	timer := time.NewTimer(time.Second) // TODO, make this configurable
+
+	// This loop will try to send, until one of:
+	// a) the required number of sends succeed
+	// b) all sends complete regardless of success
+	// c) the timeout expires and the required number of sends have returned
+outer:
+	for i := 0; i < destCount; i++ {
+		select {
+		case success := <-wait:
+			if success {
+				succeeded++
+				if succeeded >= required {
+					break outer
+				}
+			}
+		case <-timer.C:
+			for i := i; i < required; i++ {
+				<-wait
+			}
+			break outer
+		}
 	}
 
 	return nil

--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -53,6 +53,9 @@ general:
         # How long may a view change take
         viewchange: 2s
 
+        # How long to wait for a view change quorum before resending (the same) view change
+        resendviewchange: 2s
+
         # Interval to send "keep-alive" null requests.  Set to 0 to disable.
         nullrequest: 0s
 

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -69,6 +69,9 @@ type pbftMessageEvent pbftMessage
 // viewChangedEvent is sent when the view change timer expires
 type viewChangedEvent struct{}
 
+// viewChangeResendTimerEvent is sent when the view change resend timer expires
+type viewChangeResendTimerEvent struct{}
+
 // returnRequestEvent is sent by pbft when we are forwarded a request
 type returnRequestEvent *Request
 
@@ -146,8 +149,10 @@ type pbftCore struct {
 
 	currentExec        *uint64             // currently executing request
 	timerActive        bool                // is the timer running?
+	vcResendTimer      events.Timer        // timer triggering resend of a view change
 	newViewTimer       events.Timer        // timeout triggering a view change
 	requestTimeout     time.Duration       // progress timeout for requests
+	vcResendTimeout    time.Duration       // timeout before resending view change
 	newViewTimeout     time.Duration       // progress timeout for new views
 	newViewTimerReason string              // what triggered the timer
 	lastNewViewTimeout time.Duration       // last timeout we used during this view change
@@ -219,6 +224,7 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack, etf events
 	instance.consumer = consumer
 
 	instance.newViewTimer = etf.CreateTimer()
+	instance.vcResendTimer = etf.CreateTimer()
 	instance.nullRequestTimer = etf.CreateTimer()
 
 	instance.N = config.GetInt("general.N")
@@ -239,6 +245,10 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack, etf events
 	instance.byzantine = config.GetBool("general.byzantine")
 
 	instance.requestTimeout, err = time.ParseDuration(config.GetString("general.timeout.request"))
+	if err != nil {
+		panic(fmt.Errorf("Cannot parse request timeout: %s", err))
+	}
+	instance.vcResendTimeout, err = time.ParseDuration(config.GetString("general.timeout.resendviewchange"))
 	if err != nil {
 		panic(fmt.Errorf("Cannot parse request timeout: %s", err))
 	}
@@ -393,6 +403,14 @@ func (instance *pbftCore) ProcessEvent(e events.Event) events.Event {
 		return instance.processNewView()
 	case viewChangedEvent:
 		// No-op, processed by plugins if needed
+	case viewChangeResendTimerEvent:
+		if instance.activeView {
+			logger.Warningf("Replica %d had its view change resend timer expire but it's in an active view, this is benign but may indicate a bug", instance.id)
+			return nil
+		}
+		logger.Debugf("Replica %d view change resend timer expired before view change quorum was reached, resending", instance.id)
+		instance.view-- // sending the view change increments this
+		return instance.sendViewChange()
 	default:
 		logger.Warningf("Replica %d received an unknown message type %T", instance.id, et)
 	}

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -473,8 +473,8 @@ func (instance *pbftCore) processNewView2(nv *NewView) events.Event {
 		}
 
 		req, ok := instance.reqStore[d]
-		if !ok {
-			logger.Criticalf("Replica %d is missing request for assigned prepare after fetching, this indicates a serious bug", instance.id)
+		if !ok && d != "" {
+			logger.Criticalf("Replica %d is missing request for seqNo=%d with digest '%s' for assigned prepare after fetching, this indicates a serious bug", instance.id, n, d)
 		}
 		preprep := &PrePrepare{
 			View:           instance.view,

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -178,6 +178,8 @@ func (instance *pbftCore) sendViewChange() events.Event {
 
 	instance.innerBroadcast(&Message{&Message_ViewChange{vc}})
 
+	instance.vcResendTimer.Reset(instance.vcResendTimeout, viewChangeResendTimerEvent{})
+
 	return instance.recvViewChange(vc)
 }
 
@@ -244,6 +246,7 @@ func (instance *pbftCore) recvViewChange(vc *ViewChange) events.Event {
 
 	if !instance.activeView && vc.View == instance.view && quorum >= instance.allCorrectReplicasQuorum() {
 		if quorum >= instance.allCorrectReplicasQuorum() {
+			instance.vcResendTimer.Stop()
 			instance.startTimer(instance.lastNewViewTimeout, "new view change")
 			instance.lastNewViewTimeout = 2 * instance.lastNewViewTimeout
 			return viewChangeQuorumEvent{}


### PR DESCRIPTION
## Description

This changeset modifies the obcpbft `broadcast.go` to always send messages in the order in which they were received.

This is a companion to PR#1928 and incorporates some feedback from @corecode.
## Motivation and Context

The previous implementation of the broadcaster would spawn a goroutine per broadcast request, which could wake up in an arbitrary order, delivering messages to recipients in that arbitrary order.  This caused problems for sections of the code which expected and depended on messages arriving in order.

One manifestation of this was request duplication as a request might be prepared and committed before the broadcast of its original contents was received, causing the network to view the request as new and invoke it twice.

The other problem was that these spawned go routines would stack and stack until the underlying gRPC stack would timeout and cause these calls to unwind and be garbage collected.
## How Has This Been Tested?

The existing unit tests and CI, plus the busywork stress2b tool.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
