### PR TITLE
Fixes issue#936

### DIFF
--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -1211,7 +1211,7 @@ func TestChaincodeQueryChaincodeErrorCase(t *testing.T) {
 		return
 	}
 
-	if strings.Index(err.Error(), "Nil amount for c") < 0 {
+	if strings.Index(err.Error(), "Failed to get state for c") < 0 {
 		t.Fail()
 		t.Logf("Unexpected error %s", err)
 		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec1})

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -270,12 +270,14 @@ func (stub *ChaincodeStub) QueryChaincode(chaincodeName string, function string,
 
 // --------- State functions ----------
 
-// GetState returns the byte array value specified by the `key`.
+// GetState returns the value currently associated with the `key` in the ledger. If there is no value
+// associated with `key`, then the []byte value returned is nil.
 func (stub *ChaincodeStub) GetState(key string) ([]byte, error) {
 	return handler.handleGetState(key, stub.UUID)
 }
 
-// PutState writes the specified `value` and `key` into the ledger.
+// PutState associates the `value` with the `key` in the ledger. To avoid ambiguities with the operation
+// of GetState the `value` is not allowed to be nil, however a 0-length byte array is a valid `value`.
 func (stub *ChaincodeStub) PutState(key string, value []byte) error {
 	return handler.handlePutState(key, value, stub.UUID)
 }

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -33,12 +33,6 @@ type PeerChaincodeStream interface {
 	CloseSend() error
 }
 
-// KeyNotFound Error in State
-var (
-	// ErrKeyNotFoundInState if the specified key cannot be found
-	ErrKeyNotFoundInState = errors.New("chaincode: Key not found in state")
-)
-
 type nextStateInfo struct {
 	msg      *pb.ChaincodeMessage
 	sendToCC bool
@@ -466,15 +460,12 @@ func (handler *Handler) handleGetState(key string, uuid string) ([]byte, error) 
 
 	if responseMsg.Type.String() == pb.ChaincodeMessage_RESPONSE.String() {
 		// Success response
-		if responseMsg.Payload == nil {
-			chaincodeLogger.Debugf("[%s]Queried key (%s) does not exist in the state", shortuuid(responseMsg.Uuid), key)
-			return nil, ErrKeyNotFoundInState
-		} else {
+		if responseMsg.Payload != nil {
 			// Stripping NUL byte which got appended by peer
 			responseMsg.Payload = responseMsg.Payload[0 : len(responseMsg.Payload)-1]
-			chaincodeLogger.Debugf("[%s]GetState received payload %s", shortuuid(responseMsg.Uuid), pb.ChaincodeMessage_RESPONSE)
-			return responseMsg.Payload, nil
 		}
+		chaincodeLogger.Debugf("[%s]GetState received payload %s", shortuuid(responseMsg.Uuid), pb.ChaincodeMessage_RESPONSE)
+		return responseMsg.Payload, nil
 	}
 	if responseMsg.Type.String() == pb.ChaincodeMessage_ERROR.String() {
 		// Error response
@@ -493,6 +484,10 @@ func (handler *Handler) handlePutState(key string, value []byte, uuid string) er
 	chaincodeLogger.Debugf("[%s]Inside putstate, isTransaction = %t", shortuuid(uuid), handler.isTransaction[uuid])
 	if !handler.isTransaction[uuid] {
 		return errors.New("Cannot put state in query context")
+	}
+
+	if value == nil {
+		return errors.New("Cannot put nil value for a key")
 	}
 
 	payload := &pb.PutStateInfo{Key: key, Value: value}

--- a/core/system_chaincode/samplesyscc/samplesyscc.go
+++ b/core/system_chaincode/samplesyscc/samplesyscc.go
@@ -48,14 +48,15 @@ func (t *SampleSysCC) Invoke(stub *shim.ChaincodeStub, function string, args []s
 	key = args[0]
 	val = args[1]
 
-	_, err := stub.GetState(key)
-	if err != nil {
-		jsonResp := "{\"Error\":\"Failed to get val for " + key + "\"}"
-		return nil, errors.New(jsonResp)
-	}
+	/*
+		_, err := stub.GetState(key)
+		if err != nil {
+			jsonResp := "{\"Error\":\"Failed to get val for " + key + "\"}"
+			return nil, errors.New(jsonResp)
+		}*/
 
 	// Write the state to the ledger
-	err = stub.PutState(key, []byte(val))
+	err := stub.PutState(key, []byte(val))
 	if err != nil {
 		return nil, err
 	}

--- a/core/system_chaincode/samplesyscc/samplesyscc.go
+++ b/core/system_chaincode/samplesyscc/samplesyscc.go
@@ -48,15 +48,14 @@ func (t *SampleSysCC) Invoke(stub *shim.ChaincodeStub, function string, args []s
 	key = args[0]
 	val = args[1]
 
-	/*
-		_, err := stub.GetState(key)
-		if err != nil {
-			jsonResp := "{\"Error\":\"Failed to get val for " + key + "\"}"
-			return nil, errors.New(jsonResp)
-		}*/
+	_, err := stub.GetState(key)
+	if err != nil {
+		jsonResp := "{\"Error\":\"Failed to get val for " + key + "\"}"
+		return nil, errors.New(jsonResp)
+	}
 
 	// Write the state to the ledger
-	err := stub.PutState(key, []byte(val))
+	err = stub.PutState(key, []byte(val))
 	if err != nil {
 		return nil, err
 	}

--- a/examples/chaincode/go/chaincode_example_put_get_state/chaincode_example_put_get_state.go
+++ b/examples/chaincode/go/chaincode_example_put_get_state/chaincode_example_put_get_state.go
@@ -54,23 +54,22 @@ func (t *SimpleChaincode) Init(stub *shim.ChaincodeStub, function string, args [
 	return nil, nil
 }
 
-//Invoke sets key to a value
+//Invoke tries to set key value to nil
 func (t *SimpleChaincode) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
 
 	var key string
-	var value string
 	var err error
 
-	if len(args) != 2 {
+	if len(args) != 1 {
 		return nil, errors.New("Incorrect number of arguments. Expecting a key and value")
 	}
 
 	key = args[0]
-	value = args[1]
 
-	// Write the state to the ledger
-	err = stub.PutState(key, []byte(value))
+	// Try to write nil state to the ledger
+	err = stub.PutState(key, nil)
 	if err != nil {
+		fmt.Printf("Error on insert nil value for key. Error Desc:%v \n", err.Error())
 		return nil, err
 	}
 

--- a/examples/chaincode/go/chaincode_example_put_get_state/chaincode_example_put_get_state.go
+++ b/examples/chaincode/go/chaincode_example_put_get_state/chaincode_example_put_get_state.go
@@ -1,0 +1,117 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+// SimpleChaincode example simple Chaincode implementation
+type SimpleChaincode struct {
+}
+
+// Simple ledger Retrieval example which demonstrates storing a string in ledger and retrieving the same
+
+// Init callback representing the invocation of a chaincode
+func (t *SimpleChaincode) Init(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	var key string
+	var value string
+	var err error
+
+	if len(args) != 2 {
+		return nil, errors.New("Incorrect number of arguments. Expecting a key and value")
+	}
+
+	key = args[0]
+	value = args[1]
+
+	// Write the state to the ledger
+	err = stub.PutState(key, []byte(value))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+//Invoke sets key to a value
+func (t *SimpleChaincode) Invoke(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+
+	var key string
+	var value string
+	var err error
+
+	if len(args) != 2 {
+		return nil, errors.New("Incorrect number of arguments. Expecting a key and value")
+	}
+
+	key = args[0]
+	value = args[1]
+
+	// Write the state to the ledger
+	err = stub.PutState(key, []byte(value))
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Query callback representing the query of a chaincode
+func (t *SimpleChaincode) Query(stub *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	if function != "query" {
+		return nil, errors.New("Invalid query function name. Expecting \"query\"")
+	}
+	var key string // Entities
+	var err error
+
+	if len(args) != 1 {
+		return nil, errors.New("Incorrect number of arguments. Expecting the key for query")
+	}
+
+	key = args[0]
+
+	// Get the state from the ledger
+	value, err := stub.GetState(key)
+	if err != nil {
+		//fmt.Printf(" Got error %q \n" + err.Error())
+		jsonResp := "{\"Error\":\"Failed to get state for " + key + "\"}" + err.Error()
+		return nil, errors.New(jsonResp)
+	}
+
+	if value == nil {
+		jsonResp := "{\"Error\":\"Nil value for " + key + "\"}"
+		return nil, errors.New(jsonResp)
+	}
+
+	jsonResp := "{\"Key\":\"" + key + "\",\"Value\":\"" + string(value) + "\"}"
+	fmt.Printf("Query Response:%s, isNil?: %v cap:%v \n", jsonResp, (value == nil), cap(value))
+	return value, nil
+}
+
+func main() {
+	err := shim.Start(new(SimpleChaincode))
+	if err != nil {
+		fmt.Printf("Error starting Simple chaincode: %s", err)
+	}
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

PUT - Allowing empty byte to be put into ledger - Protobuf by its nature converts empty byte to nil when traversing (serialize/de-serialize) the payload from shim side to peer side. To overcome that the handler on the peer side detects nil and converts back to empty byte to put in the ledger

GET - Empty byte in the ledger or peer side needs to be traversed to the shim side: Again with protobuf converting empty byte to nil during traversal causes the issue. The fix is to pad it with NUL byte on peer side and unpad when received on the shim side

Also when key does not exist, shim throws an appropriate error
## Motivation and Context

Fixes issue#936
## How Has This Been Tested?

go test -v -run=TestPutAndGetForEmptyKeyValue

--- PASS: TestPutAndGetForEmptyKeyValue (18.81s)
        exectransaction_test.go:1495:  Test for put and get for empty key value  passed
PASS

go test -v -run=TestQueryForNonExistentKey

--- PASS: TestQueryForNonExistentKey (9.27s)
        exectransaction_test.go:1561: Test for NonExistentKey Passed. Expecting error and got error: Transaction or query returned with failure: {"Error":"Failed to get state for KeyDoesNotExist"}chaincode: Key not found in state
PASS

go test -v -TestPutWithNilKeyValue

--- PASS: TestPutWithNilKeyValue (18.88s)
        exectransaction_test.go:1560: Inserting nil value test passed. Got error as expected :Transaction or query returned with failure: Cannot put nil value for a key
PASS

**Manual Unit Test Logs -**

vagrant@hyperledger-devenv:v0.0.9-66ca505:/opt/gopath/src/github.com/hyperledger/fabric/peer$ ./peer chaincode query -l golang -n mycc -c '{"Function":"query","Args":["myname"]}'
2016/06/29 18:27:32 Load docker HostConfig: &{Binds:[] CapAdd:[] CapDrop:[] ContainerIDFile: LxcConf:[] Privileged:false PortBindings:map[] Links:[] PublishAllPorts:false DNS:[] DNSSearch:[] ExtraHosts:[] VolumesFrom:[] NetworkMode:host IpcMode: PidMode: UTSMode: RestartPolicy:{Name: MaximumRetryCount:0} Devices:[] LogConfig:{Type: Config:map[]} ReadonlyRootfs:false SecurityOpt:[] CgroupParent: Memory:0 MemorySwap:0 MemorySwappiness:0 OOMKillDisable:false CPUShares:0 CPUSet: CPUSetCPUs: CPUSetMEMs: CPUQuota:0 CPUPeriod:0 BlkioWeight:0 Ulimits:[]}
18:27:32.422 [crypto] main -> INFO 002 Log level recognized 'info', set to INFO
MuraliK

vagrant@hyperledger-devenv:v0.0.9-66ca505:/opt/gopath/src/github.com/hyperledger/fabric/peer$ ./peer chaincode invoke -l golang -n mycc -c '{"Function": "invoke", "Args": ["hisname", ""]}'
2016/06/29 18:28:11 Load docker HostConfig: &{Binds:[] CapAdd:[] CapDrop:[] ContainerIDFile: LxcConf:[] Privileged:false PortBindings:map[] Links:[] PublishAllPorts:false DNS:[] DNSSearch:[] ExtraHosts:[] VolumesFrom:[] NetworkMode:host IpcMode: PidMode: UTSMode: RestartPolicy:{Name: MaximumRetryCount:0} Devices:[] LogConfig:{Type: Config:map[]} ReadonlyRootfs:false SecurityOpt:[] CgroupParent: Memory:0 MemorySwap:0 MemorySwappiness:0 OOMKillDisable:false CPUShares:0 CPUSet: CPUSetCPUs: CPUSetMEMs: CPUQuota:0 CPUPeriod:0 BlkioWeight:0 Ulimits:[]}
18:28:11.379 [crypto] main -> INFO 002 Log level recognized 'info', set to INFO
3bffc087-ea21-4f9e-8d5a-eceb93d04ab3

vagrant@hyperledger-devenv:v0.0.9-66ca505:/opt/gopath/src/github.com/hyperledger/fabric/peer$ ./peer chaincode query -l golang -n mycc -c '{"Function":"query","Args":["hisname"]}'
2016/06/29 18:28:57 Load docker HostConfig: &{Binds:[] CapAdd:[] CapDrop:[] ContainerIDFile: LxcConf:[] Privileged:false PortBindings:map[] Links:[] PublishAllPorts:false DNS:[] DNSSearch:[] ExtraHosts:[] VolumesFrom:[] NetworkMode:host IpcMode: PidMode: UTSMode: RestartPolicy:{Name: MaximumRetryCount:0} Devices:[] LogConfig:{Type: Config:map[]} ReadonlyRootfs:false SecurityOpt:[] CgroupParent: Memory:0 MemorySwap:0 MemorySwappiness:0 OOMKillDisable:false CPUShares:0 CPUSet: CPUSetCPUs: CPUSetMEMs: CPUQuota:0 CPUPeriod:0 BlkioWeight:0 Ulimits:[]}
18:28:57.202 [crypto] main -> INFO 002 Log level recognized 'info', set to INFO

vagrant@hyperledger-devenv:v0.0.9-66ca505:/opt/gopath/src/github.com/hyperledger/fabric/peer$ ./peer chaincode query -l golang -n mycc -c '{"Function":"query","Args":["hername"]}'
2016/06/29 18:29:38 Load docker HostConfig: &{Binds:[] CapAdd:[] CapDrop:[] ContainerIDFile: LxcConf:[] Privileged:false PortBindings:map[] Links:[] PublishAllPorts:false DNS:[] DNSSearch:[] ExtraHosts:[] VolumesFrom:[] NetworkMode:host IpcMode: PidMode: UTSMode: RestartPolicy:{Name: MaximumRetryCount:0} Devices:[] LogConfig:{Type: Config:map[]} ReadonlyRootfs:false SecurityOpt:[] CgroupParent: Memory:0 MemorySwap:0 MemorySwappiness:0 OOMKillDisable:false CPUShares:0 CPUSet: CPUSetCPUs: CPUSetMEMs: CPUQuota:0 CPUPeriod:0 BlkioWeight:0 Ulimits:[]}
18:29:38.922 [crypto] main -> INFO 002 Log level recognized 'info', set to INFO

Usage:
  peer chaincode query [flags]

Flags:
  -x, --hex[=false]: If true, output the query value byte array in hexadecimal. Incompatible with --raw
  -r, --raw[=false]: If true, output the query value as raw bytes, otherwise format as a printable string

Global Flags:
  -a, --attributes="[]": User attributes for the chaincode in JSON format
  -c, --ctor="{}": Constructor message for the chaincode in JSON format
  -l, --lang="golang": Language the chaincode is written in
      --logging-level="": Default logging level and overrides, see core.yaml for full syntax
  -n, --name="": Name of the chaincode returned by the deploy transaction
  -p, --path="": Path to chaincode
      --test.coverprofile="coverage.cov": Done
  -t, --tid="": Name of a custom ID generation algorithm (hashing and decoding) e.g. sha256base64
  -u, --username="": Username for chaincode operations when security is enabled

Error: Error querying chaincode: rpc error: code = 2 desc = "Error:Transaction or query returned with failure: {\"Error\":\"Failed to get state for hername\"}chaincode: Key not found in state"
# Golint, govet, gofmt, goimports

Log below shows go tools run all the source code changes

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$ golint handler.go
handler.go:472:10: if block ends with a return statement, so drop this else and outdent its block

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$ go tool vet handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$ gofmt -d handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$ goimports handler.go > handler_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$ diff handler.go handler_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode/shim (issue-936)
$

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ golint handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ go tool vet handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ gofmt -d handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ gofmt -w handler.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ goimports handler.go > handler_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ diff handler.go handler_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ golint exectransaction_test.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ go tool vet exectransaction_test.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ gofmt -d exectransaction_test.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ goimports exectransaction_test.go > exectransaction_test_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/core/chaincode (issue-936)
$ diff exectransaction_test.go exectransaction_test_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example_put_get_state (issue-936)
$ go tool vet chaincode_example_put_get_state.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example_put_get_state (issue-936)
$ golint chaincode_example_put_get_state.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example_put_get_state (issue-936)
$ gofmt -d chaincode_example_put_get_state.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example_put_get_state (issue-936)
$ goimports chaincode_example_put_get_state.go > chaincode_example_put_get_state_imports.go

btp3@btp3-PC MINGW64 /c/Go/src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example_put_get_state (issue-936)
$ diff chaincode_example_put_get_state.go chaincode_example_put_get_state_imports.go
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- x[] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:

Murali Katipalli
