### PR TITLE
2036: separate the TCAA functionality from the TCA (tca.go -> tcaa.go)

### DIFF
--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -75,11 +75,6 @@ type TCAP struct {
 	tca *TCA
 }
 
-// TCAA serves the administrator GRPC interface of the TCA.
-type TCAA struct {
-	tca *TCA
-}
-
 // TCertSet contains relevant information of a set of tcerts
 type TCertSet struct {
 	Ts           int64
@@ -589,27 +584,6 @@ func (tcap *TCAP) RevokeCertificate(context.Context, *pb.TCertRevokeReq) (*pb.CA
 // RevokeCertificateSet revokes a certificate set from the TCA.  Not yet implemented.
 func (tcap *TCAP) RevokeCertificateSet(context.Context, *pb.TCertRevokeSetReq) (*pb.CAStatus, error) {
 	Trace.Println("grpc TCAP:RevokeCertificateSet")
-
-	return nil, errors.New("not yet implemented")
-}
-
-// RevokeCertificate revokes a certificate from the TCA.  Not yet implemented.
-func (tcaa *TCAA) RevokeCertificate(context.Context, *pb.TCertRevokeReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:RevokeCertificate")
-
-	return nil, errors.New("not yet implemented")
-}
-
-// RevokeCertificateSet revokes a certificate set from the TCA.  Not yet implemented.
-func (tcaa *TCAA) RevokeCertificateSet(context.Context, *pb.TCertRevokeSetReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:RevokeCertificateSet")
-
-	return nil, errors.New("not yet implemented")
-}
-
-// PublishCRL requests the creation of a certificate revocation list from the TCA.  Not yet implemented.
-func (tcaa *TCAA) PublishCRL(context.Context, *pb.TCertCRLReq) (*pb.CAStatus, error) {
-	Trace.Println("grpc TCAA:CreateCRL")
 
 	return nil, errors.New("not yet implemented")
 }

--- a/membersrvc/ca/tcaa.go
+++ b/membersrvc/ca/tcaa.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"errors"
+
+	pb "github.com/hyperledger/fabric/membersrvc/protos"
+	"golang.org/x/net/context"
+)
+
+// TCAA serves the administrator GRPC interface of the TCA.
+type TCAA struct {
+	tca *TCA
+}
+
+// RevokeCertificate revokes a certificate from the TCA.  Not yet implemented.
+func (tcaa *TCAA) RevokeCertificate(context.Context, *pb.TCertRevokeReq) (*pb.CAStatus, error) {
+	Trace.Println("grpc TCAA:RevokeCertificate")
+
+	return nil, errors.New("not yet implemented")
+}
+
+// RevokeCertificateSet revokes a certificate set from the TCA.  Not yet implemented.
+func (tcaa *TCAA) RevokeCertificateSet(context.Context, *pb.TCertRevokeSetReq) (*pb.CAStatus, error) {
+	Trace.Println("grpc TCAA:RevokeCertificateSet")
+
+	return nil, errors.New("not yet implemented")
+}
+
+// PublishCRL requests the creation of a certificate revocation list from the TCA.  Not yet implemented.
+func (tcaa *TCAA) PublishCRL(context.Context, *pb.TCertCRLReq) (*pb.CAStatus, error) {
+	Trace.Println("grpc TCAA:CreateCRL")
+
+	return nil, errors.New("not yet implemented")
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

A quick separation of the external gRPC (Admin) interface for TCA.
Part of the breaking down of #2034 into smaller, gradual, issues as requested.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2036 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Full build via `make all`, running all tests.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: JonathanLevi
