### PR TITLE
busywork: Remove all non-determinism + New Stress targets

### DIFF
--- a/tools/busywork/README.md
+++ b/tools/busywork/README.md
@@ -89,11 +89,14 @@ to run a simple stress test. This stress test exercises a single peer
 running `NOOPS` consensus.
 
 At present the PBFT *batch* algorithm is the only true consensus algorithm
-being suported by the development team. The target 
+supported by the development team. The targets
 
     make stress2b
+	make sweep1b
 	
-runs PBFT *batch* on a 4-peer network. 
+both test 4-peer PBFT *batch* networks. The `stress2b` test is a single run
+with a single client. The `sweep1b` test sweeps a test setup over a range of
+from 1 to 64 clients.
 
 There is also a pre-canned target
 
@@ -109,10 +112,7 @@ counter (8 bytes) to 1000 counters (8000 bytes):
 
     .PHONY: stress2b1k
 	stress2b1k:
-            @CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
-            $(NETWORK) -batch 4
-            @echo "makefile: Sleeping 10 seconds to allow peers to interlock"
-			sleep 10
+            @(STRESS2_CONFIG) $(NETWORK) -batch 4
 	        @$(STRESS2) -size 1000
 	
 ## Running Peers and Clients on Separate Machines

--- a/tools/busywork/README.md
+++ b/tools/busywork/README.md
@@ -96,7 +96,8 @@ supported by the development team. The targets
 	
 both test 4-peer PBFT *batch* networks. The `stress2b` test is a single run
 with a single client. The `sweep1b` test sweeps a test setup over a range of
-from 1 to 64 clients.
+from 1 to 64 clients. At present the `sweep1b` target appears to work in
+server environments, but fails in Vagrant/laptop environments.
 
 There is also a pre-canned target
 

--- a/tools/busywork/bin/checkAgreement
+++ b/tools/busywork/bin/checkAgreement
@@ -185,7 +185,7 @@ if {[null [parms explicitPeers]]} {
     if {[catch {busywork::networkToArray ::parms network.} msg]} {
         errorExit $msg
     }
-    if {[parms network.consensus] eq "noops"]} {
+    if {[parms network.consensus] eq "noops"} {
         puts stderr $usage
         err err "checkAgreement does not support NOOPS consensus"
         errorExit "Search for 'NOOPS' in the usage statement to understand why"

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -35,6 +35,9 @@ secure1
 
 sweep1b sweep1n
 
+    *** Note: The 'sweep1b' target currently appears to work in large server ***
+    *** environments but not in Vagrant/laptop environments                  ***
+
     A user-mode network of 4 validating peers running without security. One
     chaincode with one array. Sweep the number of clients from 1 to 64 by
     powers-of-2, sending a constant 32K transactions into the network

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -21,21 +21,36 @@ stress1
     A single validating peer with NOOPS consensus and no security. 64 clients
     each drive 1000 transactions into a single array without interlock.
 
-stress2 stress2n stress2b
+stress2b stress2n
 
-    NB: We are currently trying to work around issues in this test case, it is
-    not being run exactly as described below, and does not run successfully
-    with PBFT consensus.
-
-    A Docker-compose network of 4 validating peers running PBFT without
-    security. Send 10,000 transactions into a single array as a single burst,
-    using only the first peer, with one interlock at the end of the
-    burst. Consensus protocols are NOOPS (stress2n) or PBFT Batch (stress2b).
+    A user-mode network of 4 validating peers running without security. Send
+    10,000 transactions into a single array as a single burst, using only the
+    first peer, with one interlock at the end of the burst. Consensus
+    protocols are PBFT Batch (stress2b) or NOOPS (stress2n).
 
 secure1
 
     A 4-node setup with security. Security-mode is so slow that this is not a
     very stressful test. This test uses PBFT batch mode.
+
+sweep1b sweep1n
+
+    A user-mode network of 4 validating peers running without security. One
+    chaincode with one array. Sweep the number of clients from 1 to 64 by
+    powers-of-2, sending a constant 32K transactions into the network
+    targeting all peers in short bursts, each client interlocking every 64
+    transactions.  Consensus protocols are PBFT Batch (sweep1b) or NOOPS
+    (sweep1n).
+
+sweep2b sweep2n
+
+    A user-mode network of 4 validating peers running without security. Four
+    chaincodes, each managing 128 arrays. The median array size here is 64
+    counters or 512 bytes. Sweep the number of clients from 1 to 64 by
+    powers-of-2, sending a constant 32K transactions into the network
+    targeting all peers in moderate bursts, each client interlocking every 256
+    transactions.  Consensus protocols are PBFT Batch (sweep2b) or NOOPS
+    (sweep2n).
 
 
 ############################################################################
@@ -44,6 +59,10 @@ secure1
 build
 
     Build the chaincode
+
+countersTest
+
+    Test the 'counters' chaincode
 
 endif
 
@@ -66,14 +85,14 @@ stress1:
 		-keepLog
 
 
-# Note, fabric buffers are too small to do 10K TX, must do 100 X 100
-# We're using all peers here, once buffers increase we can go back to 1
-# This will eventually be more stressful
-
-.PHONY: stress2 stress2n stress2b
-STRESS2 = ./driver \
+.PHONY: stress2b stress2n
+STRESS2 = \
+	echo "makefile: Sleeping 10 seconds to allow peers to interlock;" \
+	sleep 10; \
+	./driver \
 		-transactions 10000 \
-		-peerBurst 100 \
+		-peerBurst 10000 \
+		-targetPeers 1 \
 		-interlock \
 		-interlockTimeout 5m \
 		-keepLog \
@@ -82,22 +101,13 @@ STRESS2 = ./driver \
 STRESS2_CONFIG = \
 	@CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s
 
-stress2n: 
-	@$(STRESS2_CONFIG) \
-	$(NETWORK) -noops 4
-	@echo "makefile: Sleeping 10 seconds to allow peers to interlock"
-	@sleep 10
-	@$(STRESS2)
-
 stress2b: 
-	@$(STRESS2_CONFIG) \
-	$(NETWORK) -batch 4
-	@echo "makefile: Sleeping 10 seconds to allow peers to interlock"
-	@sleep 10
+	@$(STRESS2_CONFIG) $(NETWORK) -batch 4
 	@$(STRESS2)
 
-stress2: stress2n stress2b
-
+stress2n: 
+	@$(STRESS2_CONFIG) $(NETWORK) -noops 4
+	@$(STRESS2)
 
 .PHONY: secure1
 secure1:
@@ -112,6 +122,71 @@ secure1:
 		-keepLog \
 		-checkAgreement -dupCheck
 
+.PHONY: sweep1b sweep1n
+SWEEP1 = \
+	echo "makefile: Sleeping 10 seconds to allow peers to interlock"; \
+	sleep 10; \
+	set -e; \
+	./driver \
+		-clients $$clients \
+		-transactions $$((32768 / $$clients)) \
+		-peerBurst 8 \
+		-netBurst 8 \
+		-interlock \
+		-keepLog \
+		-convergeWait 5m -convergePoll 5s \
+		-checkAgreement -dupCheck
+
+SWEEP1_CONFIG = \
+	CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
+	CORE_PEER_VALIDATOR_CONSENSUS_BUFFERSIZE=32768
+
+sweep1b: 
+	@for clients in 1 2 4 8 16 32 64; do \
+		$(SWEEP1_CONFIG) $(NETWORK) -batch 4; \
+		$(SWEEP1); \
+	done
+
+sweep1n: 
+	@for clients in 1 2 4 8 16 32 64; do \
+		$(SWEEP1_CONFIG) $(NETWORK) -noops 4; \
+		$(SWEEP1); \
+	done
+
+
+.PHONY: sweep2b sweep2n
+SWEEP2 = \
+	echo "makefile: Sleeping 10 seconds to allow peers to interlock"; \
+	sleep 10; \
+	set -e; \
+	./driver \
+		-clients $$clients \
+		-chaincodes 4 \
+		-arrays 128 \
+		-transactions $$((64 / $$clients)) \
+		-peerBurst 16 \
+		-netBurst 16 \
+		-interlock \
+		-keepLog \
+		-convergeWait 5m -convergePoll 5s \
+		-checkAgreement -dupCheck
+
+SWEEP2_CONFIG = \
+	CORE_PBFT_GENERAL_TIMEOUT_NULLREQUEST=3s \
+	CORE_PEER_VALIDATOR_CONSENSUS_BUFFERSIZE=32768
+
+sweep2b: 
+	@for clients in 1 2 4 8 16 32 64; do \
+		$(SWEEP2_CONFIG) $(NETWORK) -batch 4; \
+		$(SWEEP2); \
+	done
+
+sweep2n: 
+	@for clients in 1 2 4 8 16 32 64; do \
+		$(SWEEP2_CONFIG) $(NETWORK) -noops 4; \
+		$(SWEEP2); \
+	done
+
 
 ############################################################################
 # Miscellaneous
@@ -119,6 +194,11 @@ secure1:
 .PHONY: build
 build:
 	go build -a
+
+.PHONY: countersTest
+countersTest:
+	./countersTest
+
 
 # Load the user's private makefile, if it exists.
 

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -39,17 +39,20 @@ sweep1b sweep1n
     chaincode with one array. Sweep the number of clients from 1 to 64 by
     powers-of-2, sending a constant 32K transactions into the network
     targeting all peers in short bursts, each client interlocking every 64
-    transactions.  Consensus protocols are PBFT Batch (sweep1b) or NOOPS
+    transactions. Consensus protocols are PBFT Batch (sweep1b) or NOOPS
     (sweep1n).
 
 sweep2b sweep2n
+
+    *** Note: The 'sweep2b' target does not work at present. These targets ***
+    *** may be modified or removed in the future.                          ***
 
     A user-mode network of 4 validating peers running without security. Four
     chaincodes, each managing 128 arrays. The median array size here is 64
     counters or 512 bytes. Sweep the number of clients from 1 to 64 by
     powers-of-2, sending a constant 32K transactions into the network
     targeting all peers in moderate bursts, each client interlocking every 256
-    transactions.  Consensus protocols are PBFT Batch (sweep2b) or NOOPS
+    transactions. Consensus protocols are PBFT Batch (sweep2b) or NOOPS
     (sweep2n).
 
 

--- a/tools/busywork/counters/Makefile
+++ b/tools/busywork/counters/Makefile
@@ -138,7 +138,7 @@ SWEEP1 = \
 		-transactions $$((32768 / $$clients)) \
 		-peerBurst 8 \
 		-netBurst 8 \
-		-interlock \
+		-interlock -interlockTimeout 5m \
 		-keepLog \
 		-convergeWait 5m -convergePoll 5s \
 		-checkAgreement -dupCheck
@@ -172,7 +172,7 @@ SWEEP2 = \
 		-transactions $$((64 / $$clients)) \
 		-peerBurst 16 \
 		-netBurst 16 \
-		-interlock \
+		-interlock -interlockTimeout 5m \
 		-keepLog \
 		-convergeWait 5m -convergePoll 5s \
 		-checkAgreement -dupCheck

--- a/tools/busywork/counters/README.md
+++ b/tools/busywork/counters/README.md
@@ -58,17 +58,6 @@ values, interpreted as detailed for the individual keys below.
   interface. See the `-loggingLevel` option for details on the `<level>`
   argument. The default level for *shim* logging is WARNING.
   
-- `-checkCounters=<bool>` : The `<bool>` value defaults to `false`.  When
-   `false`, the chaincode does not check for consistency of the array state
-   before incrementing and decrementing. This setting is required in most
-   cases because if a peer "falls behind" the other peers it may get its state
-   by a state transfer, and not by actually executing transactions. The `true`
-   setting will likely only work (and *should* work) with NOOPS consensus.
-  
-- `-checkStatus=<bool>` : The `<bool>` value defaults to `true`. This is a
-  debugging flag only. See **counters.go**, `status()` function for the
-  semantics when this flag is set to `false`.
-  
 Examples:
 
     parms -id cc0 -loggingLevel debug
@@ -156,17 +145,15 @@ Examples:
 	status a b c  # Assume lengths 1, 2, 3 and counts 10, 20, 30
 	--> "1 1 10 10 2 2 20 20 3 3 30 30"
 
-It is an error to name an array that has not been created. This query *does
-not* signal an error if the expected and actual values do not match. As
-mentioned above with the `parms -checkCounters` option, if state transfer has
-taken place on a peer then the expected count (which records the number of
-transactions actually executed by the peer) will not match the actual count
-obtained from the state. There is no reason for the expected and actual array
-lengths not to match, however.
+It is an error to name an array that has not been created. 
 
-### `ping`
-
-This query always succeeds by returning the chaincode ID.
+The `<expectedLength>` is obtained from the database. This query *does not*
+signal an error if the expected and actual values do not match. The
+`<expectedCount>` and `<actualCount>` will currently always be equal, and
+correspond to the value held in the first element of the array. The
+implementation of state transfer does not allow the chaincode to independently
+track the expected counter value, so correctness checking of the count will
+need to be performed by the environment.
 
 ### `parms ?... <parm> ...?`
 
@@ -183,6 +170,11 @@ Examples:
 	
 The return value of this query is an empty string.
 	
+### `ping`
+
+This query always succeeds by returning the chaincode ID, as most recently set
+by the `parms` invocation or query.
+
 
   
   

--- a/tools/busywork/counters/counters.go
+++ b/tools/busywork/counters/counters.go
@@ -39,9 +39,9 @@ import (
 // architecture that support concurrency. For now it is handy to put it here;
 // in the future a different way of exposing the shim might be preferred.
 type counters struct {
-	logger      *shim.ChaincodeLogger // Our logger
-	id          string                // Chaincode ID
-	stub        *shim.ChaincodeStub	  // The stub
+	logger *shim.ChaincodeLogger // Our logger
+	id     string                // Chaincode ID
+	stub   *shim.ChaincodeStub   // The stub
 }
 
 // newCounters is a "constructor" for counters objects
@@ -121,7 +121,7 @@ func (c *counters) putUint64(name string, x uint64) {
 
 // getArray gets an array from the state and does a few basic consistency
 // checks.
-func (c *counters) getArray (name string) []uint64 {
+func (c *counters) getArray(name string) []uint64 {
 	b, err := c.stub.GetState(name)
 	if err != nil {
 		c.criticalf("getArray: GetState() for array '%s' failed: %s", name, err)

--- a/tools/busywork/counters/counters.go
+++ b/tools/busywork/counters/counters.go
@@ -33,21 +33,21 @@ import (
 )
 
 // counters implementation
+//
+// NB: It is not clear whether this usage of the stub, that is, storing the
+// stub in the counters object, will work in future versions of the
+// architecture that support concurrency. For now it is handy to put it here;
+// in the future a different way of exposing the shim might be preferred.
 type counters struct {
-	logger        *shim.ChaincodeLogger // Our logger
-	id            string                // Chaincode ID
-	length        map[string]uint64     // Array lengths
-	count         map[string]uint64     // Current array counts
-	checkCounters bool                  // Error-check counter arrays?
-	checkStatus   bool                  // Error-check the 'status' method?
+	logger      *shim.ChaincodeLogger // Our logger
+	id          string                // Chaincode ID
+	stub        *shim.ChaincodeStub	  // The stub
 }
 
 // newCounters is a "constructor" for counters objects
 func newCounters() *counters {
 	c := new(counters)
 	c.logger = shim.NewLogger("counters:<uninitialized>")
-	c.length = map[string]uint64{}
-	c.count = map[string]uint64{}
 	return c
 }
 
@@ -84,14 +84,83 @@ func (c *counters) assert(p bool, format string, args ...interface{}) {
 	}
 }
 
+// lengthKey computes the key used to store the array length
+func lengthKey(name string) string {
+	return "length" + "\x00" + name
+}
+
+// getUint64 is a generic GetState() for integers
+func (c *counters) getUint64(name string) uint64 {
+	b, err := c.stub.GetState(name)
+	if err != nil {
+		c.criticalf("getUint64: Error from getState(%s): %s", name, err)
+	}
+	if len(b) != 8 {
+		c.criticalf("getUint64: Reading '%s', expected 8 bytes but read %d", name, len(b))
+	}
+	var i uint64
+	err = binary.Read(bytes.NewReader(b), binary.LittleEndian, &i)
+	if err != nil {
+		c.criticalf("getUint64: Error converting bytes of '%s' to uint64: %s", name, err)
+	}
+	return i
+}
+
+// putUint64 is a generic PutState() for integers
+func (c *counters) putUint64(name string, x uint64) {
+	b := new(bytes.Buffer)
+	err := binary.Write(b, binary.LittleEndian, x)
+	if err != nil {
+		c.criticalf("putUint64: Error from binary.Write(): %s", err)
+	}
+	err = c.stub.PutState(name, b.Bytes())
+	if err != nil {
+		c.criticalf("putuint64: Error from PutState(%s): %s", name, err)
+	}
+}
+
+// getArray gets an array from the state and does a few basic consistency
+// checks.
+func (c *counters) getArray (name string) []uint64 {
+	b, err := c.stub.GetState(name)
+	if err != nil {
+		c.criticalf("getArray: GetState() for array '%s' failed: %s", name, err)
+	}
+	if len(b) == 0 {
+		c.criticalf("getArray: Array '%s' is empty", name)
+	}
+	if len(b)%8 != 0 {
+		c.criticalf("getArray: Array '%s' was retreived as %d bytes; Expected a multiple of 8", name, len(b))
+	}
+	array := make([]uint64, len(b)/8)
+	err = binary.Read(bytes.NewReader(b), binary.LittleEndian, &array)
+	if err != nil {
+		c.criticalf("getArray: Error converting array '%s' (length %d) to uint64: %s", name, len(b), err)
+	}
+	return array
+}
+
+// putArray puts an array back to the state
+func (c *counters) putArray(name string, array []uint64) {
+	b := new(bytes.Buffer)
+	err := binary.Write(b, binary.LittleEndian, array)
+	if err != nil {
+		c.criticalf("putArray: Error on binary.Write() for array '%s': %s", name, err)
+	}
+	err = c.stub.PutState(name, b.Bytes())
+	if err != nil {
+		c.criticalf("putArray: Error on PutState() for array '%s': %s", name, err)
+	}
+}
+
 // create (re-)creates one or more counter arrays and zeros their state.
-func (c *counters) create(stub *shim.ChaincodeStub, args []string) (val []byte, err error) {
+func (c *counters) create(args []string) (val []byte, err error) {
 
 	// There must always be an even number of argument strings, and the odd
 	// (length) strings must parse as non-0 unsigned 64-bit values.
 
 	if (len(args) % 2) != 0 {
-		c.errorf("create : Odd number of parameters; Must be pairs of ... <name> <length> ...")
+		c.errorf("create: Odd number of parameters; Must be pairs of ... <name> <length> ...")
 	}
 	name := false
 	var names []string
@@ -103,28 +172,28 @@ func (c *counters) create(stub *shim.ChaincodeStub, args []string) (val []byte, 
 		} else {
 			length, err := strconv.ParseUint(x, 0, 64)
 			if err != nil {
-				c.errorf("create : This - '%s' - does not parse as a 64-bit integer", x)
+				c.errorf("create: This - '%s' - does not parse as a 64-bit integer", x)
 			}
 			if length <= 0 {
-				c.errorf("create : Argument %d is negative or 0", n)
+				c.errorf("create: Argument %d is negative or 0", n)
 			}
-			c.debugf("create : Length = %d", length)
+			c.debugf("create: Length = %d", length)
 			lengths = append(lengths, length)
 		}
 	}
 
 	// Now create and store each array. Note that we create the arrays
-	// directly as byte arrays.
+	// directly as byte arrays. The length of each array is stored in the
+	// database.
 
 	for n, name := range names {
 		length := lengths[n]
 		a := make([]byte, length*8)
-		err := stub.PutState(name, a)
+		err := c.stub.PutState(name, a)
 		if err != nil {
-			c.criticalf("create : Error on PutState, %s[%d] : %s", name, length, err)
+			c.criticalf("create: Error on PutState, array '%s' with length %d: %s", name, length, err)
 		}
-		c.length[name] = length
-		c.count[name] = 0
+		c.putUint64(lengthKey(name), uint64(length))
 	}
 
 	return
@@ -132,99 +201,71 @@ func (c *counters) create(stub *shim.ChaincodeStub, args []string) (val []byte, 
 
 // incDec either increments or decrements 0 or more counter arrays. The choice
 // is made based on the value of 'incr'.
-func (c *counters) incDec(stub *shim.ChaincodeStub, args []string, incr int) (val []byte, err error) {
+func (c *counters) incDec(args []string, incr int) (val []byte, err error) {
 
 	c.assert((incr == 1) || (incr == -1), "The 'incr' parameter must be 1 or -1")
 
 	// Check each array for existence and record the number of times it will
-	// be incremented/decremented, checking for overflow/underflow along the
-	// way.
+	// be incremented/decremented. We assume that no-one will be able to
+	// process a command with >= 2^64 increments or decrements.
 
 	offset := map[string]uint64{}
 	var names []string
 	for _, name := range args {
-		if _, ok := c.length[name]; !ok {
-			c.errorf("incDec : Array '%s' does not exist", name)
-		}
 		if offset[name] == 0 {
 			names = append(names, name)
 		}
 		offset[name]++
-		if incr > 0 {
-			if offset[name] > (0xffffffffffffffff - c.count[name]) {
-				c.criticalf("incDec : Array '%s' would overflow", name)
-			}
-		} else {
-			if offset[name] > c.count[name] {
-				c.criticalf("incDec : Array '%s' would underflow", name)
-			}
-		}
 	}
 
-	// Bring the arrays into (our) memory, checking expected lengths.
+	// Bring the arrays into (our) memory.
 
 	arrays := map[string][]uint64{}
 	for _, name := range names {
-		b, err := stub.GetState(name)
-		if err != nil {
-			c.criticalf("incDec : GetState() for array '%s' failed : %s", name, err)
-		}
-		length := c.length[name]
-		if uint64(len(b)) != (length * 8) {
-			c.criticalf("incDec : Array '%s' was retreived as %d bytes; Expected %d", name, len(b), length*8)
-		}
-		array := make([]uint64, length)
-		arrays[name] = array
-
-		c.debugf("incDec : Array '%s' initial value : %v\n", name, array)
-		err = binary.Read(bytes.NewReader(b), binary.LittleEndian, &array)
-		c.debugf("incDec : Array '%s' after Read    : %v\n", name, array)
-
-		if err != nil {
-			c.criticalf("incDec : Error converting bytes to uint64 : %s", err)
-		}
+		arrays[name] = c.getArray(name)
 	}
 
-	// Increment/decrement, insuring that each array has the correct state in
-	// every location. The unsigned offsets are "signed" here.
+	// Increment/decrement, insuring that each array has consistent state in
+	// every location. The unsigned offsets are "signed" here. Underflow and
+	// overflow checks are performed on the first element here.
 
 	for _, name := range names {
-		count := c.count[name]
+
 		counters := arrays[name]
-		offset[name] = offset[name] * uint64(incr)
-		c.debugf("incDec : Array %s has count %d and offset %d", name, count, offset[name])
-		for i, v := range counters {
-			if c.checkCounters && (v != count) {
-				c.criticalf("incDec : Element %s[%d] has value %d; Expected %d", name, i, v, count)
+		finalOffset := offset[name] * uint64(incr)
+		expected := counters[0]
+
+		if incr < 0 {
+			if (expected + finalOffset) > expected {
+				c.criticalf("incDec: Underflow on array '%s'", name)
 			}
-			new := v + offset[name]
+		} else {
+			if (expected + finalOffset) < expected {
+				c.criticalf("incDec: Overflow on array '%s'", name)
+			}
+		}
+
+		for i, v := range counters {
+			if v != expected {
+				c.criticalf("incDec: Inconsistent state for element '%s[%d]', expecting %d, found %d", name, i, expected, v)
+			}
+			new := v + finalOffset
 			c.debugf("incDec : %s[%d] <- %d", name, i, new)
 			counters[i] = new
 		}
 	}
 
-	// Write the arrays back to the state. The new count values are only
-	// recorded once this operation is successful.
+	// Write the arrays back to the state.
 
 	for _, name := range names {
-		b := new(bytes.Buffer)
-		err := binary.Write(b, binary.LittleEndian, arrays[name])
-		if err != nil {
-			c.criticalf("incDec : Error on binary.Write() : %s", err)
-		}
-		c.debugf("incDec : Putting array '%s' bytes : %v", name, b.Bytes())
-		err = stub.PutState(name, b.Bytes())
-		if err != nil {
-			c.criticalf("incDec : Error on PutState() for array '%s' : %s", name, err)
-		}
-		c.count[name] += offset[name]
+		c.putArray(name, arrays[name])
 	}
 
 	return
 }
 
 // initParms handles the initialization of `parms`.
-func (c *counters) initParms(stub *shim.ChaincodeStub, args []string) (val []byte, err error) {
+func (c *counters) initParms(args []string) (val []byte, err error) {
 
 	c.infof("initParms : Command-line arguments : %v", args)
 
@@ -233,15 +274,14 @@ func (c *counters) initParms(stub *shim.ChaincodeStub, args []string) (val []byt
 	flags.StringVar(&c.id, "id", "", "A unique identifier; Allows multiple copies of this chaincode to be deployed")
 	loggingLevel := flags.String("loggingLevel", "default", "The logging level of the chaincode logger. Defaults to INFO.")
 	shimLoggingLevel := flags.String("shimLoggingLevel", "default", "The logging level of the chaincode 'shim' interface. Defaults to WARNING.")
-	flags.BoolVar(&c.checkCounters, "checkCounters", false, "Default false. If true, consistency checks are made on counter states during increment/decrement.")
-	flags.BoolVar(&c.checkStatus, "checkStatus", true, "Default true; If false, no error/consistency checks are made in the 'status' method.")
 	err = flags.Parse(args)
 	if err != nil {
 		c.errorf("initParms : Error during option processing : %s", err)
 	}
 
-	// Replace the original logger logging as "counters", with a new logger,
-	// then set its logging level and the logging level of the shim.
+	// Replace the original logger, logging as "counters", with a new logger
+	// logging as "counters:<id>", then set its logging level and the logging
+	// level of the shim.
 	c.logger = shim.NewLogger("counters:" + c.id)
 	if *loggingLevel == "default" {
 		c.logger.SetLevel(shim.LogInfo)
@@ -257,7 +297,7 @@ func (c *counters) initParms(stub *shim.ChaincodeStub, args []string) (val []byt
 }
 
 // queryParms handles the `parms` query
-func (c *counters) queryParms(stub *shim.ChaincodeStub, args []string) (val []byte, err error) {
+func (c *counters) queryParms(args []string) (val []byte, err error) {
 	flags := flag.NewFlagSet("queryParms", flag.ContinueOnError)
 	flags.StringVar(&c.id, "id", "", "Uniquely identify a chaincode instance")
 	err = flags.Parse(args)
@@ -267,35 +307,14 @@ func (c *counters) queryParms(stub *shim.ChaincodeStub, args []string) (val []by
 	return
 }
 
-// status implements the `status` query. If the -checkStatus flag was passed
-// as false, then we do not check for the array having been created, and we
-// assume that the length and count obtained from the state are correct. This
-// is a debug-only setting.
-func (c *counters) status(stub *shim.ChaincodeStub, args []string) (val []byte, err error) {
-
-	c.debugf("status : Entry : checkStatus = %v", c.checkStatus)
+// status implements the `status` query.
+func (c *counters) status(args []string) (val []byte, err error) {
 
 	// Run down the list of arrays, pulling their state into our memory
 
 	arrays := map[string][]uint64{}
 	for _, name := range args {
-		if c.checkStatus {
-			if _, ok := c.length[name]; !ok {
-				c.errorf("status : Array '%s' has never been created", name)
-			}
-		}
-		b, err := stub.GetState(name)
-		if err != nil {
-			c.criticalf("status : GetState() for array '%s' failed : %s", name, err)
-		}
-		length := len(b) / 8
-		array := make([]uint64, length)
-		arrays[name] = array
-		err = binary.Read(bytes.NewReader(b), binary.LittleEndian, &array)
-		if err != nil {
-			c.criticalf("status : Error converting %d bytes of array %s to uint64 : %s", len(b), name, err)
-		}
-		c.debugf("status : Array %s[%d] (%d bytes)", name, length, len(b))
+		arrays[name] = c.getArray(name)
 	}
 
 	// Now create the result
@@ -305,29 +324,24 @@ func (c *counters) status(stub *shim.ChaincodeStub, args []string) (val []byte, 
 		if res != "" {
 			res += " "
 		}
+		expectedLength := c.getUint64(lengthKey(name))
 		actualLength := uint64(len(arrays[name]))
 		actualCount := arrays[name][0]
-		var expectedLength, expectedCount uint64
-		if c.checkStatus {
-			expectedLength = c.length[name]
-			expectedCount = c.count[name]
-		} else {
-			expectedLength = actualLength
-			expectedCount = actualCount
-		}
+		expectedCount := actualCount
 		res += fmt.Sprintf("%d %d %d %d", expectedLength, actualLength, expectedCount, actualCount)
 	}
-	c.debugf("status : Final status : %s", res)
+	c.debugf("status: Final status: %s", res)
 	return []byte(res), nil
 }
 
 // Init handles chaincode initialization. Only the 'parms' function is
 // recognized here.
 func (c *counters) Init(stub *shim.ChaincodeStub, function string, args []string) (val []byte, err error) {
+	c.stub = stub
 	defer busy.Catch(&err)
 	switch function {
 	case "parms":
-		return c.initParms(stub, args)
+		return c.initParms(args)
 	default:
 		c.errorf("Init : Function '%s' is not recognized for INIT", function)
 	}
@@ -336,14 +350,15 @@ func (c *counters) Init(stub *shim.ChaincodeStub, function string, args []string
 
 // Invoke handles the `invoke` methods.
 func (c *counters) Invoke(stub *shim.ChaincodeStub, function string, args []string) (val []byte, err error) {
+	c.stub = stub
 	defer busy.Catch(&err)
 	switch function {
 	case "create":
-		return c.create(stub, args)
+		return c.create(args)
 	case "decrement":
-		return c.incDec(stub, args, -1)
+		return c.incDec(args, -1)
 	case "increment":
-		return c.incDec(stub, args, 1)
+		return c.incDec(args, 1)
 	default:
 		c.errorf("Invoke : Function '%s' is not recognized for INVOKE", function)
 	}
@@ -352,14 +367,15 @@ func (c *counters) Invoke(stub *shim.ChaincodeStub, function string, args []stri
 
 // Query handles the `query` methods.
 func (c *counters) Query(stub *shim.ChaincodeStub, function string, args []string) (val []byte, err error) {
+	c.stub = stub
 	defer busy.Catch(&err)
 	switch function {
 	case "parms":
-		return c.queryParms(stub, args)
+		return c.queryParms(args)
 	case "ping":
 		return []byte(c.id), nil
 	case "status":
-		return c.status(stub, args)
+		return c.status(args)
 	default:
 		c.errorf("Query : Function '%s' is not recognized for QUERY", function)
 	}

--- a/tools/busywork/counters/countersTest
+++ b/tools/busywork/counters/countersTest
@@ -1,0 +1,73 @@
+#!/usr/bin/tclsh
+
+# This is a simple, in-vivo sniff-test of the counters chaincode
+
+lappend auto_path [file dirname [info script]]/../tcl
+
+package require busywork
+
+setLoggingPrefix test
+setLoggingLevel {} note
+
+# Calls 'busy', returns contents of stdout
+proc busy {args} {
+    eval exec -ignorestderr [busywork::bin]/busy $args
+}
+
+# Calls 'busy' and prints contents of stdout
+proc busyOut {args} {
+    eval execout -ignorestderr [busywork::bin]/busy $args
+}
+
+
+note {} "Creating a 4-peer network"
+execout -ignorestderr [busywork::bin]/userModeNetwork -peerLogging debug 4
+
+note {} "Deploying 2 chaincodes with interlock"
+busyOut -waitFor 2m \
+    deploy vp0 cc0 github.com/hyperledger/fabric/tools/busywork/counters parms -id cc0
+busyOut -waitFor 2m \
+    deploy vp1 cc1 github.com/hyperledger/fabric/tools/busywork/counters parms -id cc1
+
+note {} "Creating arrays with interlock"
+busyOut -waitFor 1m invoke vp2 cc0 create a1 1 a2 2
+busyOut -waitFor 1m invoke vp3 cc1 create a1 1 a2 2
+
+note {} "Issuing increments and decrements with interlock"
+busyOut -waitFor 1m invoke vp0 cc0 increment a1 a2 a2
+busyOut -waitFor 1m invoke vp1 cc1 increment a1 a2 a2
+busyOut -waitFor 1m invoke vp2 cc0 decrement a2
+busyOut -waitFor 1m invoke vp3 cc1 decrement a2
+
+note {} "Checking status"
+set s0 [busy query vp0 cc0 status a1 a2]
+set s1 [busy query vp1 cc1 status a1 a2]
+
+if {$s0 ne "1 1 1 1 2 2 1 1"} {
+    error "Mismatch for s0: $s0"
+}
+
+if {$s1 ne "1 1 1 1 2 2 1 1"} {
+    error "Mismatch for s1: $s1"
+}
+
+note {} "Forcing underflow with interlock"
+busyOut -waitFor 1m invoke vp2 cc0 decrement a2
+busyOut -waitFor 1m invoke vp3 cc0 decrement a2
+
+# It's difficult to observe the errors. We can only observe that the value is
+# stuck at 0. Note we only underflowed cc0.
+
+note {} "Checking that underflow was disallowed"
+set s0 [busy query vp0 cc0 status a1 a2]
+set s1 [busy query vp1 cc1 status a1 a2]
+
+if {$s0 ne "1 1 1 1 2 2 0 0"} {
+    error "Mismatch for s0: $s0"
+}
+
+if {$s1 ne "1 1 1 1 2 2 1 1"} {
+    error "Mismatch for s1: $s1"
+}
+
+note {} A-OK

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -219,13 +219,16 @@ Optional parameters. Default values are given after the colon:
     completes within each timeout period. 
 
 -convergeWait <duration> : 10s
+-convergePoll <duration> : 1s
 
     If the run is in -interlock mode, then the run will not finish until at
     least one peer has recorded every transaction. However due to delays and
     state transfer, there may be lagging peers that have not finished yet. In
     this case we do "strong reads" of the block height of every node, and do
     not start checking until there is 100% consensus on the block
-    height. These checks must converge within the -convergeWait time.
+    height. These checks must converge within the -convergeWait time. The
+    network is polled (and the current status printed) every -convergePoll
+    interval. 
 
 -finalWait <duration> : 10s    
 
@@ -353,6 +356,7 @@ set options {
     {key     -interlockTimeout     parms(interlockTimeout)  60s}
     {key     {-interlockProgress -interlockAbsolute} parms(interlockProgress) 0}
     {key     -convergeWait         parms(convergeWait)      10s}
+    {key     -convergePoll         parms(convergePoll)      1s}
     {key     -finalWait            parms(finalWait)         10s}
     {bool    {-keepLog -noKeepLog} parms(keepLog)           0}
     {bool    {-force -noForce}     parms(force)             0}
@@ -945,9 +949,11 @@ if {$errors && ![parms force]} {
 
 # Finally, check the results for correctness. For the most accurate completed
 # transaction rates you need to -interlock, as it is likely that not all
-# invocations have been commited at this point if -interlock is not specified.
+# invocations have been commited at this point if -interlock is not
+# specified. We can't interlock NOOPS because the blockchains are not required
+# to be identical.
 
-if {[parms interlock]} {
+if {[parms interlock] && ![parms noops]} {
 
     # For interlocked runs, do "strong reads" of the block height until
     # consensus is reached.
@@ -963,8 +969,11 @@ if {[parms interlock]} {
         return [expr {[llength $heights] == 1}]
     }
     
-    note {} "Waiting up to [parms finalWait] for block-height consensus"
-    if {[waitFor [parms convergeWait] strongReadBlockHeight 1s]} {
+    note {} \
+        "Waiting up to [parms convergeWait] for block-height consensus, " \
+        "polling every [parms convergePoll]"
+    if {[waitFor \
+             [parms convergeWait] strongReadBlockHeight [parms convergePoll]]} {
         if {![parms force]} {
             set errors 1
             errorExit "Aborting due to block-height consensus timeout"

--- a/tools/busywork/counters/driver
+++ b/tools/busywork/counters/driver
@@ -314,6 +314,14 @@ Optional parameters. Default values are given after the colon:
 -timestamp | -noTimestamp : -noTimestamp
 
     If -timestamp is selected, the logs from this script will be timestamped.
+
+-traceInterlock : N/A
+
+    This is a debugging flag. If set, a timestamped trace of the interlock
+    operations of the clients is produced. Clients "interlock" after each
+    network burst if -interlock is selected, waiting until all transactions of
+    the burst are seen as having been committed to the blockchain.
+
 }
 
 ############################################################################
@@ -368,6 +376,7 @@ set options {
     {key     -retry                parms(retry)             0}
     {key     -args                 parms(args)              {}}
     {bool    {-timestamp -noTimestamp} parms(timestamp)     0}
+    {bool    -traceInterlock       parms(traceInterlock)    0}
 }
 
 mapKeywordArgs $argv $options parms(explicitPeers)
@@ -821,13 +830,14 @@ oo::class create LimitedRandomBag {
 proc clientRoutine {i_logger} {
 
     clearAtExitHandlers
-    setLoggingPrefix client[parms client]
+    setLoggingPrefix client[format %3d [parms client]]
 
     $i_logger reset
 
     set peerBag [RandomBag new [parms peers]]
     set keyBag [LimitedRandomBag new [parms arrayKeys] [parms transactions]]
     set uuids {}
+    set tx 0
 
     while {1} {
 
@@ -839,10 +849,22 @@ proc clientRoutine {i_logger} {
             lappend netBurst $peerBurst
         }
 
-        if {[parms interlock]} {
+        if {[parms interlock] && ![null $uuids]} {
+
+            if {[parms traceInterlock]} {
+                set nTx [llength $uuids]
+                set range "$tx - [expr {$tx + $nTx} - 1]"
+                note {} "[timestamp]: Start Interlock: $range"
+                incr tx $nTx
+            }
 
             set unmatched \
                 [$i_logger waitUUIDs invoke $uuids [parms interlockTimeout]]
+
+            if {[parms traceInterlock]} {
+                note {} "[timestamp]: End   Interlock: $range"
+            }
+
             if {$unmatched ne {}} {
                 err err "Interlock timed out; Aborting"
                 err err "Unmatched UUIDs below"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

This change set removes all\* vesitiges of "non-determinism" from the
`busywork/counters` chaincode. When @jyellick fixed a non-determinism bug here
a few days ago, I knew there were still other instances - but thought they
would be OK. I now realize that there are cases where peers never execute even
a single transaction, even when they are not under stress. So I'm throwing in
the towel, and I have effectively rewritten this chaincode, updated the
documentation and added a test program for the new verison. To be completely
honest, the data model manipulated by this chaincode is so simple that my
"non-determinism" for error checking never caught a single bug.

The PBFT Batch protocol is working well-enough now that the **busywork**
`stress2b` test can run in its originally intended form. I've restructured the
Makefile to show this, and I've also added a new `sweep1b` test that also
works. The bad news is that the more complex `sweep2b` test fails (see #2077).

I've also included a couple of minor bug fixes and enhancements to the
`busywork/counters/driver` that give the PBFT Batch runs every opportunity to
succeed.

*Depends on what's considered non-deterministic, but the chaincode no longer maintains an independent idea of what the state should be.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Completely Fixes #1857
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I added a new test for the new counters chaincode. I've also run the new make targets interactively and verified that they work.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
