### PR TITLE
Fix build errors. Resolves issue #1965

### DIFF
--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -115,6 +115,26 @@ func (d *mockDevops) Query(c context.Context, cis *protos.ChaincodeInvocationSpe
 	return nil, fmt.Errorf("Unknown query function")
 }
 
+func (d *mockDevops) EXP_GetApplicationTCert(ctx context.Context, secret *protos.Secret) (*protos.Response, error) {
+	return nil, nil
+}
+
+func (d *mockDevops) EXP_PrepareForTx(ctx context.Context, secret *protos.Secret) (*protos.Response, error) {
+	return nil, nil
+}
+
+func (d *mockDevops) EXP_ProduceSigma(ctx context.Context, sigmaInput *protos.SigmaInput) (*protos.Response, error) {
+	return nil, nil
+}
+
+func (d *mockDevops) EXP_ExecuteWithBinding(ctx context.Context, executeWithBinding *protos.ExecuteWithBinding) (*protos.Response, error) {
+	return nil, nil
+}
+
+func (d *mockDevops) GetTransactionResult(ctx context.Context, txRequest *protos.TransactionRequest) (*protos.Response, error) {
+	return nil, nil
+}
+
 func initGlobalServerOpenchain(t *testing.T) {
 	var err error
 	serverOpenchain, err = NewOpenchainServerWithPeerInfo(new(peerInfo))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Fixes build errors resulting from PR #1903 
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1965

The issue was that PR #1923 was merged before PR #1903. This resulted in compile errors when #1903 was merged which were not detected by CI because it ran prior to #1923 being added to the master branch.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Ran `make checks`. No new test cases required as this does not add new functionality
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
