### PR TITLE
core/rest: DELETE /registrar// deletes entire local crypto/client directory

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -182,6 +183,37 @@ func getRESTFilePath() string {
 	return localStore
 }
 
+// isEnrollmentIDValid returns true if the given enrollmentID matches the valid
+// pattern defined in the configuration.
+func isEnrollmentIDValid(enrollmentID string) (bool, error) {
+	pattern := viper.GetString("rest.validPatterns.enrollmentID")
+	if pattern == "" {
+		return false, errors.New("Missing configuration key rest.validPatterns.enrollmentID")
+	}
+	return regexp.MatchString(pattern, enrollmentID)
+}
+
+// validateEnrollmentIDParameter checks whether the given enrollmentID is
+// valid: if valid, returns true and does nothing; if not, writes the HTTP
+// error response and returns false.
+func validateEnrollmentIDParameter(rw web.ResponseWriter, enrollmentID string) bool {
+	validID, err := isEnrollmentIDValid(enrollmentID)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(rw).Encode(restResult{Error: err.Error()})
+		restLogger.Errorf("Error when validating enrollment ID: %s", err)
+		return false
+	}
+	if !validID {
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(restResult{Error: "Invalid enrollment ID parameter"})
+		restLogger.Errorf("Invalid enrollment ID parameter '%s'.\n", enrollmentID)
+		return false
+	}
+
+	return true
+}
+
 // Register confirms the enrollmentID and secret password of the client with the
 // CA and stores the enrollment certificate and key in the Devops server.
 func (s *ServerOpenchainREST) Register(rw web.ResponseWriter, req *web.Request) {
@@ -218,6 +250,10 @@ func (s *ServerOpenchainREST) Register(rw web.ResponseWriter, req *web.Request) 
 		fmt.Fprintf(rw, "{\"Error\": \"enrollId and enrollSecret may not be blank.\"}")
 		restLogger.Error("{\"Error\": \"enrollId and enrollSecret may not be blank.\"}")
 
+		return
+	}
+
+	if !validateEnrollmentIDParameter(rw, loginSpec.EnrollId) {
 		return
 	}
 
@@ -288,6 +324,10 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
 
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
+
 	// Retrieve the REST data storage path
 	// Returns /var/hyperledger/production/client/
 	localStore := getRESTFilePath()
@@ -304,8 +344,6 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 		encoder.Encode(restResult{Error: fmt.Sprintf("User %s must log in.", enrollmentID)})
 		restLogger.Infof("User '%s' must log in.\n", enrollmentID)
 	}
-
-	return
 }
 
 // DeleteEnrollmentID removes the login token of the specified user from the
@@ -315,6 +353,10 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 func (s *ServerOpenchainREST) DeleteEnrollmentID(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	// Retrieve the REST data storage path
 	// Returns /var/hyperledger/production/client/
@@ -369,6 +411,10 @@ func (s *ServerOpenchainREST) DeleteEnrollmentID(rw web.ResponseWriter, req *web
 func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	restLogger.Debugf("REST received enrollment certificate retrieval request for registrationID '%s'", enrollmentID)
 
@@ -454,6 +500,10 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	restLogger.Debugf("REST received transaction certificate retrieval request for registrationID '%s'", enrollmentID)
 

--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -293,18 +293,17 @@ func TestServerOpenchainREST_API_GetEnrollmentID(t *testing.T) {
 	httpServer := httptest.NewServer(buildOpenchainRESTRouter())
 	defer httpServer.Close()
 
-	body := performHTTPGet(t, httpServer.URL+"/registrar/NON-EXISTING-USER")
+	body := performHTTPGet(t, httpServer.URL+"/registrar/NON_EXISTING_USER")
 	res := parseRESTResult(t, body)
-	if res.Error == "" {
-		t.Errorf("Expected an error when retrieving non-existing user, but got none")
+	if res.Error != "User NON_EXISTING_USER must log in." {
+		t.Errorf("Expected an error when retrieving non-existing user, but got: %v", res.Error)
 	}
 
 	body = performHTTPGet(t, httpServer.URL+"/registrar/BAD-\"-CHARS")
 	res = parseRESTResult(t, body)
-	if res.Error == "" {
-		t.Errorf("Expected an error when retrieving non-existing user, but got none")
+	if res.Error != "Invalid enrollment ID parameter" {
+		t.Errorf("Expected an error when retrieving non-existing user, but got: %v", res.Error)
 	}
-
 }
 
 func TestServerOpenchainREST_API_GetPeers(t *testing.T) {

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -25,6 +25,11 @@ rest:
     # The address that the REST service will listen on for incoming requests.
     address: 0.0.0.0:5000
 
+    validPatterns:
+
+        # Valid enrollment ID pattern in URLs: At least one character long, and
+        # all characters are A-Z, a-z, 0-9 or _.
+        enrollmentID: '^\w+$'
 
 ###############################################################################
 #


### PR DESCRIPTION
core/rest: Add format validation on URL parameters to prevent remote deletion of local dirs.
## Description

Added simple validation via regexp on URL path components to prevent these parameters being empty or with unexpected chars.

This commit adds simple format validation:
- ID for `/registrar/:id` endpoints must be at least 1 char long and all chars must be `\w` = `[a-zA-Z0-9_]`
- Block number for `/chain/blocks/:id` must be at least 1 digit long and all chars must be digits
- UUID for `/transactions/:uuid` endpoint must be `[\w-]+` (we can be more      strict here)

Note that the first limit will prevent user-IDs from having minus chars, dots, equals, at-signs, etc. This might be too strict and break existing users. Alternatively, we can replace it to something more relaxed like `[^/]+` (one or more chars that are not slash - we definitely don't support slashes in usernames; I suggest avoiding backslashes too if we're supposed to work on Windows).
## Motivation and Context

Passing an empty :id parameter to DELETE /registrar/:id endpoint causes     deletion of the entire `/var/hyperledger/production/crypto/client`     directory. For example, run this in vagrant:

```
$ mkdir -p /var/hyperledger/production/crypto/client
$ echo "important_data" > /var/hyperledger/production/crypto/client/myfile
$ curl -v -X DELETE http://127.0.0.1:5000/registrar//
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
> DELETE /registrar// HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 127.0.0.1:5000
> Accept: */*
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Headers: accept, content-type
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Date: Fri, 24 Jun 2016 19:03:23 GMT
< Content-Length: 54
< 
* Connection #0 to host 127.0.0.1 left intact
{"OK": "Deleted login token and directory for user ."}

$ ls -l /var/hyperledger/production/crypto/client
ls: cannot access /var/hyperledger/production/crypto/client: No such file or directory

# Whoops important data is gone!
```
## How Has This Been Tested?

core/rest unit tests still pass.

Verified the above scenario. Now the curl call response is:

```
< HTTP/1.1 404 Not Found
...
{"Error":"Openchain endpoint not found."}
```

because the route is no longer matched (due to the stricter URL parameter validation).
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Dov Murik dmurik@us.ibm.com
