### PR TITLE
Clear batch store on view change

### DIFF
--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -47,7 +47,7 @@ general:
         # and this much time has elapsed since the current batch was formed
         batch: 1s
 
-        # How long may a request take between reception and execution
+        # How long may a request take between reception and execution, must be greater than the batch timeout
         request: 2s
 
         # How long may a view change take
@@ -56,7 +56,7 @@ general:
         # How long to wait for a view change quorum before resending (the same) view change
         resendviewchange: 2s
 
-        # Interval to send "keep-alive" null requests.  Set to 0 to disable.
+        # Interval to send "keep-alive" null requests.  Set to 0 to disable. If enabled, must be greater than request timeout
         nullrequest: 0s
 
 ################################################################################

--- a/consensus/obcpbft/config.yaml
+++ b/consensus/obcpbft/config.yaml
@@ -45,7 +45,7 @@ general:
 
         # Send a pre-prepare if there are pending requests, batchsize isn't reached yet,
         # and this much time has elapsed since the current batch was formed
-        batch: 2s
+        batch: 1s
 
         # How long may a request take between reception and execution
         request: 2s

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -101,6 +101,16 @@ func newObcBatch(id uint64, config *viper.Viper, stack consensus.Stack) *obcBatc
 	logger.Infof("PBFT Batch size = %d", op.batchSize)
 	logger.Infof("PBFT Batch timeout = %v", op.batchTimeout)
 
+	if op.batchTimeout >= op.pbft.requestTimeout {
+		op.pbft.requestTimeout = 3 * op.batchTimeout / 2
+		logger.Warningf("Configured request timeout must be greater than batch timeout, setting to %v", op.pbft.requestTimeout)
+	}
+
+	if op.pbft.requestTimeout >= op.pbft.nullRequestTimeout && op.pbft.nullRequestTimeout != 0 {
+		op.pbft.nullRequestTimeout = 3 * op.pbft.requestTimeout / 2
+		logger.Warningf("Configured null request timeout must be greater than request timeout, setting to %v", op.pbft.nullRequestTimeout)
+	}
+
 	op.incomingChan = make(chan *batchMessage)
 
 	op.batchTimer = etf.CreateTimer()

--- a/consensus/obcpbft/obc-batch.go
+++ b/consensus/obcpbft/obc-batch.go
@@ -210,8 +210,7 @@ func (op *obcBatch) execute(seqNo uint64, raw []byte) {
 			continue
 		}
 
-		// TODO, this is a really and inefficient way to do this, but because reqs aren't comparable, they cannot be retrieved from the map directly
-		logger.Debugf("Batch replica %d executing request with transaction %s from outstandingReqs", op.pbft.id, tx.Uuid)
+		logger.Debugf("Batch replica %d executing request with transaction %s from outstandingReqs, seqNo=%d", op.pbft.id, tx.Uuid, seqNo)
 
 		if outstanding, pending := op.reqStore.remove(req); !outstanding || !pending {
 			logger.Debugf("Batch replica %d missing transaction %s outstanding=%v, pending=%v", op.pbft.id, tx.Uuid, outstanding, pending)
@@ -415,6 +414,7 @@ func (op *obcBatch) ProcessEvent(event events.Event) events.Event {
 		op.startTimerIfOutstandingRequests()
 		return res
 	case viewChangedEvent:
+		op.batchStore = nil
 		// Outstanding reqs doesn't make sense for batch, as all the requests in a batch may be processed
 		// in a different batch, but PBFT core can't see through the opaque structure to see this
 		// so, on view change, clear it out
@@ -507,9 +507,9 @@ func (op *obcBatch) getManager() events.Manager {
 }
 
 func (op *obcBatch) startTimerIfOutstandingRequests() {
-	if op.pbft.skipInProgress || op.pbft.currentExec != nil {
+	if op.pbft.skipInProgress || op.pbft.currentExec != nil || !op.pbft.activeView {
 		// Do not start view change timer if some background event is in progress
-		logger.Debugf("Replica %d not starting timer because skip in progress or current exec", op.pbft.id)
+		logger.Debugf("Replica %d not starting timer because skip in progress or current exec or in view change", op.pbft.id)
 		return
 	}
 

--- a/consensus/obcpbft/obc-batch_test.go
+++ b/consensus/obcpbft/obc-batch_test.go
@@ -354,3 +354,18 @@ func TestClassicBackToBackStateTransfer(t *testing.T) {
 		}
 	}
 }
+
+func TestClearBatchStoreOnViewChange(t *testing.T) {
+	b := newObcBatch(1, loadConfig(), &omniProto{})
+	defer b.Close()
+
+	b.batchStore = []*Request{&Request{}}
+
+	// Send a request, which will be ignored, triggering view change
+	b.manager.Queue() <- viewChangedEvent{}
+	b.manager.Queue() <- nil
+
+	if len(b.batchStore) != 0 {
+		t.Fatalf("Should have cleared the batch store on view change")
+	}
+}


### PR DESCRIPTION
## Description

This changeset clears the batch store on view change, does not start the request timer when not in an active view, and decreases the batch timeout to be less than the request timeout.

Usual SMEs are @kchristidis @corecode and @tuand27613, though you may wish to check PR #2007 (the companion to this PR against 0.5) for signoffs.
## Motivation and Context

This is intended to address symptoms of #1874 as well as a duplicated deploy transaction seen in busywork.

If a replica was a primary and had a transaction in its batch store when the view change timer expired, it would include that request in the next batch when it became primary again, leading to transaction duplication.

If only a single request came in, then the view change timer would expire before the batch was created, and the network would view change over and over again until another request came in, never executing the first request.

Finally, while processing a new view, it was possible for the request timer to start, negating the doubling of the new view timer.
## How Has This Been Tested?

This has been tested against the busywork stress2b test, and a new unit test checking for the batchStore emptying on view change has been added.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Jason Yellick jyellick@us.ibm.com
