### PR TITLE
 Check for state transfer on view change before ordering

### DIFF
--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -1116,3 +1116,67 @@ Feature: lanching 3 peers
     Examples: Composition options
         |          ComposeFile     |
         |   docker-compose-2.yml   |
+
+
+@issue_1942
+#@doNotDecompose
+Scenario: chaincode example02 with 4 peers, stop and start alternates, reverse
+    Given we compose "docker-compose-4-consensus-batch.yml"
+    And I register with CA supplying username "binhn" and secret "7avZQLwcUe9q" on peers:
+                                  | vp0  |
+    And I use the following credentials for querying peers:
+                            | peer |   username  |    secret    |
+                          | vp0  |  test_user0 | MS9qrN8hFjlE |
+                          | vp1  |  test_user1 | jGlNl6ImkuDo |
+                          | vp2  |  test_user2 | zMflqOKezFiA |
+                          | vp3  |  test_user3 | vWdLCE00vJy0 |
+
+    When requesting "/chain" from "vp0"
+    Then I should get a JSON response with "height" = "1"
+
+    When I deploy chaincode "github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02" with ctor "init" to "vp0"
+                          | arg1 |  arg2 | arg3 | arg4 |
+                          |  a   |  1000 |  b   |   0  |
+    Then I should have received a chaincode name
+    Then I wait up to "60" seconds for transaction to be committed to peers:
+                          | vp0  | vp1 | vp2 | vp3 |
+
+    When I query chaincode "example2" function name "query" with value "a" on peers:
+                          | vp0 | vp1  | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "1000"
+                          | vp0 |  vp1 | vp2 | vp3 |
+
+    Given I stop peers:
+                          | vp2 |
+    And I register with CA supplying username "test_user3" and secret "vWdLCE00vJy0" on peers:
+                          | vp3  |
+
+    When I invoke chaincode "example2" function name "invoke" on "vp3" "3" times
+                          |arg1|arg2|arg3|
+                          | a  | b  | 1  |
+    Then I should have received a transactionID
+    Then I wait up to "180" seconds for transaction to be committed to peers:
+                          | vp0 | vp1 | vp3 |
+
+    When I query chaincode "example2" function name "query" with value "a" on peers:
+                          | vp0  | vp1 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "997"
+                          | vp0  | vp1 | vp3 |
+
+    Given I start peers:
+                          | vp2  |
+    And I wait "30" seconds
+
+    Given I stop peers:
+                          | vp1  |
+    When I invoke chaincode "example2" function name "invoke" on "vp3" "20" times
+                          |arg1|arg2|arg3|
+                          | a  | b  | 1  |
+    Then I should have received a transactionID
+    Then I wait up to "300" seconds for transaction to be committed to peers:
+                          | vp0  | vp2 | vp3 |
+
+    When I query chaincode "example2" function name "query" with value "a" on peers:
+                          | vp0  | vp2 | vp3 |
+    Then I should get a JSON response from peers with "OK" = "977"
+                          | vp0  | vp2 | vp3 |

--- a/consensus/obcpbft/broadcast.go
+++ b/consensus/obcpbft/broadcast.go
@@ -41,7 +41,7 @@ type broadcaster struct {
 
 type sendRequest struct {
 	msg  *pb.Message
-	done chan struct{}
+	done chan bool
 }
 
 func newBroadcaster(self uint64, N int, f int, c communicator) *broadcaster {
@@ -75,7 +75,6 @@ func (b *broadcaster) Wait() {
 
 func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidatorNotFound bool) bool {
 	defer func() {
-		send.done <- struct{}{}
 		b.closed.Done()
 	}()
 	h, err := getValidatorHandle(dest)
@@ -84,6 +83,7 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 			logger.Warningf("could not get handle for replica %d", dest)
 		}
 		time.Sleep(time.Second)
+		send.done <- false
 		return true
 	}
 
@@ -95,6 +95,9 @@ func (b *broadcaster) drainerSend(dest uint64, send *sendRequest, printedValidat
 	err = b.comm.Unicast(send.msg, h)
 	if err != nil {
 		logger.Warningf("could not send to replica %d: %v", dest, err)
+		send.done <- false
+	} else {
+		send.done <- true
 	}
 
 	return false
@@ -110,7 +113,7 @@ func (b *broadcaster) drainer(dest uint64) {
 				// Drain the message channel to free calling waiters before we shut down
 				select {
 				case send := <-b.msgChans[dest]:
-					send.done <- struct{}{}
+					send.done <- false
 					b.closed.Done()
 				default:
 					return
@@ -122,7 +125,7 @@ func (b *broadcaster) drainer(dest uint64) {
 	}
 }
 
-func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{}) {
+func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan bool) {
 	select {
 	case b.msgChans[dest] <- &sendRequest{
 		msg:  msg,
@@ -130,7 +133,7 @@ func (b *broadcaster) unicastOne(msg *pb.Message, dest uint64, wait chan struct{
 	}:
 	default:
 		// If this channel is full, we must discard the message and flag it as done
-		wait <- struct{}{}
+		wait <- false
 		b.closed.Done()
 	}
 }
@@ -152,7 +155,7 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		required = destCount - b.f
 	}
 
-	wait := make(chan struct{}, destCount)
+	wait := make(chan bool, destCount)
 
 	if dest != nil {
 		b.closed.Add(1)
@@ -164,8 +167,29 @@ func (b *broadcaster) send(msg *pb.Message, dest *uint64) error {
 		}
 	}
 
-	for i := 0; i < required; i++ {
-		<-wait
+	succeeded := 0
+	timer := time.NewTimer(time.Second) // TODO, make this configurable
+
+	// This loop will try to send, until one of:
+	// a) the required number of sends succeed
+	// b) all sends complete regardless of success
+	// c) the timeout expires and the required number of sends have returned
+outer:
+	for i := 0; i < destCount; i++ {
+		select {
+		case success := <-wait:
+			if success {
+				succeeded++
+				if succeeded >= required {
+					break outer
+				}
+			}
+		case <-timer.C:
+			for i := i; i < required; i++ {
+				<-wait
+			}
+			break outer
+		}
 	}
 
 	return nil

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -321,11 +321,11 @@ func (op *obcBatch) processMessage(ocMsg *pb.Message, senderHandle *pb.PeerID) e
 			return nil
 		}
 
+		op.logAddTxFromRequest(req)
+		op.reqStore.storeOutstanding(req)
 		if (op.pbft.primary(op.pbft.view) == op.pbft.id) && op.pbft.activeView {
 			return op.leaderProcReq(req)
 		}
-		op.logAddTxFromRequest(req)
-		op.reqStore.storeOutstanding(req)
 		op.startTimerIfOutstandingRequests()
 		return nil
 	} else if pbftMsg := batchMsg.GetPbftMessage(); pbftMsg != nil {
@@ -409,6 +409,11 @@ func (op *obcBatch) ProcessEvent(event events.Event) events.Event {
 		if op.pbft.activeView && (len(op.batchStore) > 0) {
 			return op.sendBatch()
 		}
+	case *Commit:
+		// TODO, this is extremely hacky, but should go away when batch and core are merged
+		res := op.pbft.ProcessEvent(event)
+		op.startTimerIfOutstandingRequests()
+		return res
 	case viewChangedEvent:
 		// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
 		// in a different batch, but PBFT core can't see through the opaque structure to see this
@@ -418,6 +423,11 @@ func (op *obcBatch) ProcessEvent(event events.Event) events.Event {
 		logger.Debugf("Replica %d batch thread recognizing new view", op.pbft.id)
 		if op.batchTimerActive {
 			op.stopBatchTimer()
+		}
+
+		if op.pbft.skipInProgress {
+			// If we're the new primary, but we're in state transfer, we can't trust ourself not to duplicate things
+			op.reqStore.outstandingRequests.empty()
 		}
 
 		op.reqStore.pendingRequests.empty()
@@ -499,11 +509,13 @@ func (op *obcBatch) getManager() events.Manager {
 func (op *obcBatch) startTimerIfOutstandingRequests() {
 	if op.pbft.skipInProgress || op.pbft.currentExec != nil {
 		// Do not start view change timer if some background event is in progress
+		logger.Debugf("Replica %d not starting timer because skip in progress or current exec", op.pbft.id)
 		return
 	}
 
 	if !op.reqStore.hasNonPending() {
 		// Only start a timer if we are aware of outstanding requests
+		logger.Debugf("Replica %d not starting timer because all outstanding requests are pending", op.pbft.id)
 		return
 	}
 	op.pbft.softStartTimer(op.pbft.requestTimeout, "Batch outstanding requests")

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -134,14 +134,8 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 	for i, b := range bs {
 		b.manager.Queue() <- nil
 		count := b.reqStore.outstandingRequests.Len()
-		if i == 0 {
-			if count != 0 {
-				t.Errorf("Batch primary should not have the request in its store: %v", b.reqStore.outstandingRequests)
-			}
-		} else {
-			if count != 1 {
-				t.Errorf("Batch backup %d should have the request in its store", i)
-			}
+		if count != 1 {
+			t.Errorf("Batch backup %d should have the request in its store", i)
 		}
 	}
 }
@@ -190,6 +184,8 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 		}
 	}
 
+	tmp := uint64(1)
+	b.pbft.currentExec = &tmp
 	events.SendEvent(b, committedEvent{})
 	execute()
 


### PR DESCRIPTION
## Description

This changeset adds a check to the batch ordering, that when a replica becomes a new primary, it first checks to see if it is in state transfer before attempting to order any outstanding requests. 

It also prevents null requests from permanently disabling the outstanding request timer, and adds outstanding requests to the primary before ordering.
## Motivation and Context

The outstanding requests are cleared at the conclusion of state transfer, which is sufficient in most cases, as a replica in state transfer is usually not the primary.  However, a replica may become the new primary in a view change which also forces a state transfer.  In this case, the replica is the primary, and can order requests until it exhausts half its log size (4 of them by default).  This can lead to duplication of up to 4 transactions on certain view changes.

Typical SMEs include @kchristidis @corecode and @tuand27613 .

This is a companion PR to #1987 
## How Has This Been Tested?

This PR contains a behave test which exhibits the failure (thanks @lhaskins!)
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
