### PR TITLE
Fix memory leaks in busywork/bin/fabricLogger

### DIFF
--- a/tools/busywork/bin/fabricLogger
+++ b/tools/busywork/bin/fabricLogger
@@ -194,8 +194,13 @@ atErrorExit {killPIDs}
 
 # TODO : Move block access to ::fabric package procedures
 
+# NB: To avoid memory leaks the HTTP token must always be cleaned up
+# (deleted). We even delete the token on errorExit paths, as one day we may
+# decide to add an option to return errors instead of exiting from errorExit.
+
 proc forceBreakOrErrorExit {i_token} {
     if {[parms force]} {
+        http::cleanup $i_token
         err {} "Continuing after error (-force mode)"
         return -code break
     } else {
@@ -224,6 +229,7 @@ while {1} {
                 http::cleanup $token
                 continue
             }
+            http::cleanup $token
             errorExit \
                 "$peer @ block $block: ::http::geturl failed " \
                 "with [parms retry] retries : $token"
@@ -233,6 +239,7 @@ while {1} {
 
             # End of blockchain
             
+            http::cleanup $token
             if {![parms follow]} {exit 0}
             if {[parms followPoll] == 0} break
             after [parms followPoll]

--- a/tools/busywork/tcl/io.tcl
+++ b/tools/busywork/tcl/io.tcl
@@ -319,6 +319,7 @@ proc httpTokenDump {i_token {i_level err} {i_module {}}} {
 proc httpErrorExit {i_token} {
 
     httpTokenDump $i_token
+    http::cleanup $i_token
     errorExit
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Although Tcl uses reference-counting garbage collection for temporary objects, some objects like the HTTP "tokens" returned by http::geturl are defined in a global symbol table and have infinite lifetimes unless explicitly freed. There were a few places I forgot to delete these objects in the **fabricLogger** utility. Those places have been identified and fixed.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1746 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I've run **busywork** test cases and followed the memory utilization of the **fabricLogger** using **top**. The obvious memory leak is now gone.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
