### PR TITLE
improve pbft performance of reqstore

### DIFF
--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -94,7 +94,7 @@ func TestClearOustandingReqsOnStateRecovery(t *testing.T) {
 
 	b.manager.Queue() <- nil
 
-	if len(*(b.reqStore.outstandingRequests)) != 0 {
+	if b.reqStore.outstandingRequests.Len() != 0 {
 		t.Fatalf("Should not have any requests outstanding after completing state transfer")
 	}
 }
@@ -133,7 +133,7 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 
 	for i, b := range bs {
 		b.manager.Queue() <- nil
-		count := len(*(b.reqStore.outstandingRequests))
+		count := b.reqStore.outstandingRequests.Len()
 		if i == 0 {
 			if count != 0 {
 				t.Errorf("Batch primary should not have the request in its store: %v", b.reqStore.outstandingRequests)
@@ -193,7 +193,7 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	events.SendEvent(b, committedEvent{})
 	execute()
 
-	if len(*(b.reqStore.outstandingRequests)) != 0 {
+	if b.reqStore.outstandingRequests.Len() != 0 {
 		t.Fatalf("All requests should have been executed and deleted after exec")
 	}
 

--- a/consensus/obcpbft/requeststore.go
+++ b/consensus/obcpbft/requeststore.go
@@ -125,7 +125,7 @@ func (rs *requestStore) remove(request *Request) (outstanding, pending bool) {
 	return
 }
 
-// getNextNonPending returns up to the next n outstanding, but not pending requests
+// hasNonPending returns up to the next n outstanding, but not pending requests
 func (rs *requestStore) hasNonPending() bool {
 	return rs.outstandingRequests.Len() > rs.pendingRequests.Len()
 }

--- a/consensus/obcpbft/requeststore_test.go
+++ b/consensus/obcpbft/requeststore_test.go
@@ -53,3 +53,31 @@ func TestOrderedRequests(t *testing.T) {
 		t.Errorf("incorrect order")
 	}
 }
+
+func BenchmarkOrderedRequests(b *testing.B) {
+	or := &orderedRequests{}
+	or.empty()
+
+	Nreq := 100
+
+	reqs := make(map[string]*Request)
+	for i := 0; i < Nreq; i++ {
+		rc := wrapRequest(createPbftRequestWithChainTx(int64(i), 0))
+		reqs[rc.key] = rc.req
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, r := range reqs {
+			or.add(r)
+		}
+
+		for k := range reqs {
+			_ = or.has(k)
+		}
+
+		for _, r := range reqs {
+			or.remove(r)
+		}
+	}
+}

--- a/consensus/obcpbft/requeststore_test.go
+++ b/consensus/obcpbft/requeststore_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+                 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package obcpbft
+
+import "testing"
+
+func TestOrderedRequests(t *testing.T) {
+	or := &orderedRequests{}
+	or.empty()
+
+	r1 := createPbftRequestWithChainTx(2, 1)
+	r2 := createPbftRequestWithChainTx(2, 2)
+	r3 := createPbftRequestWithChainTx(19, 1)
+	if or.has(wrapRequest(r1).key) {
+		t.Errorf("should not have req")
+	}
+	or.add(r1)
+	if !or.has(wrapRequest(r1).key) {
+		t.Errorf("should have req")
+	}
+	if or.has(wrapRequest(r2).key) {
+		t.Errorf("should not have req")
+	}
+	if or.remove(r2) {
+		t.Errorf("should not have removed req")
+	}
+	if !or.remove(r1) {
+		t.Errorf("should have removed req")
+	}
+	if or.remove(r1) {
+		t.Errorf("should not have removed req")
+	}
+	if len(or.order) != 0 || len(or.presence) != 0 {
+		t.Errorf("should have 0 len")
+	}
+	or.adds([]*Request{r1, r2, r3})
+
+	if or.order[2].req != r3 {
+		t.Errorf("incorrect order")
+	}
+}

--- a/consensus/obcpbft/requeststore_test.go
+++ b/consensus/obcpbft/requeststore_test.go
@@ -25,14 +25,14 @@ func TestOrderedRequests(t *testing.T) {
 	r1 := createPbftRequestWithChainTx(2, 1)
 	r2 := createPbftRequestWithChainTx(2, 2)
 	r3 := createPbftRequestWithChainTx(19, 1)
-	if or.has(wrapRequest(r1).key) {
+	if or.has(or.wrapRequest(r1).key) {
 		t.Errorf("should not have req")
 	}
 	or.add(r1)
-	if !or.has(wrapRequest(r1).key) {
+	if !or.has(or.wrapRequest(r1).key) {
 		t.Errorf("should have req")
 	}
-	if or.has(wrapRequest(r2).key) {
+	if or.has(or.wrapRequest(r2).key) {
 		t.Errorf("should not have req")
 	}
 	if or.remove(r2) {
@@ -44,12 +44,12 @@ func TestOrderedRequests(t *testing.T) {
 	if or.remove(r1) {
 		t.Errorf("should not have removed req")
 	}
-	if len(or.order) != 0 || len(or.presence) != 0 {
+	if or.order.Len() != 0 || len(or.presence) != 0 {
 		t.Errorf("should have 0 len")
 	}
 	or.adds([]*Request{r1, r2, r3})
 
-	if or.order[2].req != r3 {
+	if or.order.Back().Value.(requestContainer).req != r3 {
 		t.Errorf("incorrect order")
 	}
 }
@@ -58,11 +58,11 @@ func BenchmarkOrderedRequests(b *testing.B) {
 	or := &orderedRequests{}
 	or.empty()
 
-	Nreq := 100
+	Nreq := 1000
 
 	reqs := make(map[string]*Request)
 	for i := 0; i < Nreq; i++ {
-		rc := wrapRequest(createPbftRequestWithChainTx(int64(i), 0))
+		rc := or.wrapRequest(createPbftRequestWithChainTx(int64(i), 0))
 		reqs[rc.key] = rc.req
 	}
 	b.ResetTimer()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail. -->

Change complexity of batch outstanding requests datastructure from O(N^2) to O(1).
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a temporary performance regression.  Slack #performance-benchmark reports 10x performance increase.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- If this PR does not contain a new test case, explain why. -->

new tests
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
- [x] Either no new documentation is required by this change, OR I added new documentation
- [x] Either no new tests are required by this change, OR I added new tests
- [x] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Simon Schubert sis@zurich.ibm.com
