### PR TITLE
Added the non-'f' Go language chaincode logging APIs

### DIFF
--- a/core/chaincode/shim/shim_test.go
+++ b/core/chaincode/shim/shim_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package shim
 
 import (
-        "os"
+	"os"
 	"testing"
 
 	"github.com/op/go-logging"
@@ -96,7 +96,7 @@ func TestShimLogging(t *testing.T) {
 // TestChaincodeLogging tests the logging APIs for chaincodes.
 func TestChaincodeLogging(t *testing.T) {
 
-        // From start() - We can't call start() from this test
+	// From start() - We can't call start() from this test
 	format := logging.MustStringFormatter("%{time:15:04:05.000} [%{module}] %{level:.4s} : %{message}")
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, format)

--- a/core/chaincode/shim/shim_test.go
+++ b/core/chaincode/shim/shim_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package shim
 
 import (
+        "os"
 	"testing"
 
 	"github.com/op/go-logging"
@@ -94,14 +95,30 @@ func TestShimLogging(t *testing.T) {
 
 // TestChaincodeLogging tests the logging APIs for chaincodes.
 func TestChaincodeLogging(t *testing.T) {
+
+        // From start() - We can't call start() from this test
+	format := logging.MustStringFormatter("%{time:15:04:05.000} [%{module}] %{level:.4s} : %{message}")
+	backend := logging.NewLogBackend(os.Stderr, "", 0)
+	backendFormatter := logging.NewBackendFormatter(backend, format)
+	logging.SetBackend(backendFormatter).SetLevel(logging.Level(shimLoggingLevel), "shim")
+
 	foo := NewLogger("foo")
 	bar := NewLogger("bar")
-	foo.Debugf("Foo is debugging %d", 10)
-	bar.Infof("Bar in informational %d", "yes")
+
+	foo.Debugf("Foo is debugging: %d", 10)
+	bar.Infof("Bar is informational? %s.", "Yes")
 	foo.Noticef("NOTE NOTE NOTE")
-	bar.Warningf("Danger Danger %s %s", "Will", "Robinson")
-	foo.Errorf("I'm sorry Dave, I'm afraid I can't do that")
-	bar.Criticalf("PI is not equal to 3.14, we computed it as %f", 4.13)
+	bar.Warningf("Danger, Danger %s %s", "Will", "Robinson!")
+	foo.Errorf("I'm sorry Dave, I'm afraid I can't do that.")
+	bar.Criticalf("PI is not equal to 3.14, we computed it as %.2f", 4.13)
+
+	bar.Debug("Foo is debugging:", 10)
+	foo.Info("Bar is informational?", "Yes.")
+	bar.Notice("NOTE NOTE NOTE")
+	foo.Warning("Danger, Danger", "Will", "Robinson!")
+	bar.Error("I'm sorry Dave, I'm afraid I can't do that.")
+	foo.Critical("PI is not equal to", 3.14, ", we computed it as", 4.13)
+
 	foo.SetLevel(LogWarning)
 	if foo.IsEnabledFor(LogDebug) {
 		t.Errorf("'foo' should not be enabled for LogDebug")

--- a/docs/dev-setup/logging-control.md
+++ b/docs/dev-setup/logging-control.md
@@ -73,6 +73,13 @@ to the `LogLevel` API.
 Formatted logging at various severity levels is provided by the functions
 
 ```
+(c *ChaincodeLogger) Debug(args ...interface{})
+(c *ChaincodeLogger) Info(args ...interface{})
+(c *ChaincodeLogger) Notice(args ...interface{})
+(c *ChaincodeLogger) Warning(args ...interface{})
+(c *ChaincodeLogger) Error(args ...interface{})
+(c *ChaincodeLogger) Critical(args ...interface{})
+
 (c *ChaincodeLogger) Debugf(format string, args ...interface{})
 (c *ChaincodeLogger) Infof(format string, args ...interface{})
 (c *ChaincodeLogger) Noticef(format string, args ...interface{})
@@ -81,7 +88,10 @@ Formatted logging at various severity levels is provided by the functions
 (c *ChaincodeLogger) Criticalf(format string, args ...interface{})
 ```
 
+The `f` forms of the logging APIs provide for precise control over the formatting of the logs. The non-`f` forms of the APIs currently insert a space between the printed representations of the arguments, and arbitrarily choose the formats to use.
+
 In the current implementation, the logs produced by the `shim` and a `ChaincodeLogger` are timestamped, marked with the logger *name* and severity level, and written to `stderr`. Note that logging level control is currently based on the *name* provided when the `ChaincodeLogger` is created. To avoid ambiguities, all `ChaincodeLogger` should be given unique names other than "shim". The logger *name* will appear in all log messages created by the logger. The `shim` logs as "shim".
+
 
 Go language chaincodes can also control the logging level of the chaincode `shim` interface through the `SetLoggingLevel` API.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Also added more documentation to explain why this was done the way it was.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Answers #1815
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Ran "make checks" in Vagrant. Some "custody" tests are failing. Don't know why.
I also ran the shim unit tests from the terminal and observed that the outputs was being generated correctly.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
