### PR TITLE
Assorted statetransfer fixes, general cleanup

### DIFF
--- a/core/peer/statetransfer/statetransfer.go
+++ b/core/peer/statetransfer/statetransfer.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/hyperledger/fabric/core/ledger/statemgmt"
 	"github.com/hyperledger/fabric/core/peer"
-	"github.com/hyperledger/fabric/protos"
+	pb "github.com/hyperledger/fabric/protos"
 	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 )
@@ -51,9 +51,9 @@ type PartialStack interface {
 	peer.BlockChainAccessor
 	peer.BlockChainModifier
 	peer.BlockChainUtil
-	GetPeers() (*protos.PeersMessage, error)
-	GetPeerEndpoint() (*protos.PeerEndpoint, error)
-	GetRemoteLedger(receiver *protos.PeerID) (peer.RemoteLedger, error)
+	GetPeers() (*pb.PeersMessage, error)
+	GetPeerEndpoint() (*pb.PeerEndpoint, error)
+	GetRemoteLedger(receiver *pb.PeerID) (peer.RemoteLedger, error)
 }
 
 // Coordinator is used to initiate state transfer.  Start must be called before use, and Stop should be called to free allocated resources
@@ -62,7 +62,7 @@ type Coordinator interface {
 	Stop()  // Stop up the block transfer go routine
 
 	// SyncToTarget attempts to move the state to the given target, returning an error, and whether this target might succeed if attempted at a later time
-	SyncToTarget(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID) (error, bool)
+	SyncToTarget(blockNumber uint64, blockHash []byte, peerIDs []*pb.PeerID) (error, bool)
 }
 
 // coordinatorImpl is the structure used to manage the state of state transfer
@@ -71,8 +71,6 @@ type coordinatorImpl struct {
 
 	DiscoveryThrottleTime time.Duration // The amount of time to wait after discovering there are no connected peers
 
-	id *protos.PeerID // Useful log messages and not attempting to recover from ourselves
-
 	stateValid bool // Are we currently operating under the assumption that the state is valid?
 	inProgress bool // Set when state transfer is in progress so that the state may not be consistent
 
@@ -80,14 +78,9 @@ type coordinatorImpl struct {
 	validBlockRanges     []*blockRange // Used by the block thread to track which pieces of the blockchain have already been hashed
 	RecoverDamage        bool          // Whether state transfer should ever modify or delete existing blocks if they are determined to be corrupted
 
-	blockHashReceiver chan *blockHashReply // Used to process incoming valid block hashes, write only from the state thread
-	blockSyncReq      chan *blockSyncReq   // Used to request a block sync, new requests cause the existing request to abort, write only from the state thread
+	blockSyncReq chan *blockSyncReq // Used to request a block sync, new requests cause the existing request to abort, write only from the state thread
 
 	threadExit chan struct{} // Used to inform the threads that we are shutting down
-
-	blockThreadIdle bool // Used to check if the block thread is idle
-
-	blockThreadIdleChan chan struct{} // Used to block until the block thread is idle
 
 	BlockRequestTimeout         time.Duration // How long to wait for a peer to respond to a block request
 	StateDeltaRequestTimeout    time.Duration // How long to wait for a peer to respond to a state delta request
@@ -103,27 +96,20 @@ type coordinatorImpl struct {
 // SyncToTarget consumes the calling thread and attempts to perform state transfer until success or an error occurs
 // If the peerIDs are nil, then all peers are assumed to have the given block.
 // If the call returns an error, a boolean is included which indicates if the error may be transient and the caller should retry
-func (sts *coordinatorImpl) SyncToTarget(blockNumber uint64, blockHash []byte, peerIDs []*protos.PeerID) (error, bool) {
-	logger.Debugf("%v attempting to sync to target %x for block number %d with peers %v", sts.id, blockHash, blockNumber, peerIDs)
-	bhr := &blockHashReply{
-		syncMark: syncMark{
-			blockNumber: blockNumber,
-			peerIDs:     peerIDs,
-		},
-		blockHash: blockHash,
-	}
+func (sts *coordinatorImpl) SyncToTarget(blockNumber uint64, blockHash []byte, peerIDs []*pb.PeerID) (error, bool) {
+	logger.Debugf("Syncing to target %x for block number %d with peers %v", blockHash, blockNumber, peerIDs)
 
 	if !sts.inProgress {
 		sts.currentStateBlockNumber = sts.stack.GetBlockchainSize() - 1 // The block height is one more than the latest block number
 		sts.inProgress = true
 	}
 
-	err, recoverable := sts.attemptStateTransfer(bhr)
-
+	err, recoverable := sts.attemptStateTransfer(blockNumber, peerIDs, blockHash)
 	if err == nil {
 		sts.inProgress = false
 	}
 
+	logger.Debugf("Sync to target %x for block number %d returned, now at block height %d with err=%v recoverable=%v", blockHash, blockNumber, sts.stack.GetBlockchainSize(), err, recoverable)
 	return err, recoverable
 }
 
@@ -151,14 +137,6 @@ func NewCoordinatorImpl(stack PartialStack) Coordinator {
 	sts := &coordinatorImpl{}
 
 	sts.stack = stack
-	ep, err := stack.GetPeerEndpoint()
-
-	if nil != err {
-		logger.Debug("Error resolving our own PeerID, this shouldn't happen")
-		sts.id = &protos.PeerID{Name: "ERROR_RESOLVING_ID"}
-	}
-
-	sts.id = ep.ID
 
 	sts.RecoverDamage = viper.GetBool("statetransfer.recoverdamage")
 
@@ -173,10 +151,6 @@ func NewCoordinatorImpl(stack PartialStack) Coordinator {
 	sts.blockSyncReq = make(chan *blockSyncReq)
 
 	sts.threadExit = make(chan struct{})
-
-	sts.blockThreadIdle = true
-
-	sts.blockThreadIdleChan = make(chan struct{})
 
 	sts.DiscoveryThrottleTime = 1 * time.Second // TODO make this configurable
 
@@ -217,18 +191,9 @@ func NewCoordinatorImpl(stack PartialStack) Coordinator {
 // custom interfaces and structure definitions
 // =============================================================================
 
-type syncMark struct {
-	blockNumber uint64
-	peerIDs     []*protos.PeerID
-}
-
-type blockHashReply struct {
-	syncMark
-	blockHash []byte
-}
-
 type blockSyncReq struct {
-	syncMark
+	blockNumber    uint64
+	peerIDs        []*pb.PeerID
 	reportOnBlock  uint64
 	replyChan      chan error
 	firstBlockHash []byte
@@ -262,12 +227,20 @@ func (a blockRangeSlice) Less(i, j int) bool {
 
 // Executes a func trying each peer included in peerIDs until successful
 // Attempts to execute over all peers if peerIDs is nil
-func (sts *coordinatorImpl) tryOverPeers(passedPeerIDs []*protos.PeerID, do func(peerID *protos.PeerID) error) (err error) {
+func (sts *coordinatorImpl) tryOverPeers(passedPeerIDs []*pb.PeerID, do func(peerID *pb.PeerID) error) (err error) {
 
 	peerIDs := passedPeerIDs
 
+	ep, err := sts.stack.GetPeerEndpoint()
+
+	if err != nil {
+		// Unless we throttle here, this condition will likely cause a tight loop which will adversely affect the rest of the system
+		time.Sleep(sts.DiscoveryThrottleTime)
+		return fmt.Errorf("Error resolving our own PeerID, this shouldn't happen")
+	}
+
 	if nil == passedPeerIDs {
-		logger.Debugf("%v tryOverPeers, no peerIDs given, discovering", sts.id)
+		logger.Debugf("tryOverPeers: no peerIDs given, discovering")
 
 		peersMsg, err := sts.stack.GetPeers()
 		if err != nil {
@@ -275,21 +248,21 @@ func (sts *coordinatorImpl) tryOverPeers(passedPeerIDs []*protos.PeerID, do func
 		}
 		peers := peersMsg.GetPeers()
 		for _, endpoint := range peers {
-			if endpoint.Type == protos.PeerEndpoint_VALIDATOR {
-				if endpoint.ID.Name == sts.id.Name {
+			if endpoint.Type == pb.PeerEndpoint_VALIDATOR {
+				if endpoint.ID.Name == ep.ID.Name {
 					continue
 				}
 				peerIDs = append(peerIDs, endpoint.ID)
 			}
 		}
 
-		logger.Debugf("%v discovered %d peerIDs", sts.id, len(peerIDs))
+		logger.Debugf("Discovered %d peerIDs", len(peerIDs))
 	}
 
-	logger.Debugf("%v in tryOverPeers, using peerIDs: %v", sts.id, peerIDs)
+	logger.Debugf("tryOverPeers: using peerIDs: %v", peerIDs)
 
 	if 0 == len(peerIDs) {
-		logger.Errorf("%v invoked tryOverPeers with no peers specified, throttling thread", sts.id)
+		logger.Errorf("Invoked tryOverPeers with no peers specified, throttling thread")
 		// Unless we throttle here, this condition will likely cause a tight loop which will adversely affect the rest of the system
 		time.Sleep(sts.DiscoveryThrottleTime)
 		return fmt.Errorf("No peers available to try over")
@@ -304,7 +277,7 @@ func (sts *coordinatorImpl) tryOverPeers(passedPeerIDs []*protos.PeerID, do func
 		if err == nil {
 			break
 		} else {
-			logger.Warningf("%v in tryOverPeers loop trying %v : %s", sts.id, peerIDs[index], err)
+			logger.Warningf("tryOverPeers: loop error from %v : %s", peerIDs[index], err)
 		}
 	}
 
@@ -315,17 +288,17 @@ func (sts *coordinatorImpl) tryOverPeers(passedPeerIDs []*protos.PeerID, do func
 // Attempts to complete a blockSyncReq using the supplied peers
 // Will return the last block number attempted to sync, and the last block successfully synced (or nil) and error on failure
 // This means on failure, the returned block corresponds to 1 higher than the returned block number
-func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []byte, peerIDs []*protos.PeerID) (uint64, *protos.Block, error) {
-	logger.Debugf("%v syncing blocks from %d to %d with head hash of %x", sts.id, highBlock, lowBlock, highHash)
+func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []byte, peerIDs []*pb.PeerID) (uint64, *pb.Block, error) {
+	logger.Debugf("Syncing blocks from %d to %d with head hash of %x", highBlock, lowBlock, highHash)
 	validBlockHash := highHash
 	blockCursor := highBlock
-	var block *protos.Block
+	var block *pb.Block
 	var goodRange *blockRange
 
-	err := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
+	err := sts.tryOverPeers(peerIDs, func(peerID *pb.PeerID) error {
 		for {
 			intermediateBlock := blockCursor + 1
-			var blockChan <-chan *protos.SyncBlocks
+			var blockChan <-chan *pb.SyncBlocks
 			var err error
 			for {
 
@@ -339,13 +312,12 @@ func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []by
 					if intermediateBlock < lowBlock {
 						intermediateBlock = lowBlock
 					}
-					logger.Debugf("%v requesting block range from %d to %d", sts.id, blockCursor, intermediateBlock)
+					logger.Debugf("Requesting block range from %d to %d", blockCursor, intermediateBlock)
 					blockChan, err = sts.GetRemoteBlocks(peerID, blockCursor, intermediateBlock)
 				}
 
 				if nil != err {
-					logger.Warningf("%v failed to get blocks from %d to %d from %v: %s",
-						sts.id, blockCursor, lowBlock, peerID, err)
+					logger.Warningf("Failed to get blocks from %d to %d from %v: %s", blockCursor, lowBlock, peerID, err)
 					return err
 				}
 
@@ -358,28 +330,26 @@ func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []by
 
 					if syncBlockMessage.Range.Start < syncBlockMessage.Range.End {
 						// If the message is not replying with blocks backwards, we did not ask for it
-						return fmt.Errorf("%v received a block with wrong (increasing) order from %v, aborting", sts.id, peerID)
+						return fmt.Errorf("Received a block with wrong (increasing) order from %v, aborting", peerID)
 					}
 
 					var i int
 					for i, block = range syncBlockMessage.Blocks {
 						// It no longer correct to get duplication or out of range blocks, so we treat this as an error
 						if syncBlockMessage.Range.Start-uint64(i) != blockCursor {
-							return fmt.Errorf("%v received a block out of order, indicating a buffer overflow or other corruption: start=%d, end=%d, wanted %d", sts.id, syncBlockMessage.Range.Start, syncBlockMessage.Range.End, blockCursor)
+							return fmt.Errorf("Received a block out of order, indicating a buffer overflow or other corruption: start=%d, end=%d, wanted %d", syncBlockMessage.Range.Start, syncBlockMessage.Range.End, blockCursor)
 						}
 
 						testHash, err := sts.stack.HashBlock(block)
 						if nil != err {
-							return fmt.Errorf("%v got a block %d which could not hash from %v: %s",
-								sts.id, blockCursor, peerID, err)
+							return fmt.Errorf("Got a block %d which could not hash from %v: %s", blockCursor, peerID, err)
 						}
 
 						if !bytes.Equal(testHash, validBlockHash) {
-							return fmt.Errorf("%v got block %d from %v with hash %x, was expecting hash %x",
-								sts.id, blockCursor, peerID, testHash, validBlockHash)
+							return fmt.Errorf("Got block %d from %v with hash %x, was expecting hash %x", blockCursor, peerID, testHash, validBlockHash)
 						}
 
-						logger.Debugf("%v putting block %d to with PreviousBlockHash %x and StateHash %x", sts.id, blockCursor, block.PreviousBlockHash, block.StateHash)
+						logger.Debugf("Putting block %d to with PreviousBlockHash %x and StateHash %x", blockCursor, block.PreviousBlockHash, block.StateHash)
 						if !sts.RecoverDamage {
 
 							// If we are not supposed to be destructive in our recovery, check to make sure this block doesn't already exist
@@ -390,10 +360,10 @@ func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []by
 										panic("The blockchain is corrupt and the configuration has specified that bad blocks should not be deleted/overridden")
 									}
 								} else {
-									logger.Errorf("%v could not compute the hash of block %d", sts.id, blockCursor)
+									logger.Errorf("Could not compute the hash of block %d", blockCursor)
 									panic("The blockchain is corrupt and the configuration has specified that bad blocks should not be deleted/overridden")
 								}
-								logger.Debugf("%v not actually putting block %d to with PreviousBlockHash %x and StateHash %x, as it already exists", sts.id, blockCursor, block.PreviousBlockHash, block.StateHash)
+								logger.Debugf("Not actually putting block %d to with PreviousBlockHash %x and StateHash %x, as it already exists", blockCursor, block.PreviousBlockHash, block.StateHash)
 							} else {
 								sts.stack.PutBlock(blockCursor, block)
 							}
@@ -410,23 +380,23 @@ func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []by
 						validBlockHash = block.PreviousBlockHash
 
 						if blockCursor == lowBlock {
-							logger.Debugf("%v successfully synced from block %d to block %d", sts.id, highBlock, lowBlock)
+							logger.Debugf("Successfully synced from block %d to block %d", highBlock, lowBlock)
 							return nil
 						}
 						blockCursor--
 
 					}
 				case <-time.After(sts.BlockRequestTimeout):
-					return fmt.Errorf("%v had block sync request to %v time out", sts.id, peerID)
+					return fmt.Errorf("Had block sync request to %v time out", peerID)
 				}
 			}
 		}
 	})
 
 	if nil != block {
-		logger.Debugf("%v returned from sync with block %d and state hash %x", sts.id, blockCursor, block.StateHash)
+		logger.Debugf("Returned from sync with block %d and state hash %x", blockCursor, block.StateHash)
 	} else {
-		logger.Debugf("%v returned from sync with no new blocks", sts.id)
+		logger.Debugf("Returned from sync with no new blocks")
 	}
 
 	if goodRange != nil {
@@ -438,9 +408,9 @@ func (sts *coordinatorImpl) syncBlocks(highBlock, lowBlock uint64, highHash []by
 
 }
 
-func (sts *coordinatorImpl) syncBlockchainToCheckpoint(blockSyncReq *blockSyncReq) {
+func (sts *coordinatorImpl) syncBlockchainToTarget(blockSyncReq *blockSyncReq) {
 
-	logger.Debugf("%v is processing a blockSyncReq to block %d", sts.id, blockSyncReq.blockNumber)
+	logger.Debugf("Processing a blockSyncReq to block %d", blockSyncReq.blockNumber)
 
 	blockchainSize := sts.stack.GetBlockchainSize()
 
@@ -456,7 +426,7 @@ func (sts *coordinatorImpl) syncBlockchainToCheckpoint(blockSyncReq *blockSyncRe
 		_, _, err := sts.syncBlocks(blockSyncReq.blockNumber, blockSyncReq.reportOnBlock, blockSyncReq.firstBlockHash, blockSyncReq.peerIDs)
 
 		if nil != blockSyncReq.replyChan {
-			logger.Debugf("%v replying to blockSyncReq on reply channel with : %s", sts.id, err)
+			logger.Debugf("Replying to blockSyncReq on reply channel with : %s", err)
 			blockSyncReq.replyChan <- err
 		}
 	}
@@ -467,13 +437,13 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 	if 0 == len(sts.validBlockRanges) {
 		size := sts.stack.GetBlockchainSize()
 		if 0 == size {
-			logger.Warningf("%v has no blocks in its blockchain, including the genesis block", sts.id)
+			logger.Warningf("No blocks in the blockchain, including the genesis block")
 			return false
 		}
 
 		block, err := sts.stack.GetBlockByNumber(size - 1)
 		if nil != err {
-			logger.Warningf("%v could not retrieve its head block %d: %s", sts.id, size, err)
+			logger.Warningf("Could not retrieve head block %d: %s", size, err)
 			return false
 		}
 
@@ -489,7 +459,7 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 
 	lowBlock := sts.validBlockRanges[0].lowBlock
 
-	logger.Debugf("%v validating existing blockchain, highest validated block is %d, valid through %d", sts.id, sts.validBlockRanges[0].highBlock, lowBlock)
+	logger.Debugf("Validating existing blockchain, highest validated block is %d, valid through %d", sts.validBlockRanges[0].highBlock, lowBlock)
 
 	if 1 == len(sts.validBlockRanges) {
 		if 0 == lowBlock {
@@ -508,18 +478,18 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 				// Range overlaps or is adjacent
 				block, err := sts.stack.GetBlockByNumber(lowBlock - 1) // Subtraction is safe here, lowBlock > 0
 				if nil != err {
-					logger.Warningf("%v could not retrieve block %d which it believed to be valid: %s", sts.id, lowBlock-1, err)
+					logger.Warningf("Could not retrieve block %d, believed to be valid: %s", lowBlock-1, err)
 				} else {
-					if blockHash, err := sts.stack.HashBlock(block); nil != err {
+					if blockHash, err := sts.stack.HashBlock(block); err == nil {
 						if bytes.Equal(blockHash, lowNextHash) {
 							// The chains connect, no need to validate all the way down
 							sts.validBlockRanges[0].lowBlock = sts.validBlockRanges[1].lowBlock
 							sts.validBlockRanges[0].lowNextHash = sts.validBlockRanges[1].lowNextHash
 						} else {
-							logger.Warningf("%v detected that a block range starting at %d previously believed to be valid did not hash correctly", sts.id, lowBlock-1)
+							logger.Warningf("Detected a block range starting at %d previously believed to be valid did not hash correctly", lowBlock-1)
 						}
 					} else {
-						logger.Warningf("%v could not hash block %d which it believed to be valid: %s", sts.id, lowBlock-1, err)
+						logger.Warningf("Could not hash block %d, believed to be valid: %s", lowBlock-1, err)
 					}
 				}
 			} else {
@@ -548,16 +518,16 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 
 	lastGoodBlockNumber, err := sts.stack.VerifyBlockchain(lowBlock, targetBlock)
 
-	logger.Debugf("%v verified chain from %d to %d, with target of %d", sts.id, lowBlock, lastGoodBlockNumber, targetBlock)
+	logger.Debugf("Verified chain from %d to %d, with target of %d", lowBlock, lastGoodBlockNumber, targetBlock)
 
 	if err != nil {
-		logger.Criticalf("%v had something go wrong while validating the blockchain, not sure if we will recover: %s", sts.id, err)
+		logger.Criticalf("Something went wrong validating the blockchain, recover may be impossible: %s", err)
 		return false
 	}
 
 	lastGoodBlock, err := sts.stack.GetBlockByNumber(lastGoodBlockNumber)
 	if nil != err {
-		logger.Errorf("%v could not retrieve block %d which it believed to be valid: %s", sts.id, lowBlock-1, err)
+		logger.Errorf("Could not retrieve block %d, believed to be valid: %s", lowBlock-1, err)
 		return false
 	}
 
@@ -573,246 +543,224 @@ func (sts *coordinatorImpl) verifyAndRecoverBlockchain() bool {
 
 func (sts *coordinatorImpl) blockThread() {
 
-	sts.blockThreadIdle = false
+	toggleOn := make(chan struct{})
+	close(toggleOn)
+	var toggleOff chan struct{}
+
+	// toggleOn causes the toggle case to always be able to be selected
+	// toggleOff causes the toggle case to never be selected
+	toggle := toggleOn
+
 	for {
-
 		select {
-
 		case blockSyncReq := <-sts.blockSyncReq:
-			sts.syncBlockchainToCheckpoint(blockSyncReq)
-		case <-sts.threadExit:
-			logger.Debug("Received request for block transfer thread to exit (1)")
-			return
-		default:
-			// If there is no checkpoint to sync to, make sure the rest of the chain is valid
+			sts.syncBlockchainToTarget(blockSyncReq)
+			toggle = toggleOn
+		case <-toggle:
+			// If there is no target to sync to, make sure the rest of the chain is valid
 			if !sts.verifyAndRecoverBlockchain() {
 				// There is more verification to be done, so loop
 				continue
 			}
+			logger.Infof("Validated blockchain to the genesis block")
+			toggle = toggleOff
+		case <-sts.threadExit:
+			logger.Debug("Received request for block transfer thread to exit (1)")
+			return
 		}
-
-		logger.Debugf("%v has validated its blockchain to the genesis block", sts.id)
-
-	outer:
-		for {
-			sts.blockThreadIdle = true
-			select {
-			// If we make it this far, the whole blockchain has been validated, so we only need to watch for checkpoint sync requests
-			case blockSyncReq := <-sts.blockSyncReq:
-				sts.blockThreadIdle = false
-				logger.Debug("Block thread received request for block transfer thread to sync")
-				sts.syncBlockchainToCheckpoint(blockSyncReq)
-				break outer
-			case sts.blockThreadIdleChan <- struct{}{}:
-				logger.Debugf("%v block thread reporting as idle to unblock someone", sts.id)
-				continue
-			case <-sts.threadExit:
-				logger.Debug("Block thread received request for block transfer thread to exit (2)")
-				sts.blockThreadIdle = true
-				return
-			}
-		}
-
 	}
 }
 
-func (sts *coordinatorImpl) attemptStateTransfer(mark *blockHashReply) (error, bool) {
+func (sts *coordinatorImpl) attemptStateTransfer(blockNumber uint64, peerIDs []*pb.PeerID, blockHash []byte) (error, bool) {
 	var err error
 
-	if sts.currentStateBlockNumber+uint64(sts.maxStateDeltas) < mark.blockNumber {
+	if sts.currentStateBlockNumber+uint64(sts.maxStateDeltas) < blockNumber {
 		sts.stateValid = false
 	}
 
 	if !sts.stateValid {
 		// Our state is currently bad, so get a new one
-		sts.currentStateBlockNumber, err = sts.syncStateSnapshot(mark.blockNumber, mark.peerIDs)
+		sts.currentStateBlockNumber, err = sts.syncStateSnapshot(blockNumber, peerIDs)
 
 		if nil != err {
-			return fmt.Errorf("%v could not retrieve state as recent as %d from any of specified peers", sts.id, mark.blockNumber), true
+			return fmt.Errorf("Could not retrieve state as recent as %d from any of specified peers", blockNumber), true
 		}
 
-		logger.Debugf("%v completed state transfer to block %d", sts.id, sts.currentStateBlockNumber)
+		logger.Debugf("Completed state transfer to block %d", sts.currentStateBlockNumber)
 	}
 
 	// TODO, eventually we should allow lower block numbers and rewind transactions as needed
-	if mark.blockNumber < sts.currentStateBlockNumber {
-		return fmt.Errorf("%v cannot validate its state, because its current state corresponds to a higher block number %d than was supplied %d", sts.id, sts.currentStateBlockNumber, mark.blockNumber), false
+	if blockNumber < sts.currentStateBlockNumber {
+		return fmt.Errorf("Cannot validate its state, because its current state corresponds to a higher block number %d than was supplied %d", sts.currentStateBlockNumber, blockNumber), false
 	}
 
 	blockReplyChannel := make(chan error)
 
 	req := &blockSyncReq{
-		syncMark:       mark.syncMark,
+		blockNumber:    blockNumber,
+		peerIDs:        peerIDs,
 		reportOnBlock:  sts.currentStateBlockNumber,
 		replyChan:      blockReplyChannel,
-		firstBlockHash: mark.blockHash,
+		firstBlockHash: blockHash,
 	}
 
 	select {
 	case sts.blockSyncReq <- req:
 	case <-sts.threadExit:
-		logger.Debug("Received request for a calling thread to exit while waiting for block sync reply")
+		logger.Debug("Received request to exit while calling thread waiting for block sync reply")
 		return fmt.Errorf("Interrupted with request to exit while waiting for block sync reply."), false
 	}
 
-	logger.Debugf("%v state transfer thread waiting for block sync to complete", sts.id)
+	logger.Debugf("State transfer thread waiting for block sync to complete")
 	select {
 	case err = <-blockReplyChannel:
 	case <-sts.threadExit:
 		return fmt.Errorf("Interrupted while waiting for block sync reply"), false
 	}
-	logger.Debugf("%v state transfer thread continuing", sts.id)
+	logger.Debugf("State transfer thread continuing")
 
 	if err != nil {
-		return fmt.Errorf("%v could not retrieve all blocks as recent as %d as requested: %s", sts.id, mark.blockNumber, err), true
+		return fmt.Errorf("Could not retrieve all blocks as recent as %d as requested: %s", blockNumber, err), true
 	}
 
 	stateHash, err := sts.stack.GetCurrentStateHash()
 	if nil != err {
 		sts.stateValid = false
-		return fmt.Errorf("%v could not compute its current state hash: %s", sts.id, err), true
+		return fmt.Errorf("Could not compute its current state hash: %s", err), true
 
 	}
 
 	block, err := sts.stack.GetBlockByNumber(sts.currentStateBlockNumber)
 	if err != nil {
-		return fmt.Errorf("%v could not get block %d though we just retreived it: %s", sts.id, sts.currentStateBlockNumber, err), true
+		return fmt.Errorf("Could not get block %d though we just retreived it: %s", sts.currentStateBlockNumber, err), true
 	}
 
 	if !bytes.Equal(stateHash, block.StateHash) {
 		if sts.stateValid {
 			sts.stateValid = false
-			return fmt.Errorf("%v believed its state for block %d to be valid, but its hash (%x) did not match the recovered blockchain's (%x)", sts.id, sts.currentStateBlockNumber, stateHash, block.StateHash), true
+			return fmt.Errorf("Believed its state for block %d to be valid, but its hash (%x) did not match the recovered blockchain's (%x)", sts.currentStateBlockNumber, stateHash, block.StateHash), true
 		}
-		return fmt.Errorf("%v recovered to an incorrect state at block number %d, (%x, %x)", sts.id, sts.currentStateBlockNumber, stateHash, block.StateHash), true
+		return fmt.Errorf("Recovered to an incorrect state at block number %d, (%x, %x)", sts.currentStateBlockNumber, stateHash, block.StateHash), true
 	}
 
-	logger.Debugf("%v state is now valid", sts.id)
+	logger.Debugf("State is now valid at block %d and hash %x", sts.currentStateBlockNumber, stateHash)
 
 	sts.stateValid = true
 
-	if sts.currentStateBlockNumber < mark.blockNumber {
-		sts.currentStateBlockNumber, err = sts.playStateUpToBlockNumber(sts.currentStateBlockNumber+uint64(1), mark.blockNumber, mark.peerIDs)
+	if sts.currentStateBlockNumber < blockNumber {
+		err = sts.playStateUpToBlockNumber(blockNumber, peerIDs)
 		if nil != err {
 			// This is unlikely, in the future, we may wish to play transactions forward rather than retry
 			sts.stateValid = false
-			return fmt.Errorf("%v was unable to play the state from block number %d forward to block %d: %s", sts.id, sts.currentStateBlockNumber, mark.blockNumber, err), true
+			return fmt.Errorf("Was unable to play the state from block number %d forward to block %d: %s", sts.currentStateBlockNumber, blockNumber, err), true
 		}
 	}
 
 	return nil, true
 }
 
-// blockUntilIdle makes a best effort to block until the state transfer is idle
-func (sts *coordinatorImpl) blockUntilIdle() {
-	logger.Debugf("%v caller requesting to block until idle", sts.id)
-	select {
-	case <-sts.blockThreadIdleChan:
-	case <-sts.threadExit: // In case the block thread is gone
-	}
-}
+func (sts *coordinatorImpl) playStateUpToBlockNumber(toBlockNumber uint64, peerIDs []*pb.PeerID) error {
+	logger.Debugf("Attempting to play state forward from %v to block %d", peerIDs, toBlockNumber)
+	var stateHash []byte
+	err := sts.tryOverPeers(peerIDs, func(peerID *pb.PeerID) error {
 
-func (sts *coordinatorImpl) playStateUpToBlockNumber(fromBlockNumber, toBlockNumber uint64, peerIDs []*protos.PeerID) (uint64, error) {
-	logger.Debugf("%v attempting to play state forward from %v to block %d", sts.id, peerIDs, toBlockNumber)
-	currentBlock := fromBlockNumber
-	err := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
-
-		intermediateBlock := currentBlock - 1 // Underflow is okay here, as we immediately overflow, and assign
-		var deltaMessages <-chan *protos.SyncStateDeltas
+		var deltaMessages <-chan *pb.SyncStateDeltas
 		for {
 
-			if intermediateBlock+1 == currentBlock {
-				intermediateBlock = currentBlock + sts.maxStateDeltaRange
-				if intermediateBlock > toBlockNumber {
-					intermediateBlock = toBlockNumber
-				}
-				logger.Debugf("%v requesting state delta range from %d to %d", sts.id, currentBlock, intermediateBlock)
-				var err error
-				deltaMessages, err = sts.GetRemoteStateDeltas(peerID, currentBlock, intermediateBlock)
+			intermediateBlock := sts.currentStateBlockNumber + 1 + sts.maxStateDeltaRange
+			if intermediateBlock > toBlockNumber {
+				intermediateBlock = toBlockNumber
+			}
+			logger.Debugf("Requesting state delta range from %d to %d", sts.currentStateBlockNumber+1, intermediateBlock)
+			var err error
+			deltaMessages, err = sts.GetRemoteStateDeltas(peerID, sts.currentStateBlockNumber+1, intermediateBlock)
 
-				if err != nil {
-					return fmt.Errorf("%v received an error while trying to get the state deltas for blocks %d through %d from %v", sts.id, currentBlock, intermediateBlock, peerID)
-				}
+			if err != nil {
+				return fmt.Errorf("Received an error while trying to get the state deltas for blocks %d through %d from %v", sts.currentStateBlockNumber+1, intermediateBlock, peerID)
 			}
 
-			select {
-			case deltaMessage, ok := <-deltaMessages:
-				if !ok {
-					return fmt.Errorf("%v was only able to recover to block number %d when desired to recover to %d", sts.id, currentBlock-1, toBlockNumber)
-				}
-
-				if deltaMessage.Range.Start != currentBlock || deltaMessage.Range.End < deltaMessage.Range.Start || deltaMessage.Range.End > toBlockNumber {
-					return fmt.Errorf("%v received a state delta from %v either in the wrong order (backwards) or not next in sequence, aborting, start=%d, end=%d", sts.id, peerID, deltaMessage.Range.Start, deltaMessage.Range.End)
-				}
-
-				for _, delta := range deltaMessage.Deltas {
-					umDelta := &statemgmt.StateDelta{}
-					if err := umDelta.Unmarshal(delta); nil != err {
-						return fmt.Errorf("%v received a corrupt state delta from %v : %s", sts.id, peerID, err)
+			for sts.currentStateBlockNumber < intermediateBlock {
+				select {
+				case deltaMessage, ok := <-deltaMessages:
+					if !ok {
+						return fmt.Errorf("Was only able to recover to block number %d when desired to recover to %d", sts.currentStateBlockNumber, toBlockNumber)
 					}
-					sts.stack.ApplyStateDelta(deltaMessage, umDelta)
-				}
 
-				success := false
-
-				testBlock, err := sts.stack.GetBlockByNumber(deltaMessage.Range.End)
-
-				if nil != err {
-					logger.Warningf("%v could not retrieve block %d, though it should be present", sts.id, deltaMessage.Range.End)
-				} else {
-
-					stateHash, err := sts.stack.GetCurrentStateHash()
-					if nil != err {
-						logger.Warningf("%v could not compute its state hash for some reason: %s", sts.id, err)
+					if deltaMessage.Range.Start != sts.currentStateBlockNumber+1 || deltaMessage.Range.End < deltaMessage.Range.Start || deltaMessage.Range.End > toBlockNumber {
+						return fmt.Errorf("Received a state delta from %v either in the wrong order (backwards) or not next in sequence, aborting, start=%d, end=%d", peerID, deltaMessage.Range.Start, deltaMessage.Range.End)
 					}
-					logger.Debugf("%v has played state forward from %v to block %d with StateHash (%x), the corresponding block has StateHash (%x)",
-						sts.id, peerID, deltaMessage.Range.End, stateHash, testBlock.StateHash)
 
-					if bytes.Equal(testBlock.StateHash, stateHash) {
-						success = true
+					for _, delta := range deltaMessage.Deltas {
+						umDelta := &statemgmt.StateDelta{}
+						if err := umDelta.Unmarshal(delta); nil != err {
+							return fmt.Errorf("Received a corrupt state delta from %v : %s", peerID, err)
+						}
+						sts.stack.ApplyStateDelta(deltaMessage, umDelta)
+
+						success := false
+
+						testBlock, err := sts.stack.GetBlockByNumber(sts.currentStateBlockNumber + 1)
+
+						if err != nil {
+							logger.Warningf("Could not retrieve block %d, though it should be present", deltaMessage.Range.End)
+						} else {
+
+							stateHash, err = sts.stack.GetCurrentStateHash()
+							if err != nil {
+								logger.Warningf("Could not compute state hash for some reason: %s", err)
+							}
+							logger.Debugf("Played state forward from %v to block %d with StateHash (%x), block has StateHash (%x)", peerID, deltaMessage.Range.End, stateHash, testBlock.StateHash)
+							if bytes.Equal(testBlock.StateHash, stateHash) {
+								success = true
+							}
+						}
+
+						if !success {
+							if sts.stack.RollbackStateDelta(deltaMessage) != nil {
+								sts.stateValid = false
+								return fmt.Errorf("played state forward according to %v, but the state hash did not match, failed to roll back, invalidated state", peerID)
+							}
+							return fmt.Errorf("Played state forward according to %v, but the state hash did not match, rolled back", peerID)
+
+						}
+
+						if sts.stack.CommitStateDelta(deltaMessage) != nil {
+							sts.stateValid = false
+							return fmt.Errorf("Played state forward according to %v, hashes matched, but failed to commit, invalidated state", peerID)
+						}
+
+						logger.Debugf("Moved state from %d to %d", sts.currentStateBlockNumber, sts.currentStateBlockNumber+1)
+						sts.currentStateBlockNumber++
+
+						if sts.currentStateBlockNumber == toBlockNumber {
+							logger.Debugf("Caught up to block %d", sts.currentStateBlockNumber)
+							return nil
+						}
 					}
+
+				case <-time.After(sts.StateDeltaRequestTimeout):
+					logger.Warningf("Timed out during state delta recovery from %v", peerID)
+					return fmt.Errorf("timed out during state delta recovery from %v", peerID)
 				}
-
-				if !success {
-					if nil != sts.stack.RollbackStateDelta(deltaMessage) {
-						sts.stateValid = false
-						return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, failed to roll back, invalidated state", sts.id, peerID)
-					}
-					return fmt.Errorf("%v played state forward according to %v, but the state hash did not match, rolled back", sts.id, peerID)
-
-				}
-
-				if nil != sts.stack.CommitStateDelta(deltaMessage) {
-					sts.stateValid = false
-					return fmt.Errorf("%v played state forward according to %v, hashes matched, but failed to commit, invalidated state", sts.id, peerID)
-				}
-
-				if currentBlock == toBlockNumber {
-					return nil
-				}
-				currentBlock++
-
-			case <-time.After(sts.StateDeltaRequestTimeout):
-				logger.Warningf("%v timed out during state delta recovery from %v", sts.id, peerID)
-				return fmt.Errorf("%v timed out during state delta recovery from %v", sts.id, peerID)
 			}
 		}
 
 	})
-	return currentBlock, err
+	logger.Debugf("State is now valid at block %d and hash %x", sts.currentStateBlockNumber, stateHash)
+	return err
 }
 
 // This function will retrieve the current state from a peer.
-// Note that no state verification can occur yet, we must wait for the next checkpoint, so it is important
+// Note that no state verification can occur yet, we must wait for the next target, so it is important
 // not to consider this state as valid
-func (sts *coordinatorImpl) syncStateSnapshot(minBlockNumber uint64, peerIDs []*protos.PeerID) (uint64, error) {
+func (sts *coordinatorImpl) syncStateSnapshot(minBlockNumber uint64, peerIDs []*pb.PeerID) (uint64, error) {
 
-	logger.Debugf("%v attempting to retrieve state snapshot from recovery from %v", sts.id, peerIDs)
+	logger.Debugf("Attempting to retrieve state snapshot from %v", peerIDs)
 
 	currentStateBlock := uint64(0)
 
-	ok := sts.tryOverPeers(peerIDs, func(peerID *protos.PeerID) error {
-		logger.Debugf("%v is initiating state recovery from %v", sts.id, peerID)
+	ok := sts.tryOverPeers(peerIDs, func(peerID *pb.PeerID) error {
+		logger.Debugf("Initiating state recovery from %v", peerID)
 
 		if err := sts.stack.EmptyState(); nil != err {
 			logger.Errorf("Could not empty the current state: %s", err)
@@ -831,31 +779,31 @@ func (sts *coordinatorImpl) syncStateSnapshot(minBlockNumber uint64, peerIDs []*
 			select {
 			case piece, ok := <-stateChan:
 				if !ok {
-					return fmt.Errorf("%v had state snapshot channel close prematurely after %d deltas: %s", sts.id, counter, err)
+					return fmt.Errorf("had state snapshot channel close prematurely after %d deltas: %s", counter, err)
 				}
 				if 0 == len(piece.Delta) {
 					stateHash, err := sts.stack.GetCurrentStateHash()
 					if nil != err {
 						sts.stateValid = false
-						return fmt.Errorf("%v could not compute its current state hash: %x", sts.id, err)
+						return fmt.Errorf("could not compute its current state hash: %x", err)
 
 					}
 
-					logger.Debugf("%v received final piece of state snapshot from %v after %d deltas, now has hash %x", sts.id, peerID, counter, stateHash)
+					logger.Debugf("Received final piece of state snapshot from %v after %d deltas, now has hash %x", peerID, counter, stateHash)
 					return nil
 				}
 				umDelta := &statemgmt.StateDelta{}
 				if err := umDelta.Unmarshal(piece.Delta); nil != err {
-					return fmt.Errorf("%v received a corrupt delta from %v after %d deltas : %s", sts.id, peerID, counter, err)
+					return fmt.Errorf("received a corrupt delta from %v after %d deltas : %s", peerID, counter, err)
 				}
 				sts.stack.ApplyStateDelta(piece, umDelta)
 				currentStateBlock = piece.BlockNumber
 				if err := sts.stack.CommitStateDelta(piece); nil != err {
-					return fmt.Errorf("%v could not commit state delta from %v after %d deltas: %s", sts.id, peerID, counter, err)
+					return fmt.Errorf("could not commit state delta from %v after %d deltas: %s", peerID, counter, err)
 				}
 				counter++
 			case <-timer.C:
-				return fmt.Errorf("%v timed out during state recovery from %v", sts.id, peerID)
+				return fmt.Errorf("Timed out during state recovery from %v", peerID)
 			}
 		}
 
@@ -867,19 +815,19 @@ func (sts *coordinatorImpl) syncStateSnapshot(minBlockNumber uint64, peerIDs []*
 // The below were stolen from helper.go, they should eventually be removed there, and probably made private here
 
 // GetRemoteBlocks will return a channel to stream blocks from the desired replicaID
-func (sts *coordinatorImpl) GetRemoteBlocks(replicaID *protos.PeerID, start, finish uint64) (<-chan *protos.SyncBlocks, error) {
+func (sts *coordinatorImpl) GetRemoteBlocks(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncBlocks, error) {
 	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
 	if nil != err {
 		return nil, err
 	}
-	return remoteLedger.RequestBlocks(&protos.SyncBlockRange{
+	return remoteLedger.RequestBlocks(&pb.SyncBlockRange{
 		Start: start,
 		End:   finish,
 	})
 }
 
 // GetRemoteStateSnapshot will return a channel to stream a state snapshot from the desired replicaID
-func (sts *coordinatorImpl) GetRemoteStateSnapshot(replicaID *protos.PeerID) (<-chan *protos.SyncStateSnapshot, error) {
+func (sts *coordinatorImpl) GetRemoteStateSnapshot(replicaID *pb.PeerID) (<-chan *pb.SyncStateSnapshot, error) {
 	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
 	if nil != err {
 		return nil, err
@@ -888,12 +836,12 @@ func (sts *coordinatorImpl) GetRemoteStateSnapshot(replicaID *protos.PeerID) (<-
 }
 
 // GetRemoteStateDeltas will return a channel to stream a state snapshot deltas from the desired replicaID
-func (sts *coordinatorImpl) GetRemoteStateDeltas(replicaID *protos.PeerID, start, finish uint64) (<-chan *protos.SyncStateDeltas, error) {
+func (sts *coordinatorImpl) GetRemoteStateDeltas(replicaID *pb.PeerID, start, finish uint64) (<-chan *pb.SyncStateDeltas, error) {
 	remoteLedger, err := sts.stack.GetRemoteLedger(replicaID)
 	if nil != err {
 		return nil, err
 	}
-	return remoteLedger.RequestStateDeltas(&protos.SyncBlockRange{
+	return remoteLedger.RequestStateDeltas(&pb.SyncBlockRange{
 		Start: start,
 		End:   finish,
 	})


### PR DESCRIPTION
## Description

This changeset is a long overdue cleanup of the state transfer code.  It includes removing unused struct definitions, fixing unnecessarily complicated logging statements, removing dead code paths, and generally increases the readability and debug-ability of the code.
## Motivation and Context

While debugging #1857 which appeared to be a state transfer bug, I began restructuring some of the logging, and simplifying some of the code paths to aid in the debugging.  So as not to lose this effort, this changeset attempts to extend the cleanup to the entire state transfer codebase.

This is a net deletion of 70 lines of code, and should additionally increase the readability and debug-ability. As the 0.5 release has recently been forked off, now seemed like an opportune time to push some non-specific code cleanup.

No particular skill should be needed to review this changeset, though @kchristidis @corecode @tuand27613 and @jeffgarratt are the usual suspects who might have something to say.
## How Has This Been Tested?

This PR does not add any new function, so the existing unit and behave tests should be appropriate regression testing.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
