### PR TITLE
Fixes Issue# 2115

### DIFF
--- a/bddtests/compose-defaults.yml
+++ b/bddtests/compose-defaults.yml
@@ -6,8 +6,8 @@ vp:
     # TODO:  This is currently required due to BUG in variant logic based upon log level.
     - CORE_LOGGING_LEVEL=DEBUG
   # Startup of peer must be delayed to allow membersrvc to come up first
-  #command: sh -c "sleep 5; peer node start"
-  command: peer node start
+  command: sh -c "sleep 5; peer node start"
+  #command: peer node start
   
   # Use these options if coverage desired for peers
   #image: hyperledger/fabric-peer-coverage

--- a/bddtests/peer_basic.feature
+++ b/bddtests/peer_basic.feature
@@ -1038,7 +1038,7 @@ Feature: Network of Peers
 
       Given I start peers:
             | vp0  |
-      And I wait "5" seconds
+      And I wait "10" seconds
 
       When requesting "/network/peers" from "vp1"
       Then I should get a JSON response with array "peers" contains "2" elements

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -65,7 +65,7 @@ def parseComposeOutput(context):
     for containerName in containerNames:
     	output, error, returncode = \
         	bdd_test_util.cli_call(context, ["docker", "inspect", "--format",  "{{ .NetworkSettings.IPAddress }}", containerName], expect_success=True)
-        #print("container {0} has address = {1}".format(containerName, output.splitlines()[0]))
+        print("container {0} has address = {1}".format(containerName, output.splitlines()[0]))
         ipAddress = output.splitlines()[0]
 
         # Get the environment array


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Below are the changes made to fix #2115

242d3bc - Added 5 sec's sleep to launch peers in "compose-default.yaml" file. 
fcc2d17 -  printing docker container IP address
c1d20a0 - Increased timeout to 10 sec's from 5 sec's in Issue_1851 behave test case. 
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #
#2115
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Executed behave tests in Jenkins build machines
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:thoomu@us.ibm.com
