### PR TITLE
Invalidate state on checkpoint quorum peer disagrees with

### DIFF
--- a/consensus/obcpbft/pbft-core_test.go
+++ b/consensus/obcpbft/pbft-core_test.go
@@ -1770,31 +1770,45 @@ func TestStateNetworkMovesOnDuringSlowStateTransfer(t *testing.T) {
 	}
 }
 
-func TestViewChangeResend(t *testing.T) {
-	viewChangeSent := false
+// This test is designed to ensure state transfer occurs if our checkpoint does not match a quorum cert
+func TestCheckpointDiffersFromQuorum(t *testing.T) {
+	invalidated := false
+	skipped := false
 	instance := newPbftCore(3, loadConfig(), &omniProto{
-		broadcastImpl: func(b []byte) { viewChangeSent = true },
-		signImpl:      func(b []byte) ([]byte, error) { return b, nil },
-		verifyImpl:    func(senderID uint64, signature []byte, message []byte) error { return nil },
+		//broadcastImpl:       func(b []byte) { viewChangeSent = true },
+		//signImpl:            func(b []byte) ([]byte, error) { return b, nil },
+		//verifyImpl:          func(senderID uint64, signature []byte, message []byte) error { return nil },
+		invalidateStateImpl: func() { invalidated = true },
+		skipToImpl:          func(s uint64, id []byte, replicas []uint64) { skipped = true },
 	}, &inertTimerFactory{})
-	instance.activeView = true
 
-	events.SendEvent(instance, viewChangeResendTimerEvent{})
+	seqNo := uint64(10)
 
-	if !instance.activeView {
-		t.Fatalf("Should not have resent view change resent timer event while in an active view")
+	badChkpt := &Checkpoint{
+		SequenceNumber: 10,
+		Id:             base64.StdEncoding.EncodeToString([]byte("WRONG")),
+		ReplicaId:      0,
+	}
+	instance.chkpts[seqNo] = badChkpt.Id // This is done via the exec path, shortcut it here
+	events.SendEvent(instance, badChkpt)
+
+	for i := uint64(1); i <= 3; i++ {
+		events.SendEvent(instance, &Checkpoint{
+			SequenceNumber: 10,
+			Id:             base64.StdEncoding.EncodeToString([]byte("CORRECT")),
+			ReplicaId:      i,
+		})
 	}
 
-	oldView := uint64(2)
-	instance.activeView = false
-	instance.view = oldView
-	events.SendEvent(instance, viewChangeResendTimerEvent{})
-
-	if instance.activeView {
-		t.Fatalf("Should still be inactive in our view")
+	if instance.h != 10 {
+		t.Fatalf("Replica should have moved its watermarks but did not")
 	}
 
-	if instance.view != oldView {
-		t.Fatalf("Should still be waiting for the same view (%d) got %d", oldView, instance.view)
+	if !instance.skipInProgress {
+		t.Fatalf("Replica should be attempting state transfer")
+	}
+
+	if !invalidated || !skipped {
+		t.Fatalf("Replica should have invalidated its state and skipped")
 	}
 }


### PR DESCRIPTION
## Description

This changeset verifies that the checkpoint quorum id agrees with its own checkpoint id.  If there is a quorum which disagrees with the local replica, the replica will invalidate its state, and perform state transfer.

This is a companion PR to #1971.  SMEs include @kchristidis @corecode or @tuand27613.
## Motivation and Context

The code previously naively assumed that its state must match the any checkpoint quorum, assuming it had reached that sequence number.  This caused the replica not to detect non-determinism if the replica generated its own checkpoint before the last matching quorum checkpoint was received.

This should eliminate the secondary behavior seen in #1857, where a replica would believe itself to be up to date with a diverged state.  The primary cause of #1857 (non-deterministic chaincode) has been fixed in pr #1969 for master.
## How Has This Been Tested?

This PR contains a new testcase which verifies the new behavior.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
