### PR TITLE
Busywork: Changes to allow PBFT batch runs to pass busywork tests

### DIFF
--- a/tools/busywork/README.md
+++ b/tools/busywork/README.md
@@ -88,25 +88,30 @@ to build the `peer` and `membersrvc` images. Then switch to the
 to run a simple stress test. This stress test exercises a single peer
 running `NOOPS` consensus.
 
-Currently Sieve is the only PBFT consensus algorithm that is stable enough
-to survive stress testing. The target
+At present the PBFT *batch* algorithm is the only true consensus algorithm
+being suported by the development team. (The *classic* and *sieve* algorithms
+may work for some cases.) The target 
 
-    make stress2s
+    make stress2b
 	
-runs Sieve on a 4-peer network. There is also a pre-canned target
+runs PBFT *batch* on a 4-peer network. 
+
+There is also a pre-canned target
 
     make secure1
 	
-that runs a 4-peer Sieve network with security.
+that runs a 4-peer PBFT *batch* network with security.
 
 The **busywork/counters/Makefile** allows you to define private targets in a
 private makefile, **private.mk**, which is included by the main Makefile. For
-example you might define a modification of the `stress2s` target in
+example you might define a modification of the `stress2b` target in
 **private.mk** to see what happens when the data arrays go from the default 1
 counter (8 bytes) to 1000 counters (8000 bytes):
 
-    .PHONY: stress2s1k
-	stress2s1k:
-            @$(NETWORK) -sieve 4
+    .PHONY: stress2b1k
+	stress2b1k:
+            @CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
+            $(NETWORK) -batch 4
+            @echo "Sleeping 10 seconds to allow peers to interlock"; sleep 10
 	        @$(STRESS2) -size 1000
 	

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -99,7 +99,9 @@ stress2: stress2b stress2c stress2s
 
 .PHONY: secure1
 secure1:
-	@$(NETWORK) -sieve -security 4
+	@CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
+	$(NETWORK) -batch -security 4
+	@echo "Sleeping 10 seconds to allow peers to interlock"; sleep 10
 	@./driver \
 		-transactions 100 \
 		-peerBurst 10 \

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -81,7 +81,9 @@ STRESS2 = ./driver \
 		-checkAgreement -dupCheck
 
 stress2b: 
-	@$(NETWORK) -batch 4
+	@CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
+	$(NETWORK) -batch 4
+	@echo "Sleeping 10 seconds to allow peers to interlock"; sleep 10
 	@$(STRESS2)
 
 stress2c: 

--- a/tools/busywork/counters/README.md
+++ b/tools/busywork/counters/README.md
@@ -177,7 +177,7 @@ mentioned above with the `parms -checkCounters` option, if state transfer has
 taken place on a peer then the expected count (which records the number of
 transactions actually executed by the peer) will not match the actual count
 obtained from the state. There is no reason for the expected and actual array
-lengths not to match.
+lengths not to match, however.
 
 
   

--- a/tools/busywork/counters/README.md
+++ b/tools/busywork/counters/README.md
@@ -58,9 +58,12 @@ values, interpreted as detailed for the individual keys below.
   interface. See the `-loggingLevel` option for details on the `<level>`
   argument. The default level for *shim* logging is WARNING.
   
-- `-checkCounters=<bool>` : The `<bool>` value defaults to `true`. This is a
-   debugging flag only (?). If `false`, the chaincode does not check for
-   consistency of the array state before incrementing and decrementing.
+- `-checkCounters=<bool>` : The `<bool>` value defaults to `false`.  When
+   `false`, the chaincode does not check for consistency of the array state
+   before incrementing and decrementing. This setting is required in most
+   cases because if a peer "falls behind" the other peers it may get its state
+   by a state transfer, and not by actually executing transactions. The `true`
+   setting will likely only work (and *should* work) with NOOPS consensus.
   
 - `-checkStatus=<bool>` : The `<bool>` value defaults to `true`. This is a
   debugging flag only. See **counters.go**, `status()` function for the
@@ -129,8 +132,6 @@ for each occurrence, without rewriting the array back to the state between
 increments.
 	
 
-
-
 ## Query Methods
 
 ### `parms ?... <parm> ...?`
@@ -171,7 +172,12 @@ Examples:
 	--> "1 1 10 10 2 2 20 20 3 3 30 30"
 
 It is an error to name an array that has not been created. This query *does
-not* signal an error if the expected and actual values do not match.
+not* signal an error if the expected and actual values do not match. As
+mentioned above with the `parms -checkCounters` option, if state transfer has
+taken place on a peer then the expected count (which records the number of
+transactions actually executed by the peer) will not match the actual count
+obtained from the state. There is no reason for the expected and actual array
+lengths not to match.
 
 
   

--- a/tools/busywork/counters/counters.go
+++ b/tools/busywork/counters/counters.go
@@ -233,7 +233,7 @@ func (c *counters) initParms(stub *shim.ChaincodeStub, args []string) (val []byt
 	flags.StringVar(&c.id, "id", "", "A unique identifier; Allows multiple copies of this chaincode to be deployed")
 	loggingLevel := flags.String("loggingLevel", "default", "The logging level of the chaincode logger. Defaults to INFO.")
 	shimLoggingLevel := flags.String("shimLoggingLevel", "default", "The logging level of the chaincode 'shim' interface. Defaults to WARNING.")
-	flags.BoolVar(&c.checkCounters, "checkCounters", true, "Default true; If false, no error/consistency checks are made on counter array states.")
+	flags.BoolVar(&c.checkCounters, "checkCounters", false, "Default false. If true, consistency checks are made on counter states during increment/decrement.")
 	flags.BoolVar(&c.checkStatus, "checkStatus", true, "Default true; If false, no error/consistency checks are made in the 'status' method.")
 	err = flags.Parse(args)
 	if err != nil {

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -210,7 +210,14 @@ Optional parameters. Default values are given after the colon:
 -finalWait <duration> : 10s    
 
     If not running in -interlock mode, wait this duration at the end of the
-    run to check the final status for correctness.
+    run before checking the final status for correctness.
+
+    If the run is in -interlock mode, then the run will not finish until at
+    least one peer has recorded every transaction. However due to delays and
+    state transfer, there may be lagging peers that have not finished yet. In
+    this case we do "strong reads" of the block height of every node, and do
+    not start checking until there is 100% consensus on the block
+    height. These checks must converge within the -finalWait time.
 
 -keepLog | -noKeepLog : -noKeepLog
 
@@ -457,13 +464,13 @@ for {set i 1} {$i <= [parms nArrays]} {incr i} {
 parms arrayNames $names
 note {} "[llength [parms arrayNames]] array(s) will be defined per chaincode"
 
-set countPerArray [expr {[parms transactions] * [parms clients]}]
-set totalTransactions \
-    [expr {$countPerArray * [parms nChaincodes] * [parms nArrays]}]
+parms countPerArray [expr {[parms transactions] * [parms clients]}]
+parms totalTransactions \
+    [expr {[parms countPerArray] * [parms nChaincodes] * [parms nArrays]}]
 
 note {} "[parms clients] clients will be activated"
-note {} "$countPerArray transaction(s) will be issued to each array"
-note {} "$totalTransactions total transaction(s) will be issued"
+note {} "[parms countPerArray] transaction(s) will be issued to each array"
+note {} "[parms totalTransactions] total transaction(s) will be issued"
 
 
 set sizes {}
@@ -781,6 +788,8 @@ proc clientRoutine {i_logger} {
     set keyBag [LimitedRandomBag new [parms arrayKeys] [parms transactions]]
     set uuids {}
 
+    setLoggingTimestamp 1
+
     while {1} {
 
         set netBurst {}
@@ -880,8 +889,10 @@ set t [time {set errors [waitPIDs $pids]} 1]
 
 if {!$errors} {
     set seconds [expr {[lindex $t 0] / 1e6}]
-    set rate [format %.2f [expr {$totalTransactions / $seconds}]]
-    note {} "Transaction rate : $rate per second ($totalTransactions / $seconds)"
+    set rate [format %.2f [expr {[parms totalTransactions] / $seconds}]]
+    note {} \
+        "Transaction rate : $rate per second " \
+        "([parms totalTransactions] / $seconds)"
 }
 
 if {$p_pprofClient} {
@@ -892,53 +903,100 @@ if {$p_pprofClient} {
     }
 }
 
+if {$errors && ![parms force]} {
+    errorExit "Aborting due to client errors"
+}
+
 
 # Finally, check the results for correctness. For the most accurate completed
 # transaction rates you need to -interlock, as it is likely that not all
 # invocations have been commited at this point if -interlock is not specified.
 
-if {![parms interlock] && (!$errors || [parms force])} {
+if {[parms interlock]} {
+
+    # For interlocked runs, do "strong reads" of the block height until
+    # consensus is reached.
+
+    proc strongReadBlockHeight {} {
+        set originalHeights [mapeach peer [parms peers] {
+            return [::fabric::height $peer]
+        }]
+        set heights [removeDuplicates $originalHeights]
+        if {[llength $heights] != 1} {
+            note {} "    Observed block heights: $originalHeights"
+        }
+        return [expr {[llength $heights] == 1}]
+    }
+    
+    note {} "Waiting up to [parms finalWait] for block-height consensus"
+    if {[waitFor [parms finalWait] strongReadBlockHeight 1s]} {
+        if {![parms force]} {
+            set errors 1
+            errorExit "Aborting due to block-height consensus timeout"
+        }
+    }
+        
+} else {
+
+    # For runs without -interlock, we always wait -finalWait before continuing
+    # with the checks.
+    
     note {} "Waiting [parms finalWait] before collecting the final status"
     after [durationToMs [parms finalWait]]
 }
 
-if {!$errors || [parms force]} {
-    note {} "Checking final results"
-    foreach peer [parms peers] {
-        foreach name [parms chaincodeNames] id [parms chaincodeIDs] {
-            debug {} "::fabric::query $peer $name status [parms arrayNames]"
-            set status \
-                [::fabric::query \
-                $peer [peerUser $peer] $name status [parms arrayNames]]
-            foreach \
-                {l1 l2 c1 c2} $status \
-                arrayName [parms arrayNames] \
-                size [parms arraySizes] {
 
-                    if {($l1 != $l2) || ($l1 != $size)} {
-                        err err \
-                            "Peer $peer : Array length mismatch for " \
+# Now we check the consistency of the counters. Due to state transfer it will
+# not always be the case the every chaincode executes every transaction, but
+# it must be the case that every chaincode has a state that makes it appear
+# that it executed every transaction.
+
+note {} "Checking consistency of the final state"
+foreach peer [parms peers] {
+    foreach name [parms chaincodeNames] id [parms chaincodeIDs] {
+        debug {} "::fabric::query $peer $name status [parms arrayNames]"
+        set status \
+            [::fabric::query \
+                 $peer [peerUser $peer] $name status [parms arrayNames]]
+        foreach \
+            {l1 l2 c1 c2} $status \
+            arrayName [parms arrayNames] \
+            size [parms arraySizes] {
+
+                if {($l1 != $l2) || ($l1 != $size)} {
+                    err {} \
+                        "Peer $peer : Array length mismatch for " \
                             "chaincode $id, array $arrayName.\n" \
                             "Expected $size, Reported $l1 $l2"
                         set errors 1
                     }
 
-                    if {($c1 != $c2) || ($c1 != $countPerArray)} {
-                        err err \
-                            "Peer $peer : Count mismatch for chaincode $id, " \
-                            "array $arrayName.\n" \
-                            "Expected $countPerArray, Reported $c1 $c2"
+                    if {$c1 != $c2} {
+                        warn {} \
+                            "Peer $peer: Expected/observed mismatch for " \
+                            "chaincode $id, array $arrayName"
+                        warn {} \
+                            "Expected [parms countPerArray], reported $c1 $c2"
+                    }
+
+                    if {$c2 != [parms countPerArray]} {
+                        err {} \
+                            "Peer $peer: Final count mismatch for " \
+                            "chaincode $id, array $arrayName"
+                        err {} \
+                            "Expected [parms countPerArray], Reported $c1 $c2"
                         set errors 1
                     }
                 }
         }
-    }
 }
 
 
-# Check for peer agreement
+# Check for peer agreement. Note that we do this even if the previous checks
+# failed. There are interesting cases where the status may be inconsistent but
+# the blockchains actually agree.
 
-if {$p_checkAgreement && (!$errors || [parms force])} {
+if {$p_checkAgreement} {
 
     note {} "Checking for agreement between the peers"
     set checkAgreement [file dirname [info script]]/../bin/checkAgreement
@@ -950,7 +1008,6 @@ if {$p_checkAgreement && (!$errors || [parms force])} {
         set errors 1
     }
 }
-
 
 if {$errors} {
     err err "Aborting due to errors, mismatches or disagreements above"

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -788,8 +788,6 @@ proc clientRoutine {i_logger} {
     set keyBag [LimitedRandomBag new [parms arrayKeys] [parms transactions]]
     set uuids {}
 
-    setLoggingTimestamp 1
-
     while {1} {
 
         set netBurst {}

--- a/tools/busywork/tcl/time.tcl
+++ b/tools/busywork/tcl/time.tcl
@@ -74,19 +74,24 @@ proc durationToIntegerSeconds {i_duration} {
     return [expr int([durationToMs $i_duration] / 1000)]
 }
 
-# waitFor i_timeout i_script
+# waitFor i_timeout i_script {i_poll}
 
 # This is a busy-wait polling loop that returns 0 if the i_script evaluates
 # non-0 before the timeout, otherwise returns -1 in the event of a
 # timeout. Specify -1 as the timeout to wait forever. Note that the test is
-# always guaranteed to be made at least one time, even for very short timeouts.
+# always guaranteed to be made at least one time, even for very short
+# timeouts. The i_poll argument specifies the polling interval and defaults to
+# 0, that is, continuous polling.
 
-proc waitFor {i_timeout i_script} {
+proc waitFor {i_timeout i_script {i_poll 0}} {
 
     set timeout [durationToMs $i_timeout]
+    set poll [durationToMs $i_poll]
 
     if {$timeout < 0} {
-        while {![uplevel $script]} {}
+        while {![uplevel $script]} {
+            if {$poll != 0} {after $poll}
+        }
         return 0
     }
 
@@ -95,6 +100,7 @@ proc waitFor {i_timeout i_script} {
     while {1} {
         if {[uplevel $i_script]} {return 0}
         if {$timedOut} {return -1}
+        if {$poll != 0} {after $poll}
         set now [clock clicks -milliseconds]
         set timedOut [expr {($now - $start) >= $timeout}]
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

The definition of correctness for **busywork** tests has been relaxed due to
the realities of the current PBFT consensus algorithms. Because of state transfer,
we can no longer assume that each peer has actually executed each
transaction. Instead, we can only demand that the state of the peer is
consistent with having executed every transaction. We also now wait until the
peers reach a consensus on the blockchain height at the end of the run before
querying for final status, since queries now fail on peers that are in the
middle of state transfer. 

Once a couple of outstanding consensus PRs are
processed we will probably be able to state that the busywork/counters test
case _stress2b_ is working. The documentation has already been updated as if that were true.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

This does not fix any open issues, but it is the result of working through several issues with @jyellick related to what happens during state transfer, and what it means for blockchain invokes and queries to be "correct".
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I have been testing this over a couple of weeks, for example in testing related to issues #1931 and #1857.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
