### PR TITLE
Fixes Issue 2073: Logging controls in core.yaml referring to non-existent peer commands

### DIFF
--- a/docs/dev-setup/logging-control.md
+++ b/docs/dev-setup/logging-control.md
@@ -16,7 +16,13 @@ In pretty-printed logs the logging level is indicated both by color and by a 4-c
     16:47:09.635 [rest] StartOpenchainRESTServer -> INFO 035 Initializing the REST service...
     16:47:09.635 [main] serve -> INFO 036 Starting peer with id=name:"vp1" , network id=dev, address=9.3.158.178:30303, discovery.rootnode=, validator=true
 
-An arbitrary number of logging modules can be created at runtime, therefore there is no "master list" of modules, and logging control constructs can not check whether logging modules actually do or will exist.
+An arbitrary number of logging modules can be created at runtime, therefore
+there is no "master list" of modules, and logging control constructs can not
+check whether logging modules actually do or will exist. Also note that the
+logging module system does not understand hierarchy or wildcarding: You may
+see module names like "foo/bar" in the code, but the logging system only sees
+a flat string. It doesn't understand that "foo/bar" is related to "foo" in any
+way, or that "foo/*" might indicate all "submodules" of foo.
 
 ## peer
 
@@ -24,7 +30,12 @@ The logging level of the `peer` command can be controlled from the command line 
 
     peer node start --logging-level=debug
 	
-The default logging level for each individual `peer` subcommand can also be set in the [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml) file. For example the key `logging.peer` sets the default level for the `peer` subcommmand.
+The default logging level for each individual `peer` subcommand can also be
+set in the
+[core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml)
+file. For example the key `logging.node` sets the default level for the `node`
+subcommmand. Comments in the file also explain how the logging level can be
+overridden in various ways by using environment varaibles.
 
 Logging severity levels are specified using case-insensitive strings chosen from
 
@@ -38,7 +49,10 @@ A logging level by itself is taken as the overall default. Otherwise, overrides 
 
     <module>[,<module>...]=<level> 
 
-syntax. Examples of <level> specifications (valid for both `--logging-level` and [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml) settings):
+syntax. Examples of <level> specifications (valid for all of
+`--logging-level`, environment variable and
+[core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml)
+settings):
 
     info                                       - Set default to INFO
     warning:main,db=debug:chaincode=info       - Default WARNING; Override for main,db,chaincode

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -38,40 +38,36 @@ rest:
 ###############################################################################
 logging:
 
+    # Default logging levels are specified here for each of the three peer
+    # commands 'node', 'network' and 'chaincode'. For commands that have
+    # subcommands, the defaults also apply to all subcommands of the command.
     # Valid logging levels are case-insensitive strings chosen from
 
     #     CRITICAL | ERROR | WARNING | NOTICE | INFO | DEBUG
 
-    # Logging 'module' names are also strings, however valid module names are
-    # defined at runtime and are not checked for validity during option
-    # processing.
+    # The logging levels specified here can be overridden in various ways,
+    # listed below from strongest to weakest:
+    #
+    # 1. The --logging-level=<level> command line option overrides all other
+    #    specifications.
+    #
+    # 2. The environment variable CORE_LOGGING_LEVEL otherwise applies to
+    #    all peer commands if defined as a non-empty string.
+    #
+    # 3. The environment variables CORE_LOGGING_[NODE|NETWORK|CHAINCODE]
+    #    otherwise apply to the respective peer commands if defined as non-empty
+    #    strings. 
+    #
+    # 4. Otherwise, the specifications below apply.
+    #
+    # Developers: Please see fabric/docs/dev-setup/logging-control.md for more
+    # options. 
 
-    # Default logging levels are specified here for each of the peer
-    # commands. For commands that have subcommands, the defaults also apply to
-    # all subcommands of the command. These logging levels can be overridden
-    # on the command line using the --logging-level command-line option, or by
-    # setting the CORE_LOGGING_LEVEL environment variable.
-
-    # The logging level specification is of the form
-
-    #     [<module>[,<module>...]=]<level>[:[<module>[,<module>...]=]<level>...]
-
-    # A logging level by itself is taken as the overall default. Otherwise,
-    # overrides for individual or groups of modules can be specified using the
-    # <module>[,<module>...]=<level> syntax.
-
-    # Examples:
-    #   info                                       - Set default to INFO
-    #   warning:main,db=debug:chaincode=info       - Override default WARNING in main,db,chaincode
-    #   chaincode=info:main=debug:db=debug:warning - Same as above
-    peer:      debug
-    crypto:    info
-    status:    warning
-    stop:      warning
-    login:     warning
-    vm:        warning
+    node:      info
+    network:   warning
     chaincode: warning
 
+    crypto:    info # This should not be here; See issue #769
 
 ###############################################################################
 #


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

There are now only 3 peer commands: node, network and chaincode. The logging.<command> keys in core.yaml now reflect this correctly. I've also added notes that describe how to override them. If there is complexity to this, my argument is that the complexity comes from the fact that a single executable functions both as a server and a client, and servers and clients naturally have different default logging requirements.

After some discussions with @lehors it was thought to be clearer not to document the developer-level logging control in the core.yaml file, so this is now only discussed in docs/dev-setup/logging-control.md.

I've set the default for the `node` command to 'info', which I believe is appropriate for a server. If developers want to run with debug logging all the time they can easily set CORE_LOGGING_LEVEL=debug in their .profile or .bashrc files.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2073
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I've tested the changes and override ordering interactively at the command line. No Go code is changed by this fix. The unit and behave tests also work.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
