### PR TITLE
Fixed asset_management_with_roles chaincode for issue 1953

### DIFF
--- a/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles.go
+++ b/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles.go
@@ -260,7 +260,7 @@ func (t *AssetManagementChaincode) Query(stub *shim.ChaincodeStub, function stri
 	}
 
 	if len(row.Columns) == 0 {
-		jsonResp := "{\"Error\":\"Failed retrieving owner for " + asset + ". Error " + err.Error() + ". \"}"
+		jsonResp := "{\"Error\":\"Failed retrieving owner for " + asset + ". \"}"
 		return nil, errors.New(jsonResp)
 	}
 

--- a/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles_test.go
+++ b/examples/chaincode/go/asset_management_with_roles/asset_management_with_roles_test.go
@@ -167,6 +167,12 @@ func TestAssetManagement(t *testing.T) {
 	if !reflect.DeepEqual(theOnwerIs, bobAccount) {
 		t.Fatal("Bob is not the owner of Picasso")
 	}
+
+	// Check who is the owner of an asset that doesn't exist
+	_, err = whoIsTheOwner("Klee")
+	if err == nil {
+		t.Fatal("This asset doesn't exist. Querying should fail.")
+	}
 }
 
 func deploy(admCert crypto.CertificateHandler) error {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Fixed for issue 1953, it was the result of a bad error message containing a non existing err variable that was being dereferenced and was causing a runtime panic.
## Description

Removed the non existing err variable from the chaincode. The error occured when querying for a non existing asset.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1953
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] This change requires no new documentation.
- [x] I have either added unit tests to cover my changes.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Diego Masini damasini@us.ibm.com Anna D Derbakova adderbak@us.ibm.com
