### PR TITLE
Fix for issue 1995 - Remove membersrvc/ca/.ca/ before running unit tests

### DIFF
--- a/scripts/goUnitTests.sh
+++ b/scripts/goUnitTests.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "Cleaning membership services folder"
+rm -rf membersrvc/ca/.ca/
+
 echo -n "Obtaining list of tests to run.."
 PKGS=`go list github.com/hyperledger/fabric/... | grep -v /vendor/ | grep -v /examples/`
 echo "DONE!"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Remove temporary membersrvc/ca/.ca folder before running unit tests using 'make unit-test'
## Description

<!-- Describe your changes in detail. -->

Running the 'make unit-test' command more than once, will fail with 'text file busy' for ca.go test. Deleting membersrvc/ca/.ca folder before each run will make the unit-test pass.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1995
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] This change requires no new documentation.
- [x] This change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Diego Masini diego.masini@gmail.com / damasini@us.ibm.com
