### PR TITLE
increase consensus batchsize to 1000

### DIFF
--- a/consensus/pbft/batch_test.go
+++ b/consensus/pbft/batch_test.go
@@ -139,6 +139,8 @@ func TestOutstandingReqsIngestion(t *testing.T) {
 
 func TestOutstandingReqsResubmission(t *testing.T) {
 	omni := &omniProto{}
+	config := loadConfig()
+	config.Set("general.batchsize", 2)
 	b := newObcBatch(0, loadConfig(), omni)
 	defer b.Close() // The broadcasting threads only cause problems here... but this test stalls without them
 

--- a/consensus/pbft/batch_test.go
+++ b/consensus/pbft/batch_test.go
@@ -187,7 +187,9 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	execute()
 
 	if b.reqStore.outstandingRequests.Len() != 0 {
-		t.Fatalf("All requests should have been executed and deleted after exec")
+		config := loadConfig()
+		config.Set("general.batchsize", 2)
+		newObcBatch(0, config, omni)
 	}
 
 	// Simulate changing views, with a request in the qSet, and one outstanding which is not

--- a/consensus/pbft/batch_test.go
+++ b/consensus/pbft/batch_test.go
@@ -141,7 +141,7 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	omni := &omniProto{}
 	config := loadConfig()
 	config.Set("general.batchsize", 2)
-	b := newObcBatch(0, loadConfig(), omni)
+	b := newObcBatch(0, config, omni)
 	defer b.Close() // The broadcasting threads only cause problems here... but this test stalls without them
 
 	transactionsBroadcast := 0
@@ -189,9 +189,7 @@ func TestOutstandingReqsResubmission(t *testing.T) {
 	execute()
 
 	if b.reqStore.outstandingRequests.Len() != 0 {
-		config := loadConfig()
-		config.Set("general.batchsize", 2)
-		newObcBatch(0, config, omni)
+		t.Fatalf("All requests should have been executed and deleted after exec")
 	}
 
 	// Simulate changing views, with a request in the qSet, and one outstanding which is not

--- a/consensus/pbft/config.yaml
+++ b/consensus/pbft/config.yaml
@@ -32,7 +32,7 @@ general:
     logmultiplier: 4
 
     # How many requests should the primary send per pre-prepare when in "batch" mode
-    batchsize: 1000
+    batchsize: 500
 
     # Whether the replica should act as a byzantine one; useful for debugging on testnets
     byzantine: false

--- a/consensus/pbft/config.yaml
+++ b/consensus/pbft/config.yaml
@@ -32,7 +32,7 @@ general:
     logmultiplier: 4
 
     # How many requests should the primary send per pre-prepare when in "batch" mode
-    batchsize: 2
+    batchsize: 1000
 
     # Whether the replica should act as a byzantine one; useful for debugging on testnets
     byzantine: false


### PR DESCRIPTION
## Description

To increase consensus batchsize to 1000 in config.yaml
## Motivation and Context

This is to increase the performance with pbft consensus
## How Has This Been Tested?

Compare the performance results under stress test with various batchsizes: 2 (default), 100, 500, and 1000.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [ ] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: dming@us.ibm.com
