### PR TITLE
Fixed GetRows() by moving defer into dependent goroutine

### DIFF
--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -572,11 +572,11 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching rows: %s", err)
 	}
-	defer iter.Close()
 
 	rows := make(chan Row)
 
 	go func() {
+		defer iter.Close()
 		for iter.HasNext() {
 			_, rowBytes, err := iter.Next()
 			if err != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Within the `GetRows` function in `core/chaincode/shim/chaincode.go`, I have moved `defer iter.Close()` inside the goroutine which depends on `iter` for the reason explained below.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

The `GetRows` function uses a goroutine to get rows from a `StateRangeQueryIterator`. This iterator is used within the goroutine. Defer is used to wait until the function completes to clean up the iterator. However, the function can finish before the goroutine (in my case when there are a large number of rows requested), causing the iterator to be cleaned up before the goroutine is finished using it. This results in a chaincode error:

```
00:00:00 [shim] DEBU : [xxx]Sending RANGE_QUERY_STATE_NEXT
00:00:00 [shim] DEBU : [xxx]Received message ERROR from shim
00:00:00 [shim] DEBU : [xxx]Handling ChaincodeMessage of type: ERROR(state:ready)
Error starting chaincode: Error handling message: [xxx]Chaincode handler FSM cannot handle message (ERROR) with payload size (30) while in state: ready
```
## How Has This Been Tested?

I tested this change against a chaincode project which requests a large number of rows from a table using the `GetRows` function. It solves the error shown above in a logical way. I created a separate [test to show the issue simply](https://play.golang.org/p/TNEh2gaB_m).
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Brian Ensor briancensor@gmail.com
