### PR TITLE
Removed VAGRANT env check for executing CAR platform test

### DIFF
--- a/core/chaincode/platforms/car/test/car_test.go
+++ b/core/chaincode/platforms/car/test/car_test.go
@@ -31,10 +31,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestCar_BuildImage(t *testing.T) {
-	if os.Getenv("VAGRANT") == "" {
-		t.Skip("skipping test; only supported within vagrant")
-	}
-
 	vm, err := container.NewVM()
 	if err != nil {
 		t.Fail()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

To remove the conditional check for VAGRANT env to run the CAR platform unit test
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Due to the presence of this conditional check, CAR platform unit test is not run on all platforms

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

This is a fix to the existing test case, which was not run on all platforms

<!-- Describe in detail how you tested your changes. -->
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: satheesh.ceg@gmail.com
