### PR TITLE
[make unit-test] Preventing a few "panic: runtime error" (caused by nil pointers dereferences)

### DIFF
--- a/events/consumer/consumer.go
+++ b/events/consumer/consumer.go
@@ -139,5 +139,9 @@ func (ec *EventsClient) Start() error {
 
 //Stop terminates connection with event hub
 func (ec *EventsClient) Stop() error {
+	if ec.stream == nil {
+		// in case the steam/chat server has not been established earlier, we assume that it's closed, successfully
+		return nil
+	}
 	return ec.stream.CloseSend()
 }

--- a/membersrvc/ca/ca.go
+++ b/membersrvc/ca/ca.go
@@ -435,7 +435,9 @@ func (ca *CA) readCertificateByKeyUsage(id string, usage x509.KeyUsage) ([]byte,
 	var raw []byte
 	err := ca.db.QueryRow("SELECT cert FROM Certificates WHERE id=? AND usage=?", id, usage).Scan(&raw)
 
-	Trace.Printf("err %v", err)
+	if err != nil {
+		Trace.Printf("readCertificateByKeyUsage() Error: %v", err)
+	}
 
 	return raw, err
 }
@@ -588,7 +590,7 @@ func (ca *CA) registerUserWithEnrollID(id string, enrollID string, role pb.Role,
 	var row int
 	err := ca.db.QueryRow("SELECT row FROM Users WHERE id=?", id).Scan(&row)
 	if err == nil {
-		return "", errors.New("user is already registered")
+		return "", errors.New("User is already registered")
 	}
 
 	_, err = ca.db.Exec("INSERT INTO Users (id, enrollmentId, token, role, metadata, state) VALUES (?, ?, ?, ?, ?, ?)", id, enrollID, tok, role, memberMetadata, 0)

--- a/membersrvc/ca/eca_test.go
+++ b/membersrvc/ca/eca_test.go
@@ -44,14 +44,10 @@ type User struct {
 }
 
 var (
-	ecaFiles  = [6]string{"eca.cert", "eca.db", "eca.priv", "eca.pub", "obc.aes", "obc.ecies"}
-	testAdmin = User{enrollID: "admin", enrollPwd: []byte("Xurw3yU9zI0l")}
-	testUser  = User{enrollID: "testUser", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
-	testUser2 = User{enrollID: "testUser2", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
-	//testPeer        = User{enrollID: "testPeer", role: 2}
-	//testPeer2       = User{enrollID: "testPeer", role: 2}
-	//testValidator   = User{enrollID: "testValidator", role: 4}
-	//testValidator2  = User{enrollID: "testValidator", role: 4}
+	ecaFiles    = [6]string{"eca.cert", "eca.db", "eca.priv", "eca.pub", "obc.aes", "obc.ecies"}
+	testAdmin   = User{enrollID: "admin", enrollPwd: []byte("Xurw3yU9zI0l")}
+	testUser    = User{enrollID: "testUser", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
+	testUser2   = User{enrollID: "testUser2", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
 	testAuditor = User{enrollID: "testAuditor", role: 8}
 )
 
@@ -60,8 +56,7 @@ func enrollUser(user *User) error {
 
 	ecap := &ECAP{eca}
 
-	//Phase 1 of the protocol
-	//generate crypto material
+	// Phase 1 of the protocol: Generate crypto material
 	signPriv, err := primitives.NewECDSAKey()
 	user.enrollPrivKey = signPriv
 	if err != nil {
@@ -131,7 +126,7 @@ func enrollUser(user *User) error {
 		return err
 	}
 
-	//verify we got vaild crypto material back
+	// Verify we got valid crypto material back
 	x509SignCert, err := primitives.DERToX509Certificate(resp.Certs.Sign)
 	if err != nil {
 		return err
@@ -175,7 +170,7 @@ func registerUser(registrar User, user *User) error {
 
 	r, s, err := ecdsa.Sign(rand.Reader, registrar.enrollPrivKey, hash.Sum(nil))
 	if err != nil {
-		msg := "Failed to register user.  Error signing request: " + err.Error()
+		msg := "Failed to register user. Error (ECDSA) signing request: " + err.Error()
 		return errors.New(msg)
 	}
 	R, _ := r.MarshalText()
@@ -187,15 +182,14 @@ func registerUser(registrar User, user *User) error {
 		return err
 	}
 
-	if token != nil {
-		//need the token for later tests
-		user.enrollPwd = token.Tok
-	} else {
+	if token == nil {
 		return errors.New("Failed to obtain token")
 	}
 
-	return nil
+	//need the token for later tests
+	user.enrollPwd = token.Tok
 
+	return nil
 }
 
 //check that the ECA was created / initialized
@@ -203,23 +197,22 @@ func TestNewECA(t *testing.T) {
 
 	//initialization was handled in TestMain
 	//check to see if ECA exists
-	if eca != nil {
+	if eca == nil {
+		t.Fatal("Failed to create ECA")
+	}
 
-		missing := 0
-		//check to see that the expected files were created
-		for _, file := range ecaFiles {
-			if _, err := os.Stat(eca.CA.path + "/" + file); err != nil {
-				missing++
-				t.Logf("failed to find file [%s]", file)
-			}
+	missing := 0
+
+	//check to see that the expected files were created
+	for _, file := range ecaFiles {
+		if _, err := os.Stat(eca.CA.path + "/" + file); err != nil {
+			missing++
+			t.Logf("Failed to find file: [%s]", file)
 		}
+	}
 
-		if missing > 0 {
-			t.FailNow()
-		}
-
-	} else {
-		t.Error("Failed to create ECA")
+	if missing > 0 {
+		t.Fail()
 	}
 }
 
@@ -232,7 +225,7 @@ func TestCreateCertificatePairAdmin(t *testing.T) {
 	err := enrollUser(&testAdmin)
 
 	if err != nil {
-		t.Errorf("Failed to enroll testAdmin: [%s]", err.Error())
+		t.Fatalf("Failed to enroll testAdmin: [%s]", err.Error())
 	}
 }
 
@@ -242,7 +235,7 @@ func TestRegisterUser(t *testing.T) {
 	err := registerUser(testAdmin, &testUser)
 
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 }
@@ -253,7 +246,7 @@ func TestCreateCertificatePairTestUser(t *testing.T) {
 	err := enrollUser(&testUser)
 
 	if err != nil {
-		t.Errorf("Failed to enroll testUser: [%s]", err.Error())
+		t.Fatalf("Failed to enroll testUser: [%s]", err.Error())
 	}
 }
 
@@ -262,8 +255,12 @@ func TestRegisterDuplicateUser(t *testing.T) {
 
 	err := registerUser(testAdmin, &testUser)
 
-	if err.Error() != "user is already registered" {
-		t.Errorf("Expected error was not returned when registering user twice: [%s]", err.Error())
+	if err == nil {
+		t.Fatal("Expected an error when registering the same user twice")
+	}
+
+	if err.Error() != "User is already registered" {
+		t.Fatalf("Expected error was not returned when registering user twice: [%s]", err.Error())
 	}
 }
 
@@ -274,7 +271,7 @@ func TestRegisterAuditor(t *testing.T) {
 	err := registerUser(testAdmin, &testAuditor)
 
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -287,21 +284,18 @@ func TestRegisterUserNonRegistrar(t *testing.T) {
 	err := registerUser(testUser, &testUser2)
 
 	if err == nil {
-		t.Error("User without registrar metadata should not be able to register a new user")
-	} else {
-		t.Log(err.Error())
+		t.Fatal("User without registrar metadata should not be able to register a new user")
 	}
+	t.Logf("Expected an error and indeed received: [%s]", err.Error())
 }
 
 func TestReadCACertificate(t *testing.T) {
-
 	ecap := &ECAP{eca}
 	_, err := ecap.ReadCACertificate(context.Background(), &pb.Empty{})
 
 	if err != nil {
-		t.Errorf("Failed to read ECA CA certificate: [%s]", err.Error())
+		t.Fatalf("Failed to read the CA certificate of the ECA: [%s]: ", err.Error())
 	}
-
 }
 
 func TestReadCertificatePair(t *testing.T) {
@@ -313,9 +307,8 @@ func TestReadCertificatePair(t *testing.T) {
 	_, err := ecap.ReadCertificatePair(context.Background(), req)
 
 	if err != nil {
-		t.Errorf("Failed to read certificate pair: [%s]", err.Error())
+		t.Fatalf("Failed to read certificate pair: [%s]", err.Error())
 	}
-
 }
 
 func TestReadCertificatePairBadIdentity(t *testing.T) {
@@ -327,9 +320,8 @@ func TestReadCertificatePairBadIdentity(t *testing.T) {
 	_, err := ecap.ReadCertificatePair(context.Background(), req)
 
 	if err != nil {
-		t.Errorf("Failed to read certificate pair: [%s]", err.Error())
+		t.Fatalf("Failed to read certificate pair: [%s]", err.Error())
 	}
-
 }
 
 func TestReadUserSet(t *testing.T) {
@@ -338,7 +330,7 @@ func TestReadUserSet(t *testing.T) {
 	err := enrollUser(&testAuditor)
 
 	if err != nil {
-		t.Errorf("Failed to read user set: [%s]", err.Error())
+		t.Fatalf("Failed to read user set [%s]", err.Error())
 	}
 
 	ecaa := &ECAA{eca}
@@ -355,7 +347,7 @@ func TestReadUserSet(t *testing.T) {
 
 	r, s, err := ecdsa.Sign(rand.Reader, testAuditor.enrollPrivKey, hash.Sum(nil))
 	if err != nil {
-		t.Errorf("Failed signing [%s].", err.Error())
+		t.Fatalf("Failed (ECDSA) signing [%s]", err.Error())
 	}
 	R, _ := r.MarshalText()
 	S, _ := s.MarshalText()
@@ -364,11 +356,9 @@ func TestReadUserSet(t *testing.T) {
 	resp, err := ecaa.ReadUserSet(context.Background(), req)
 
 	if err != nil {
-		t.Errorf("Failed to read user set: [%s]", err.Error())
+		t.Fatalf("Failed to read user set [%s]", err.Error())
 	}
-
-	t.Logf("number of users: [%d]", len(resp.Users))
-
+	t.Log("number of users: ", len(resp.Users))
 }
 
 func TestReadUserSetNonAuditor(t *testing.T) {
@@ -387,7 +377,7 @@ func TestReadUserSetNonAuditor(t *testing.T) {
 
 	r, s, err := ecdsa.Sign(rand.Reader, testUser.enrollPrivKey, hash.Sum(nil))
 	if err != nil {
-		t.Errorf("Failed signing [%s].", err.Error())
+		t.Fatalf("Failed (ECDSA) signing [%s]", err.Error())
 	}
 	R, _ := r.MarshalText()
 	S, _ := s.MarshalText()
@@ -396,7 +386,7 @@ func TestReadUserSetNonAuditor(t *testing.T) {
 	_, err = ecaa.ReadUserSet(context.Background(), req)
 
 	if err == nil {
-		t.Error("Only auditors should be able to call ReadUserSet")
+		t.Fatal("Only auditors should be able to call ReadUserSet")
 	}
 
 }
@@ -416,7 +406,7 @@ func TestCreateCertificatePairBadIdentity(t *testing.T) {
 	_, err := ecap.CreateCertificatePair(context.Background(), req)
 	if err.Error() != "Identity lookup error: sql: no rows in result set" {
 		t.Log(err.Error())
-		t.Error("Expected error was not returned for bad identity")
+		t.Fatal("The expected error of 'Identity lookup error: sql: no rows in result set' was not returned for bad identity")
 	}
 }
 
@@ -434,7 +424,7 @@ func TestCreateCertificatePairBadToken(t *testing.T) {
 
 	_, err := ecap.CreateCertificatePair(context.Background(), req)
 	if err.Error() != "Identity or token does not match." {
-		t.Error("Expected error was not returned for bad password")
+		t.Fatal("Expected error was not returned for bad password")
 	}
 }
 
@@ -444,7 +434,7 @@ func TestRevokeCertificatePair(t *testing.T) {
 
 	_, err := ecap.RevokeCertificatePair(context.Background(), &pb.ECertRevokeReq{})
 	if err.Error() != "ECAP:RevokeCertificate method not (yet) implemented" {
-		t.Errorf("Expected error was not returned: [%s]", err.Error())
+		t.Fatalf("Expected error was not returned: [%s]", err.Error())
 	}
 }
 
@@ -454,7 +444,7 @@ func TestRevokeCertificate(t *testing.T) {
 
 	_, err := ecaa.RevokeCertificate(context.Background(), &pb.ECertRevokeReq{})
 	if err.Error() != "ECAA:RevokeCertificate method not (yet) implemented" {
-		t.Errorf("Expected error was not returned: [%s]", err.Error())
+		t.Fatalf("Expected error was not returned: [%s]", err.Error())
 	}
 }
 
@@ -463,6 +453,6 @@ func TestPublishCRL(t *testing.T) {
 
 	_, err := ecaa.PublishCRL(context.Background(), &pb.ECertCRLReq{})
 	if err.Error() != "ECAA:PublishCRL method not (yet) implemented" {
-		t.Errorf("Expected error was not returned: [%s]", err.Error())
+		t.Fatalf("Expected error was not returned: [%s]", err.Error())
 	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

A tactical workaround has been provided earlier, as we learned that not all tests were failing or not failing right away.
## Description

A proposed fix for the `panic: runtime error: invalid memory address or nil pointer dereference`, making tests fail immediately after error.
- more calls to `t.Fatalf()`
- a minor fix in `ca.go` which now Trace.Print( err ) only if an error occurred (removing the printed `nil` output of the "happy path")
- add a check to prevent another `runtime panic()` when calling `Close()` of an `EventsClient` when a stream/connection was not established in earlier calls (e.g., during `Start()`)
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1952 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Ran tests in different environments too, verifying that the reported error could not be reproduced.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: JonathanLevi
