### PR TITLE
Remove duplicated storeRequest call per @kchristidis

### DIFF
--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -123,15 +123,13 @@ func (op *obcBatch) submitToLeader(req *Request) events.Event {
 
 	op.logAddTxFromRequest(req)
 	op.reqStore.storeOutstanding(req)
+	op.startTimerIfOutstandingRequests()
 
 	// if we believe we are the leader, then process this request
 	leader := op.pbft.primary(op.pbft.view)
 	if leader == op.pbft.id && op.pbft.activeView {
 		return op.leaderProcReq(req)
 	}
-
-	op.reqStore.storeOutstanding(req)
-	op.startTimerIfOutstandingRequests()
 
 	return nil
 }


### PR DESCRIPTION
## Description

This removes a duplicated call to store an outstanding request.
## Motivation and Context

This was [noted](https://github.com/hyperledger/fabric/commit/895dd2da3922a5428f81096134c2aff1d582a2c6#commitcomment-17982896) by @kchristidis but the PR was including that commit was merged before @kchristidis made the remark.  It is a simple case of unnecessarily storing the same request in the outstanding requests list twice.

This is inefficient, and should be removed.
## How Has This Been Tested?

This is equivalent to writing the same value into a map key twice, so there is no real value in writing a test case.  The existing CI should provide sufficient regression testing.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
