### PR TITLE
Add chaincode ping2#issue1850

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@ Fixes #
 <!-- To uncheck box, add a space: [ ] -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
-- [] I have added documentation to cover my changes or this change requires no new documentation.
-- [] I have added unit tests to cover my changes or this change requires no new tests.
+- [] I have either added documentation to cover my changes or this change requires no new documentation.
+- [] I have either added unit tests to cover my changes or this change requires no new tests.
 - [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.
 
 The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,26 @@
-<!--- Provide a general summary of your changes in the Title above -->
+<!-- Provide a general summary of your changes in the Title above -->
 
 ## Description
-<!--- Describe your changes in detail. -->
+<!-- Describe your changes in detail. -->
 
 ## Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
 Fixes #
 
 ## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- If this PR does not contain a new test case, explain why. -->
+<!-- If this PR does not contain a new test case, explain why. -->
+<!-- Describe in detail how you tested your changes. -->
 
 ## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff)
-- [] Either no new documentation is required by this change, OR I added new documentation
-- [] Either no new tests are required by this change, OR I added new tests
-- [] I have run [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports), [go vet](https://golang.org/cmd/vet/), and [golint](https://github.com/golang/lint). I have cleaned up all valid errors and warnings in code I have added or modified. These tools may generate false positives. Don't be worried about ignoring some errors or warnings. The goal is clean, consistent, and readable code.
+<!-- To check a box, and an 'x': [x] -->
+<!-- To uncheck box, add a space: [ ] -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
+- [] I have added documentation to cover my changes or this change requires no new documentation.
+- [] I have added unit tests to cover my changes or this change requires no new tests.
+- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.
+
+The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.
 
 Signed-off-by:

--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -130,13 +130,16 @@ func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEn
 		s.peerTLSSvrHostOrd = viper.GetString("peer.tls.serverhostoverride")
 	}
 
-	kadef := 5
+	kadef := 0
 	if ka := viper.GetString("chaincode.keepalive"); ka == "" {
 		s.keepalive = time.Duration(kadef) * time.Second
 	} else {
 		t, terr := strconv.Atoi(ka)
 		if terr != nil {
-			chaincodeLogger.Errorf("Invalid keepalive value %s (%s) defaulting to %d\n", ka, terr, kadef)
+			chaincodeLogger.Errorf("Invalid keepalive value %s (%s) defaulting to %d", ka, terr, kadef)
+			t = kadef
+		} else if t <= 0 {
+			chaincodeLogger.Debugf("Turn off keepalive(value %s)", ka)
 			t = kadef
 		}
 		s.keepalive = time.Duration(t) * time.Second

--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 	"time"
 
@@ -129,6 +130,18 @@ func NewChaincodeSupport(chainname ChainName, getPeerEndpoint func() (*pb.PeerEn
 		s.peerTLSSvrHostOrd = viper.GetString("peer.tls.serverhostoverride")
 	}
 
+	kadef := 5
+	if ka := viper.GetString("chaincode.keepalive"); ka == "" {
+		s.keepalive = time.Duration(kadef) * time.Second
+	} else {
+		t, terr := strconv.Atoi(ka)
+		if terr != nil {
+			chaincodeLogger.Errorf("Invalid keepalive value %s (%s) defaulting to %d\n", ka, terr, kadef)
+			t = kadef
+		}
+		s.keepalive = time.Duration(t) * time.Second
+	}
+
 	return s
 }
 
@@ -153,6 +166,7 @@ type ChaincodeSupport struct {
 	peerTLSCertFile      string
 	peerTLSKeyFile       string
 	peerTLSSvrHostOrd    string
+	keepalive            time.Duration
 }
 
 // DuplicateChaincodeHandlerError returned if attempt to register same chaincodeID while a stream already exists.

--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -393,6 +393,11 @@ chaincode:
     # the image
     installpath: /opt/gopath/bin/
 
+    #keepalive in seconds. In situations where the communiction goes through a 
+    #proxy that does not support keep-alive, this parameter will maintain connection
+    #between peer and chaincode.
+    #A value <= 0 turns keepalive off
+    keepalive: 1
 ###############################################################################
 #
 #    Ledger section - ledger configuration encompases both the blockchain

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -469,6 +469,9 @@ func TestExecuteInvokeTransaction(t *testing.T) {
 	//TLS is on by default. This is the ONLY test that does NOT use TLS
 	viper.Set("peer.tls.enabled", false)
 
+	//turn OFF keepalive. All other tests use keepalive
+	viper.Set("peer.chaincode.keepalive", "0")
+
 	if viper.GetBool("peer.tls.enabled") {
 		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
 		if err != nil {

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -264,7 +264,7 @@ func (handler *Handler) triggerNextState(msg *pb.ChaincodeMessage, send bool) {
 	handler.nextState <- &nextStateInfo{msg, send}
 }
 
-func (handler *Handler) wait() <-chan time.Time {
+func (handler *Handler) waitForKeepaliveTimer() <-chan time.Time {
 	if handler.chaincodeSupport.keepalive > 0 {
 		c := time.After(handler.chaincodeSupport.keepalive)
 		return c
@@ -332,7 +332,7 @@ func (handler *Handler) processStream() error {
 				return err
 			}
 			chaincodeLogger.Debugf("[%s]Move state message %s", shortuuid(in.Uuid), in.Type.String())
-		case <-handler.wait():
+		case <-handler.waitForKeepaliveTimer():
 			if handler.chaincodeSupport.keepalive <= 0 {
 				chaincodeLogger.Errorf("Invalid select: keepalive not on (keepalive=%d)", handler.chaincodeSupport.keepalive)
 				continue

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -224,8 +224,14 @@ func chatWithPeer(chaincodename string, stream PeerChaincodeStream, cc Chaincode
 				err = fmt.Errorf("Error handling message: %s", err)
 				return
 			}
-			if nsInfo != nil && nsInfo.sendToCC {
-				chaincodeLogger.Debugf("[%s]send state message %s", shortuuid(in.Uuid), in.Type.String())
+
+			//keepalive messages are PONGs to the fabric's PINGs
+			if (nsInfo != nil && nsInfo.sendToCC) || (in.Type == pb.ChaincodeMessage_KEEPALIVE) {
+				if in.Type == pb.ChaincodeMessage_KEEPALIVE {
+					chaincodeLogger.Debug("Sending KEEPALIVE response")
+				} else {
+					chaincodeLogger.Debugf("[%s]send state message %s", shortuuid(in.Uuid), in.Type.String())
+				}
 				if err = handler.serialSend(in); err != nil {
 					err = fmt.Errorf("Error sending %s: %s", in.Type.String(), err)
 					return
@@ -832,6 +838,7 @@ func (stub *ChaincodeStub) insertRowInternal(tableName string, row Row, update b
 }
 
 // ------------- ChaincodeEvent API ----------------------
+
 // SetEvent saves the event to be sent when a transaction is made part of a block
 func (stub *ChaincodeStub) SetEvent(name string, payload []byte) error {
 	stub.chaincodeEvent = &pb.ChaincodeEvent{EventName: name, Payload: payload}

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -866,6 +866,11 @@ func (handler *Handler) handleQueryChaincode(chaincodeName string, function stri
 
 // handleMessage message handles loop for shim side of chaincode/validator stream.
 func (handler *Handler) handleMessage(msg *pb.ChaincodeMessage) error {
+	if msg.Type == pb.ChaincodeMessage_KEEPALIVE {
+		// Received a keep alive message, we don't do anything with it for now
+		// and it does not touch the state machine
+		return nil
+	}
 	chaincodeLogger.Debugf("[%s]Handling ChaincodeMessage of type: %s(state:%s)", shortuuid(msg.Uuid), msg.Type, handler.FSM.Current())
 	if handler.FSM.Cannot(msg.Type.String()) {
 		errStr := fmt.Sprintf("[%s]Chaincode handler FSM cannot handle message (%s) with payload size (%d) while in state: %s", msg.Uuid, msg.Type.String(), len(msg.Payload), handler.FSM.Current())

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -314,6 +314,13 @@ chaincode:
     # the image
     installpath: /opt/gopath/bin/
 
+    #keepalive in seconds. In situations where the communiction goes through a 
+    #proxy that does not support keep-alive, this parameter will maintain connection
+    #between peer and chaincode
+    keepalive: 30
+
+###############################################################################
+#
 ###############################################################################
 #
 #    Ledger section - ledger configuration encompases both the blockchain

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -316,8 +316,9 @@ chaincode:
 
     #keepalive in seconds. In situations where the communiction goes through a 
     #proxy that does not support keep-alive, this parameter will maintain connection
-    #between peer and chaincode
-    keepalive: 30
+    #between peer and chaincode.
+    #A value <= 0 turns keepalive off
+    keepalive: 0
 
 ###############################################################################
 #

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -314,10 +314,10 @@ chaincode:
     # the image
     installpath: /opt/gopath/bin/
 
-    #keepalive in seconds. In situations where the communiction goes through a 
-    #proxy that does not support keep-alive, this parameter will maintain connection
-    #between peer and chaincode.
-    #A value <= 0 turns keepalive off
+    # keepalive in seconds. In situations where the communiction goes through a 
+    # proxy that does not support keep-alive, this parameter will maintain connection
+    # between peer and chaincode.
+    # A value <= 0 turns keepalive off
     keepalive: 0
 
 ###############################################################################

--- a/protos/api.pb.go
+++ b/protos/api.pb.go
@@ -36,8 +36,8 @@ It has these top-level messages:
 	ExecuteWithBinding
 	SigmaOutput
 	BuildResult
-	ChaincodeReg
 	TransactionRequest
+	ChaincodeReg
 	Interest
 	Register
 	Event

--- a/protos/chaincode.pb.go
+++ b/protos/chaincode.pb.go
@@ -109,6 +109,7 @@ const (
 	ChaincodeMessage_RANGE_QUERY_STATE       ChaincodeMessage_Type = 17
 	ChaincodeMessage_RANGE_QUERY_STATE_NEXT  ChaincodeMessage_Type = 18
 	ChaincodeMessage_RANGE_QUERY_STATE_CLOSE ChaincodeMessage_Type = 19
+	ChaincodeMessage_KEEPALIVE               ChaincodeMessage_Type = 20
 )
 
 var ChaincodeMessage_Type_name = map[int32]string{
@@ -132,6 +133,7 @@ var ChaincodeMessage_Type_name = map[int32]string{
 	17: "RANGE_QUERY_STATE",
 	18: "RANGE_QUERY_STATE_NEXT",
 	19: "RANGE_QUERY_STATE_CLOSE",
+	20: "KEEPALIVE",
 }
 var ChaincodeMessage_Type_value = map[string]int32{
 	"UNDEFINED":               0,
@@ -154,6 +156,7 @@ var ChaincodeMessage_Type_value = map[string]int32{
 	"RANGE_QUERY_STATE":       17,
 	"RANGE_QUERY_STATE_NEXT":  18,
 	"RANGE_QUERY_STATE_CLOSE": 19,
+	"KEEPALIVE":               20,
 }
 
 func (x ChaincodeMessage_Type) String() string {

--- a/protos/chaincode.proto
+++ b/protos/chaincode.proto
@@ -136,6 +136,7 @@ message ChaincodeMessage {
         RANGE_QUERY_STATE = 17;
         RANGE_QUERY_STATE_NEXT = 18;
         RANGE_QUERY_STATE_CLOSE = 19;
+        KEEPALIVE = 20;
     }
 
     Type type = 1;


### PR DESCRIPTION
Allow a keep alive messages between fabric and chaincode. Default is no-keepalive.
## Description

It is possible that an inactive gRPC connection between the chaincode and the peer can get broken by a intermediate proxy. Introduced a "keepalive" parameter (in seconds) which can be used to send ChaincodeMessage of type KEEPALIVE between the peer and chaincode. A chaincode just echoes the KEEPALIVE message received from the peer. 
## Motivation and Context

Keeps the connection between peer and chaincode going with application protocol level messages. This makes the connection liveness non dependent upon lower layer keepalive mechanisms.

Fixes #1850
## How Has This Been Tested?

Enabled all chaincode tests (except one for covering no keep-alive scenario) to use an aggressive keepalive timer of 1 second.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by:muralisr@us.ibm.com
