### PR TITLE
membershipsrv -  add membersrvc/ca/utils.go tests #1842 

### DIFF
--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -434,7 +434,7 @@ func (tcap *TCAP) createCertificateSet(ctx context.Context, raw []byte, in *pb.T
 		txPub := ecdsa.PublicKey{Curve: pub.Curve, X: txX, Y: txY}
 
 		// Compute encrypted TCertIndex
-		encryptedTidx, err := CBCEncrypt(extKey, tidx)
+		encryptedTidx, err := primitives.CBCPKCS7Encrypt(extKey, tidx)
 		if err != nil {
 			return nil, err
 		}
@@ -524,7 +524,7 @@ func (tcap *TCAP) generateExtensions(tcertid *big.Int, tidx []byte, enrollmentCe
 	enrollmentID := []byte(enrollmentCert.Subject.CommonName)
 	enrollmentID = append(enrollmentID, Padding...)
 
-	encEnrollmentID, err := CBCEncrypt(enrollmentIDKey, enrollmentID)
+	encEnrollmentID, err := primitives.CBCPKCS7Encrypt(enrollmentIDKey, enrollmentID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/membersrvc/ca/util.go
+++ b/membersrvc/ca/util.go
@@ -17,10 +17,6 @@ limitations under the License.
 package ca
 
 import (
-	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
-	crand "crypto/rand"
 	"errors"
 	"io"
 	"log"
@@ -93,70 +89,4 @@ func MemberRoleToString(role pb.Role) (string, error) {
 	}
 
 	return roleStr, nil
-}
-
-// PKCS5Pad adds a PKCS5 padding.
-//
-func PKCS5Pad(src []byte) []byte {
-	padding := aes.BlockSize - len(src)%aes.BlockSize
-	pad := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(src, pad...)
-}
-
-// PKCS5Unpad removes a PKCS5 padding.
-//
-func PKCS5Unpad(src []byte) []byte {
-	len := len(src)
-	unpad := int(src[len-1])
-	return src[:(len - unpad)]
-}
-
-// CBCEncrypt performs an AES CBC encryption.
-//
-func CBCEncrypt(key, s []byte) ([]byte, error) {
-	src := PKCS5Pad(s)
-
-	if len(src)%aes.BlockSize != 0 {
-		return nil, errors.New("plaintext length is not a multiple of the block size")
-	}
-
-	blk, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	enc := make([]byte, aes.BlockSize+len(src))
-	iv := enc[:aes.BlockSize]
-	if _, err := io.ReadFull(crand.Reader, iv); err != nil {
-		return nil, err
-	}
-
-	mode := cipher.NewCBCEncrypter(blk, iv)
-	mode.CryptBlocks(enc[aes.BlockSize:], src)
-
-	return enc, nil
-}
-
-// CBCDecrypt performs an AES CBC decryption.
-//
-func CBCDecrypt(key, src []byte) ([]byte, error) {
-	blk, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(src) < aes.BlockSize {
-		return nil, errors.New("ciphertext too short")
-	}
-	iv := src[:aes.BlockSize]
-	src = src[aes.BlockSize:]
-
-	if len(src)%aes.BlockSize != 0 {
-		return nil, errors.New("ciphertext length is not a multiple of the block size")
-	}
-
-	mode := cipher.NewCBCDecrypter(blk, iv)
-	mode.CryptBlocks(src, src)
-
-	return PKCS5Unpad(src), nil
 }

--- a/membersrvc/ca/util_test.go
+++ b/membersrvc/ca/util_test.go
@@ -17,55 +17,34 @@ limitations under the License.
 package ca
 
 import (
-	"crypto/rand"
+	"reflect"
 	"testing"
+
+	pb "github.com/hyperledger/fabric/membersrvc/protos"
 )
 
-func TestCBCEncryptCBCDecrypt(t *testing.T) {
+func TestRandomString(t *testing.T) {
 
-	key := make([]byte, 32)
-	rand.Reader.Read(key)
-
-	var msg = []byte("a message to be encrypted")
-
-	encrypted, encErr := CBCEncrypt(key, msg)
-
-	if encErr != nil {
-		t.Fatalf("Error encrypting message %v", encErr)
+	rand := randomString(100)
+	if rand == "" {
+		t.Error("The randomString function must return a non nil value.")
 	}
 
-	decrypted, dErr := CBCDecrypt(key, encrypted)
-
-	if dErr != nil {
-		t.Fatalf("Error encrypting message %v", dErr)
+	if reflect.TypeOf(rand).String() != "string" {
+		t.Error("The randomString function must returns a string type value.")
 	}
-
-	if string(msg[:]) != string(decrypted[:]) {
-		t.Fatalf("Encryption->Decryption with same key should result in original message")
-	}
-
 }
 
-func TestCBCEncryptCBCDecrypt_KeyMismatch(t *testing.T) {
+func TestMemberRoleToStringNone(t *testing.T) {
 
-	defer func() {
-		recover()
-	}()
+	var role, err = MemberRoleToString(pb.Role_NONE)
 
-	key := make([]byte, 32)
-	rand.Reader.Read(key)
+	if err != nil {
+		t.Errorf("Error converting member role to string, result: %s", role)
+	}
 
-	decryptionKey := make([]byte, 32)
-	copy(decryptionKey, key[:])
-	decryptionKey[0] = key[0] + 1
-
-	var msg = []byte("a message to be encrypted")
-
-	encrypted, _ := CBCEncrypt(key, msg)
-	decrypted, _ := CBCDecrypt(decryptionKey, encrypted)
-
-	if string(msg[:]) == string(decrypted[:]) {
-		t.Fatalf("Encryption->Decryption with different keys shouldn't return original message")
+	if role != pb.Role_name[int32(pb.Role_NONE)] {
+		t.Errorf("The role string returned should have been %s", "NONE")
 	}
 
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

This PR solves the issue #1842 adding more tests and code fixes to membership services.
## Motivation and Context

Grow test coverage into membership services. Some function in util.go file were replaced by the equivalent existing functions in package primitives. The table below shows the function has been replaced in the first column and the function by what has been replaced in the second column. The function invocations were tested considering function compatibility making all the encrypt/decrypt/padding/unpadding combinations between both files. 
membersrvc/ca/util.go core/crypto/primitives/aes.go
**PKCS5Pad          ->           PKCS7Padding**
**PKCS5Unpad     ->            PKCS7UnPadding**
**CBCEncrypt        ->             CBCPKCS7Encrypt**
**CBCDecrypt       ->             CBCPKCS7Decrypt**

This task has been made in order to reach a more reusable code avoiding duplicate functions. 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->
- Compatibility tests: All valid combinations of encrypt/decrypt/padding/unpadding have been tested
- Two tests have been added into util_test.go file. 
- Unit tests have been run without errors. 
- Behave tests have been run without errors.
- Node.js tests have been run without errors.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] this change requires no new documentation.
- [X] I have either added unit tests to cover my changes.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: 
Guillermo Romero : gromeroar guillermo.romero@gmail.com / rologui@ar.ibm.com
