### PR TITLE
Fixing issue #1897

### DIFF
--- a/sdk/node/test/unit/chain-tests.js
+++ b/sdk/node/test/unit/chain-tests.js
@@ -29,12 +29,6 @@ var fs = require('fs');
 
 var chain = hlc.newChain("testChain");
 
-var registrar = {
-    name: 'WebAppAdmin',
-    secret: 'DJY27pEnl16d'
-};
-
-
 //
 // Configure the test chain
 //
@@ -113,8 +107,8 @@ function getUser(name, cb) {
         if (err) return cb(err);
         if (user.isEnrolled()) return cb(null,user);
         // User is not enrolled yet, so perform both registration and enrollment
+        // The chain registrar is already set inside 'Set chain registrar' test
         var registrationRequest = {
-            registrar: registrar.user,
             enrollmentID: name,
             account: "bank_a",
             affiliation: "00001"


### PR DESCRIPTION
## Description

The Node.js unit test file chain-tests.js contained an unused and confusing `registrar` variable. I am removing it and clarifying the usage of the registrar in the test by adding a comment.
## Motivation and Context

This change clarifies the usage of the `registrar` inside the chain-tests.js unit test file.
Fixes #1897 
## How Has This Been Tested?

I have verified the change with existing test cases and clarified the change by adding a comment. 
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Removing unused registrar variable inside the chain-tests.js unit test
file.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
