### PR TITLE
Set the Subject.CommonName of each TCert to 'Transaction Certificate'

### DIFF
--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -360,6 +360,7 @@ func (tcap *TCAP) createCertificateSet(ctx context.Context, raw []byte, in *pb.T
 	var err error
 	var id = in.Id.Id
 	var timestamp = in.Ts.Seconds
+	const TCERT_SUBJECT_COMMON_NAME_VALUE string = "Transaction Certificate"
 
 	if in.Attributes != nil && viper.GetBool("aca.enabled") {
 		attrs, err = tcap.requestAttributes(id, raw, in.Attributes)
@@ -444,7 +445,7 @@ func (tcap *TCAP) createCertificateSet(ctx context.Context, raw []byte, in *pb.T
 			return nil, err
 		}
 
-		spec := NewDefaultPeriodCertificateSpec(id, tcertid, &txPub, x509.KeyUsageDigitalSignature, extensions...)
+		spec := NewDefaultPeriodCertificateSpecWithCommonName(id, TCERT_SUBJECT_COMMON_NAME_VALUE, tcertid, &txPub, x509.KeyUsageDigitalSignature, extensions...)
 		if raw, err = tcap.tca.createCertificateFromSpec(spec, timestamp, kdfKey, false); err != nil {
 			Error.Println(err)
 			return nil, err

--- a/membersrvc/ca/tca_test.go
+++ b/membersrvc/ca/tca_test.go
@@ -68,6 +68,7 @@ func TestCreateCertificateSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const EXPECTED_TCERT_SUBJECT_COMMON_NAME_VALUE string = "Transaction Certificate"
 	ncerts := 1
 	for nattributes := -1; nattributes < 1; nattributes++ {
 		certificateSetRequest, err := buildCertificateSetRequest(enrollmentID, priv, ncerts, nattributes)
@@ -102,6 +103,19 @@ func TestCreateCertificateSet(t *testing.T) {
 		tcerts := response.GetCerts()
 		if len(tcerts.Certs) != ncerts {
 			t.Fatal(fmt.Errorf("Invalid tcert size. Expected: %v, Actual: %v", ncerts, len(tcerts.Certs)))
+		}
+
+		for pos, eachTCert := range tcerts.Certs {
+			tcert, err := x509.ParseCertificate(eachTCert.Cert)
+			if err != nil {
+				t.Fatalf("Error: %v\nCould not x509.ParseCertificate %v", err, eachTCert.Cert)
+			}
+
+			t.Logf("Examining TCert[%d]'s Subject: %v", pos, tcert.Subject)
+			if tcert.Subject.CommonName != EXPECTED_TCERT_SUBJECT_COMMON_NAME_VALUE {
+				t.Fatalf("The TCert's Subject.CommonName is '%s' which is different than '%s'", tcert.Subject.CommonName, EXPECTED_TCERT_SUBJECT_COMMON_NAME_VALUE)
+			}
+			t.Logf("Successfully verified that TCert[%d].Subject.CommonName == '%s'", pos, tcert.Subject.CommonName)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Set the Subject.CommonName of TCerts to 'Transaction Certificate'
## Description of Changes

<!-- Describe your changes in detail. -->
- Introduce the constant `TCERT_SUBJECT_COMMON_NAME_VALUE`
- Create TCerts using the `NewDefaultPeriodCertificateSpecWithCommonName` passing in the above constant.
- Assert that `EnrollmentID` is no longer placed in the `Subject.CommonName`
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

TCerts currently contain the actual EnrollmentID (in the clear) in the `Subject.CommonName` field, instead we want to simply use the `Transaction Certificate`. There are some good reasons for that, some more info/background listed on the underlying issue.

Fixes #1409 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Taking the TDD approach. Checking-in the test first, asserting the expected behavior. 
Tested and 'locked'  the expected behavior using the Golang unit test of `membersrvc` (the `ca` package). 

So [﻿8509106](https://github.com/hyperledger/fabric/pull/2001/commits/8509106986e9a45409e06eecdf7b3456ffb83fea) shall result in the following error:

```
--- FAIL: TestCreateCertificateSet (0.04s)
    tca_test.go:114: Examining TCert[0]'s Subject: %!(EXTRA pkix.Name={[US] [Hyperledger] [] [] [] [] []  test_user0 [{2.5.4.6 US} {2.5.4.10 Hyperledger} {2.5.4.3 test_user0}] []})
    tca_test.go:116: The TCert's Subject.CommonName is 'test_user0' which is different than 'Transaction Certificate'
```

(Specifically)
`The TCert's Subject.CommonName is 'test_user0' which is different than 'Transaction Certificate'`

And then in the following/next check-in, adding the 'feature' (setting the `Subject.CommonName` to `Transaction Certificate`) shall make this assertion/test succeed.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: JonathanLevi
