### PR TITLE
Fix busywork counters non-determinism

### DIFF
--- a/tools/busywork/counters/counters.go
+++ b/tools/busywork/counters/counters.go
@@ -192,12 +192,12 @@ func (c *counters) incDec(stub *shim.ChaincodeStub, args []string, incr int) (va
 		count := c.count[name]
 		counters := arrays[name]
 		offset[name] = offset[name] * uint64(incr)
-		new := count + offset[name]
 		c.debugf("incDec : Array %s has count %d and offset %d", name, count, offset[name])
 		for i, v := range counters {
 			if c.checkCounters && (v != count) {
 				c.criticalf("incDec : Element %s[%d] has value %d; Expected %d", name, i, v, count)
 			}
+			new := v + offset[name]
 			c.debugf("incDec : %s[%d] <- %d", name, i, new)
 			counters[i] = new
 		}


### PR DESCRIPTION
## Description

This changeset fixes the busywork counters chaincode to use the ledger retrieved state, rather than the chaincode local variable for updating the ledger state.
## Motivation and Context

This is invalid chaincode and has produced spurious test failures.

Fixes #1857, though #1857 is also being used to track a second checkpoint garbage collection issue that this non-deterministic testing surfaced.

As @bcbrock is the primary author of the busywork tests, his signoff should be required.
## How Has This Been Tested?

This is part of the busywork tests, and so this has been tested by running the busywork stress2b test.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
