### PR TITLE
Resend view change requests periodically if quorum is not achieved

### DIFF
--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -53,6 +53,9 @@ general:
         # How long may a view change take
         viewchange: 2s
 
+        # How long to wait for a view change quorum before resending (the same) view change
+        resendviewchange: 2s
+
         # Interval to send "keep-alive" null requests.  Set to 0 to disable.
         nullrequest: 0s
 

--- a/consensus/obcpbft/pbft-core.go
+++ b/consensus/obcpbft/pbft-core.go
@@ -69,6 +69,9 @@ type pbftMessageEvent pbftMessage
 // viewChangedEvent is sent when the view change timer expires
 type viewChangedEvent struct{}
 
+// viewChangeResendTimerEvent is sent when the view change resend timer expires
+type viewChangeResendTimerEvent struct{}
+
 // returnRequestEvent is sent by pbft when we are forwarded a request
 type returnRequestEvent *Request
 
@@ -146,8 +149,10 @@ type pbftCore struct {
 
 	currentExec        *uint64             // currently executing request
 	timerActive        bool                // is the timer running?
+	vcResendTimer      events.Timer        // timer triggering resend of a view change
 	newViewTimer       events.Timer        // timeout triggering a view change
 	requestTimeout     time.Duration       // progress timeout for requests
+	vcResendTimeout    time.Duration       // timeout before resending view change
 	newViewTimeout     time.Duration       // progress timeout for new views
 	newViewTimerReason string              // what triggered the timer
 	lastNewViewTimeout time.Duration       // last timeout we used during this view change
@@ -219,6 +224,7 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack, etf events
 	instance.consumer = consumer
 
 	instance.newViewTimer = etf.CreateTimer()
+	instance.vcResendTimer = etf.CreateTimer()
 	instance.nullRequestTimer = etf.CreateTimer()
 
 	instance.N = config.GetInt("general.N")
@@ -239,6 +245,10 @@ func newPbftCore(id uint64, config *viper.Viper, consumer innerStack, etf events
 	instance.byzantine = config.GetBool("general.byzantine")
 
 	instance.requestTimeout, err = time.ParseDuration(config.GetString("general.timeout.request"))
+	if err != nil {
+		panic(fmt.Errorf("Cannot parse request timeout: %s", err))
+	}
+	instance.vcResendTimeout, err = time.ParseDuration(config.GetString("general.timeout.resendviewchange"))
 	if err != nil {
 		panic(fmt.Errorf("Cannot parse request timeout: %s", err))
 	}
@@ -393,6 +403,14 @@ func (instance *pbftCore) ProcessEvent(e events.Event) events.Event {
 		return instance.processNewView()
 	case viewChangedEvent:
 		// No-op, processed by plugins if needed
+	case viewChangeResendTimerEvent:
+		if instance.activeView {
+			logger.Warningf("Replica %d had its view change resend timer expire but it's in an active view, this is benign but may indicate a bug", instance.id)
+			return nil
+		}
+		logger.Debugf("Replica %d view change resend timer expired before view change quorum was reached, resending", instance.id)
+		instance.view-- // sending the view change increments this
+		return instance.sendViewChange()
 	default:
 		logger.Warningf("Replica %d received an unknown message type %T", instance.id, et)
 	}

--- a/consensus/obcpbft/viewchange.go
+++ b/consensus/obcpbft/viewchange.go
@@ -178,6 +178,8 @@ func (instance *pbftCore) sendViewChange() events.Event {
 
 	instance.innerBroadcast(&Message{&Message_ViewChange{vc}})
 
+	instance.vcResendTimer.Reset(instance.vcResendTimeout, viewChangeResendTimerEvent{})
+
 	return instance.recvViewChange(vc)
 }
 
@@ -244,6 +246,7 @@ func (instance *pbftCore) recvViewChange(vc *ViewChange) events.Event {
 
 	if !instance.activeView && vc.View == instance.view && quorum >= instance.allCorrectReplicasQuorum() {
 		if quorum >= instance.allCorrectReplicasQuorum() {
+			instance.vcResendTimer.Stop()
 			instance.startTimer(instance.lastNewViewTimeout, "new view change")
 			instance.lastNewViewTimeout = 2 * instance.lastNewViewTimeout
 			return viewChangeQuorumEvent{}


### PR DESCRIPTION
## Description

This changeset introduces a new timer which is started after sending a view change message, and stopped when a quorum of view change messages is received.  The timeout is configurable via the `config.yaml`.

This is a companion PR to #1927 
## Motivation and Context

This fixes #1917 which contains a detailed scenario which results in PBFT network deadlock.
## How Has This Been Tested?

A new unit test is included, existing CI should be sufficient to cover the remainder.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [X] Either no new documentation is required by this change, OR I added new documentation
- [X] Either no new tests are required by this change, OR I added new tests
- [X] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
