### PR TITLE
Deduplicate requests based on last execution time

### DIFF
--- a/consensus/obcpbft/broadcast.go
+++ b/consensus/obcpbft/broadcast.go
@@ -41,7 +41,7 @@ type broadcaster struct {
 
 type sendRequest struct {
 	msg  *pb.Message
-	done chan struct{}
+	done chan bool
 }
 
 func newBroadcaster(self uint64, N int, f int, c communicator) *broadcaster {
@@ -75,7 +75,6 @@ func (b *broadcaster) Wait() {
 
 func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidatorNotFound bool) bool {
 	defer func() {
-		send.done <- struct{}{}
 		b.closed.Done()
 	}()
 	h, err := getValidatorHandle(dest)
@@ -84,6 +83,7 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 			logger.Warningf("could not get handle for replica %d", dest)
 		}
 		time.Sleep(time.Second)
+		send.done <- false
 		return true
 	}
 
@@ -95,6 +95,9 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 	err = b.comm.Unicast(send.msg, h)
 	if err != nil {
 		logger.Warningf("could not send to replica %d: %v", dest, err)
+		send.done <- false
+	} else {
+		send.done <- true
 	}
 
 	return false
@@ -110,7 +113,7 @@ func (b *broadcaster) drainer(dest uint64) {
 				// Drain the message channel to free calling waiters before we shut down
 				select {
 				case send := <-b.msgChans[dest]:
-					send.done <- struct{}{}
+					send.done <- false
 					b.closed.Done()
 				default:
 					return
@@ -122,7 +125,7 @@ func (b *broadcaster) drainer(dest uint64) {
 	}
 }
 
-func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{}) {
+func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan bool) {
 	select {
 	case b.msgChans[dest] <- &sendRequest{
 		msg:  msg,
@@ -130,7 +133,7 @@ func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{
 	}:
 	default:
 		// If this channel is full, we must discard the message and flag it as done
-		wait <- struct{}{}
+		wait <- false
 		b.closed.Done()
 	}
 }
@@ -152,7 +155,7 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		required = destCount - b.f
 	}
 
-	wait := make(chan struct{}, destCount)
+	wait := make(chan bool, destCount)
 
 	if dest != nil {
 		b.closed.Add(1)
@@ -164,8 +167,29 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		}
 	}
 
-	for i := 0; i < required; i++ {
-		<-wait
+	succeeded := 0
+	timer := time.NewTimer(time.Second) // TODO, make this configurable
+
+	// This loop will try to send, until one of:
+	// a) the required number of sends succeed
+	// b) all sends complete regardless of success
+	// c) the timeout expires and the required number of sends have returned
+outer:
+	for i := 0; i < destCount; i++ {
+		select {
+		case success := <-wait:
+			if success {
+				succeeded++
+				if succeeded >= required {
+					break outer
+				}
+			}
+		case <-timer.C:
+			for i := i; i < required; i++ {
+				<-wait
+			}
+			break outer
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This changeset adds back in a portion of the deduplication logic which was removed.  Specifically, it will cause a replica to ignore any requests from a peer which are timestamped prior to the timestamp of the most recently executed request from that peer.

Note, there is only one new commit here, but it is built upon some other outstanding PRs.
## Motivation and Context

This is a stopgap measure, designed to fix #1931 until a more permanent solution can be found.

The problem is that deduplicating in this manner allows request censorship by the primary.  A malicious primary may choose to execute a later request from a replica to effectively censor the request from before it.  This problem is solved in the paper by having only one outstanding request per client (and consequently, no second later request can be executed).  This is not practical for the fabric, as VPs are clients.  A better solution is being actively pursued.

I'm unsure whether we wish to include this in the 0.5 release or not.  Maybe @corecode @kchristidis @bcbrock @tuand27613 could weigh in quickly with their opinions.
## How Has This Been Tested?

This has been tested against the busywork stress2b test.  CI will cover additionally.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
