### PR TITLE
Remove all command-line flags that shadow keys in core.yaml

### DIFF
--- a/peer/main.go
+++ b/peer/main.go
@@ -242,18 +242,7 @@ func main() {
 
 	// Set the flags on the node start command.
 	flags := nodeStartCmd.Flags()
-	flags.Bool("peer-tls-enabled", false, "Connection uses TLS if true, else plain TCP")
-	flags.String("peer-tls-cert-file", "testdata/server1.pem", "TLS cert file")
-	flags.String("peer-tls-key-file", "testdata/server1.key", "TLS key file")
-	flags.Int("peer-gomaxprocs", 2, "The maximum number threads excuting peer code")
-	flags.Bool("peer-discovery-enabled", true, "Whether peer discovery is enabled")
-
 	flags.BoolVarP(&chaincodeDevMode, "peer-chaincodedev", "", false, "Whether peer in chaincode development mode")
-
-	viper.BindPFlag("peer.tls.enabled", flags.Lookup("peer-tls-enabled"))
-	viper.BindPFlag("peer.tls.cert.file", flags.Lookup("peer-tls-cert-file"))
-	viper.BindPFlag("peer.tls.key.file", flags.Lookup("peer-tls-key-file"))
-	viper.BindPFlag("peer.gomaxprocs", flags.Lookup("peer-gomaxprocs"))
 
 	// Now set the configuration file.
 	viper.SetConfigName(cmdRoot) // Name of config file (without extension)
@@ -273,7 +262,7 @@ func main() {
 	nodeCmd.AddCommand(nodeStartCmd)
 	nodeCmd.AddCommand(nodeStatusCmd)
 
-	nodeStopCmd.Flags().StringVarP(&stopPidFile, "stop-peer-pid-file", "", viper.GetString("peer.fileSystemPath"), "Location of peer pid local file, for forces kill")
+	nodeStopCmd.Flags().StringVar(&stopPidFile, "stop-peer-pid-file", viper.GetString("peer.fileSystemPath"), "Location of peer pid local file, for forces kill")
 	nodeCmd.AddCommand(nodeStopCmd)
 
 	mainCmd.AddCommand(nodeCmd)

--- a/peer/main.go
+++ b/peer/main.go
@@ -243,19 +243,7 @@ func main() {
 
 	// Set the flags on the node start command.
 	flags := nodeStartCmd.Flags()
-	flags.Bool("peer-tls-enabled", false, "Connection uses TLS if true, else plain TCP")
-	flags.String("peer-tls-cert-file", "testdata/server1.pem", "TLS cert file")
-	flags.String("peer-tls-key-file", "testdata/server1.key", "TLS key file")
-	flags.Int("peer-gomaxprocs", 2, "The maximum number threads excuting peer code")
-	flags.Bool("peer-discovery-enabled", true, "Whether peer discovery is enabled")
-
 	flags.BoolVarP(&chaincodeDevMode, "peer-chaincodedev", "", false, "Whether peer in chaincode development mode")
-
-	viper.BindPFlag("peer.tls.enabled", flags.Lookup("peer-tls-enabled"))
-	viper.BindPFlag("peer.tls.cert.file", flags.Lookup("peer-tls-cert-file"))
-	viper.BindPFlag("peer.tls.key.file", flags.Lookup("peer-tls-key-file"))
-	viper.BindPFlag("peer.gomaxprocs", flags.Lookup("peer-gomaxprocs"))
-	viper.BindPFlag("peer.discovery.enabled", flags.Lookup("peer-discovery-enabled"))
 
 	// Now set the configuration file.
 	viper.SetConfigName(cmdRoot) // Name of config file (without extension)
@@ -275,7 +263,7 @@ func main() {
 	nodeCmd.AddCommand(nodeStartCmd)
 	nodeCmd.AddCommand(nodeStatusCmd)
 
-	nodeStopCmd.Flags().StringVarP(&stopPidFile, "stop-peer-pid-file", "", viper.GetString("peer.fileSystemPath"), "Location of peer pid local file, for forces kill")
+	nodeStopCmd.Flags().StringVar(&stopPidFile, "stop-peer-pid-file", viper.GetString("peer.fileSystemPath"), "Location of peer pid local file, for forces kill")
 	nodeCmd.AddCommand(nodeStopCmd)
 
 	mainCmd.AddCommand(nodeCmd)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Removed all command-line flags from main.go that shadow keys in core.yaml. I also fixed an incorrect usage of StringVarP. I've also grep-ed the docs and I can't find these used anywhere.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1962
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Passes tests in Vagrant environment
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass.

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
