### PR TITLE
core/rest: Fix panic when block not found in DB

### DIFF
--- a/core/rest/rest_api_test.go
+++ b/core/rest/rest_api_test.go
@@ -239,6 +239,14 @@ func TestServerOpenchainREST_API_GetBlockByNumber(t *testing.T) {
 	if res.Error == "" {
 		t.Errorf("Expected an error when URL doesn't have a number, but got none")
 	}
+
+	// Add a fake block number 9 and try to fetch non-existing block 6
+	ledger.PutRawBlock(&block0, 9)
+	body = performHTTPGet(t, httpServer.URL+"/chain/blocks/6")
+	res = parseRESTResult(t, body)
+	if res.Error == "" {
+		t.Errorf("Expected an error when block doesn't exist, but got none")
+	}
 }
 
 func TestServerOpenchainREST_API_GetTransactionByUUID(t *testing.T) {


### PR DESCRIPTION
## Description

When querying REST API using `/chain/blocks/N`, if N refers to a block which is _lower_ than the current chain height but the block doesn't exist in the DB, the REST API panics.  This PR fixes this.
## Motivation and Context

This deals with a `nil,nil` response from `ledger.GetBlockByNumber`; see #1610 for discussion whether this response should be valid at all.

Fixes #2012
## How Has This Been Tested?

Current REST API unit tests past. Unfortunately, I could find a way to mimic this scenario in unit tests - I tried reducing `deltaHistorySize` to 3 but it only deletes records from the state delta columnfamily and not from the blocks columnfamily. If anyone has an idea how to cause this scenario in the unit-tests, please let me know and I'll add it.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Dov Murik dmurik@us.ibm.com
