### PR TITLE
Fix for #1968 switch in rolesToMask

### DIFF
--- a/sdk/node/src/hlc.ts
+++ b/sdk/node/src/hlc.ts
@@ -2552,7 +2552,7 @@ function rolesToMask(roles?:string[]):number {
     let mask:number = 0;
     if (roles) {
         for (let role in roles) {
-            switch (role) {
+            switch (roles[role]) {
                 case 'client':
                     mask |= 1;
                     break;       // Client mask


### PR DESCRIPTION
## Description

Iteration over array was based on index, but should have used the values in the array. fixed switch statement in rolesToMask
## Motivation and Context

The ability to register a user using the sdk with other than the default role 'client'
Fixes #1968 
## How Has This Been Tested?

Running updated unit tests in fabric/sdk/node/test/unit/

Submitted register request using sdk to peer in net mode. Confirmed in log and request response.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by:  Allen Bailey eabailey@us.ibm.com
