### PR TITLE
Invalidate state on checkpoint quorum peer disagrees with

### DIFF
--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -134,9 +134,6 @@ func (op *obcBatch) submitToLeader(req *Request) events.Event {
 		return op.leaderProcReq(req)
 	}
 
-	op.reqStore.storeOutstanding(req)
-	op.startTimerIfOutstandingRequests()
-
 	return nil
 }
 

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -127,6 +127,7 @@ func (op *obcBatch) submitToLeader(req *Request) events.Event {
 
 	op.logAddTxFromRequest(req)
 	op.reqStore.storeOutstanding(req)
+	op.startTimerIfOutstandingRequests()
 
 	// if we believe we are the leader, then process this request
 	leader := op.pbft.primary(op.pbft.view)

--- a/core/peer/statetransfer/statetransfer.go
+++ b/core/peer/statetransfer/statetransfer.go
@@ -580,6 +580,7 @@ func (sts *coordinatorImpl) blockThread() {
 
 		case blockSyncReq := <-sts.blockSyncReq:
 			sts.syncBlockchainToCheckpoint(blockSyncReq)
+			continue
 		case <-sts.threadExit:
 			logger.Debug("Received request for block transfer thread to exit (1)")
 			return


### PR DESCRIPTION
## Description

This changeset verifies that the checkpoint quorum id agrees with its own checkpoint id.  If there is a quorum which disagrees with the local replica, the replica will invalidate its state, and perform state transfer.

As we have had multiple complaints about this behavior, I think this should be a candidate for inclusion in 0.5 (@srderson).  I will submit a complementary PR for master.  SMEs include @kchristidis @corecode or @tuand27613.
## Motivation and Context

The code previously naively assumed that its state must match the any checkpoint quorum, assuming it had reached that sequence number.  This caused the replica not to detect non-determinism if the replica generated its own checkpoint before the last matching quorum checkpoint was received.

This should eliminate the secondary behavior seen in #1857, where a replica would believe itself to be up to date with a diverged state.  The primary cause of #1857 (non-deterministic chaincode) has been fixed in pr #1969 for master.
## How Has This Been Tested?

This PR contains a new testcase which verifies the new behavior.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
