### PR TITLE
Move wiki sections 'Proposals' and 'Release Notes' to docs directory of code repository

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,3 +115,18 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - Deploy Transaction
      - Execute Transaction
      - Chaincode Execution
+
+### Release Notes
+* [Fabric Releases](Fabric-Releases.md)
+* [Current API Changes](Sprint-Release-Notes.md)
+* [Release Process](Release-Process.md)
+
+### Proposals
+* [Fabric Next: Big Picture](Fabric-Next.md)
+* [Next Consensus Architecture Proposal](Next-Consensus-Architecture-Proposal.md)
+* [Next Ledger Architecture Proposal](Next-Ledger-Architecture-Proposal.md)
+* [Client SDK Specification](Client-SDK-Specification.md)
+* [Access Control Specification](Access-Control-Specification.md)
+* [Custom Events](Custom-Events-High-level-specification.md)
+* [System Chaincode](System-Chaincode-Specification.md)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,16 +117,16 @@ Overview docs; Reference docs; API and chaincode developer docs; Network operati
      - Chaincode Execution
 
 ### Release Notes
-* [Fabric Releases](Fabric-Releases.md)
-* [Current API Changes](Sprint-Release-Notes.md)
-* [Release Process](Release-Process.md)
+* [Fabric Releases](releasenotes/Fabric-Releases.md)
+* [Current API Changes](releasenotes/Sprint-Release-Notes.md)
+* [Release Process](releasenotes/Release-Process.md)
 
 ### Proposals
-* [Fabric Next: Big Picture](Fabric-Next.md)
-* [Next Consensus Architecture Proposal](Next-Consensus-Architecture-Proposal.md)
-* [Next Ledger Architecture Proposal](Next-Ledger-Architecture-Proposal.md)
-* [Client SDK Specification](Client-SDK-Specification.md)
-* [Access Control Specification](Access-Control-Specification.md)
-* [Custom Events](Custom-Events-High-level-specification.md)
-* [System Chaincode](System-Chaincode-Specification.md)
+* [Fabric Next: Big Picture](proposals/Fabric-Next.md)
+* [Next Consensus Architecture Proposal](proposals/Next-Consensus-Architecture-Proposal.md)
+* [Next Ledger Architecture Proposal](proposals/Next-Ledger-Architecture-Proposal.md)
+* [Client SDK Specification](proposals/Client-SDK-Specification.md)
+* [Access Control Specification](proposals/Access-Control-Specification.md)
+* [Custom Events](proposals/Custom-Events-High-level-specification.md)
+* [System Chaincode](proposals/System-Chaincode-Specification.md)
 

--- a/docs/proposals/Access-Control-Specification.md
+++ b/docs/proposals/Access-Control-Specification.md
@@ -1,0 +1,13 @@
+[Issue #961](https://github.com/hyperledger/fabric/issues/961)
+
+This section will document the design of the access control mechanisms for chaincode developers.
+
+The process will be driven by demonstrating a test driven approach using the following functional matrix as the outline of phases of RBAC/ABAC maturity.
+
+RBAC/ABAC Functionality | CC to CC invoke | Attr Based | Role based | TCert based | User Defined Membership Services | Doable with current master| Note | Link to behave feature |
+--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+access control based on TCerts (No attributes, not role based) |  |   |   | X | X | X | asset_mgt.go  |  |
+Role based access control using TCerts w/o using attributes    |  |   | X | X | X | X |  TBD, extension of asset_mgt.go |  |
+Attribute based access control using Tcerts with Attributes    |  | X | X |   |   |   |  extension of asset_mgt_with_roles.go |  |
+attribute access control with User Defined membership services |  |   |   |   | X |   |   |   |
+All of above | X | X | X | X | X |  |   |    |

--- a/docs/proposals/Client-SDK-Specification.md
+++ b/docs/proposals/Client-SDK-Specification.md
@@ -1,0 +1,22 @@
+[Issue #960](https://github.com/hyperledger/fabric/issues/960)
+
+The current implementation of these functions requires a non-validating peer (NVP), which provides transaction, event, and some implicit wallet management APIs. 
+![Current SDK](https://github.com/hyperledger/fabric/blob/master/docs/wiki-images/sdk-current.png)
+
+As shown above, the app calls NVP through REST API (eg invoke transaction). The request arrives at the `HTTP` service, which gRPCs to the `devops` service. The `devops` service constructs the transaction, signs it, and gRPCs it to VP (or NVP where it runs on).
+
+To address the above stories, which covers client API, thin client, transaction confidentiality, and wallet management, we may group these functions in an SDK providing native APIs for application to use on 1 side and gRPC to Endorsers (new name for validator without consensus) directly on the other side without having to go through NVP. The key motivation for this design is to reduce the latency going through REST and multiple gRPC hops. Since this model allows the application to use the SDK directly in the same process, it provides better security in managing user-certificate mapping with user-authentication.
+
+The SDK may be predicted as follow:
+![Future SDK](https://github.com/hyperledger/fabric/blob/master/docs/wiki-images/sdk-future.png)
+
+Basically this SDK rips out the capabilities from NVP and rolls them into library. Of course with additional work on the wallet management as specified below, but the capabilities on transaction and event handling should stay in tact. The native API layer provide Node.js and Java bindings through gRPC to the SDK library.
+
+The alternative model would be to implement the SDK natively in Node.js and Java and gRPC to the Endorsers. This would avoid an extra hop in gRPC, but the cost of reimplementing the NVP capabilities existing in Go is quite high, especially doing that in 2 languages. Another alternative would be to look into Go binding to Java and JavaScript, which would have to go through C and quite convoluted code.
+
+May 11/2016 update:
+------------------
+The alternative model described above is preferred and now being worked on.  Even though it is more work, it is better for the end user to have a pure language model.  The 1st SDK client being worked on is for node.js and can be found in the fabric/sdk/node directory.  There is a README.md with an overall description of the API.  The interactions with membership services is working, and the transaction path is currently being worked on.  This should be complete in a couple of weeks, so you can watch fabric/sdk/node for changes.
+
+Once this is complete, hopefully others can help with the client SDK for other languages, following the node.js SDK as a model.  The desire is that other languages look much like the node.js API, except where it makes sense to diverge for some language-specific reason.
+ 

--- a/docs/proposals/Custom-Events-High-level-specification.md
+++ b/docs/proposals/Custom-Events-High-level-specification.md
@@ -1,0 +1,101 @@
+
+@muralisrini and @pmullaney
+
+[issue 1129](https://github.com/hyperledger/fabric/issues/1129)
+
+## Introduction
+
+The events framework supports the ability to emit 2 types of audible events, block and custom/chaincode events (of type ChaincodeEvent defined in events.proto). The basic idea is that clients (event consumers) will register for event types (currently "block" or "chaincode") and in the case of chaincode they may specify additional registration criteria namely chaincodeID and eventname. ChaincodeID indentifies the specific chaincode deployment that the client has interest in seeing events from and eventname is a string that the chaincode developer embeds when invoking the chaincode stub's `SetEvent` API. Invoke transactions are currently the only operations that can emit events and each invoke is limited to one event emitted per transaction. It should be noted that there are no “transient” or “ephemeral” events that are not stored on the ledger. Thus, events are as deterministic as any other transactional data on the block chain. This basic infrastructure can be extended for successful
+
+## Tactical design – use TransactionResult to store events
+
+Add an Event message to TransactionResult
+
+```
+/ chaincodeEvent - any event emitted by a transaction
+type TransactionResult struct {
+	Uuid           string          
+	Result         []byte
+	ErrorCode      uint32
+	Error          string
+	ChaincodeEvent *ChaincodeEvent
+}
+```
+Where **ChaincodeEvent** is
+
+```
+type ChaincodeEvent struct {
+	ChaincodeID string 
+	TxID        string 
+	EventName   string 
+	Payload     []byte
+}
+```
+
+Where ChaincodeID is the uuid associated with the chaincode, TxID is the transaction that generated the event, EventName is the name given to the event by the chaincode(see `SetEvent`), and Payload is the payload attached to the event by the chaincode. The fabric does not impose a structure or restriction on the Payload although it is good practice to not make it large in size.
+
+SetEvent API on chaincode Shim
+
+```
+func (stub *ChaincodeStub) GetState(key string)
+func (stub *ChaincodeStub) PutState(key string, value [\]byte)
+func (stub *ChaincodeStub) DelState(key string)
+…
+…
+func (stub *ChaincodeStub) SetEvent(name string, payload []byte)
+…
+…
+```
+
+When the transaction is completed, SetEvent will result in the event being added to TransactionResult and commited to ledger. The event will then be posted to all clients registered for that event by the event framework.
+
+
+##General Event types and their relation to Chaincode Events
+
+
+Events are associated with event types. Clients register interest in the event types they want to receive events of.
+Life-cycle of an Event Type is illustrated by a “block” event
+
+	1. On boot-up peer adds "block" to the supported event types
+	2. Clients can register interest in “block” event type with a peer (or multiple peers)
+	3. On Block creation Peers post an event to all registered clients
+	4. Clients receive the “block” event and process the transactions in the block
+
+Chaincode events add an additional level of registration filtering. Instead of registering for all events of a given event type, chaincode events allow clients to register for a specific event from a specific chaincode. For this first version, for simplicity, we have not implemented wildcard or regex matching on the eventname but that is planned. More information on this in "Client Interface" below.
+
+## Client Interface
+
+The current interface for client to register and then receive events is a gRPC interface with pb messages defined in protos/events.proto. The Register message is a series (`repeated`) of Interest messages. Each Interest represents a single event registration.
+
+```
+message Interest {
+    EventType eventType = 1;
+    //Ideally we should just have the following oneof for different
+    //Reg types and get rid of EventType. But this is an API change
+    //Additional Reg types may add messages specific to their type
+    //to the oneof.
+    oneof RegInfo {
+        ChaincodeReg chaincodeRegInfo = 2;
+    }
+}
+
+//ChaincodeReg is used for registering chaincode Interests
+//when EventType is CHAINCODE
+message ChaincodeReg {
+    string chaincodeID = 1;
+    string eventName = 2;
+    ~~bool anyTransaction = 3;~~ //TO BE REMOVED
+}
+
+//Register is sent by consumers for registering events
+//string type - "register"
+message Register {
+    repeated Interest events = 1;
+}
+
+```
+
+As mentioned in previous section, clients should register for chaincode events using `ChaincodeReg` message where `chaincodeID` refers to the ID of chaincode as returned by the deploy transaction and `eventName` refers to the name of the event posted by the chaincode.  Setting `eventName` with empty string (or "*") will cause all events from a chaincode to be sent to the listener. 
+
+There is a service defined in events.proto with a single method that receives a stream of registration events and returns an stream that the client can use to read events from as they occur.
+

--- a/docs/proposals/Fabric-Next.md
+++ b/docs/proposals/Fabric-Next.md
@@ -1,0 +1,89 @@
+***Status: Draft (not ready for review; not yet prioritized)***
+
+This page contains a list of high-level items proposed for development of the next generation Fabric. It includes both existing feature enhancements and new features.
+
+#### 1. Introduction
+The key motivation for the next generation is modularization to achieve plug-ability and concurrency. As outlined in the [next consensus architecture](Next-Consensus-Architecture-Proposal) and the [next ledger structure](Next-Ledger-Architecture-Proposal), we want to enable different implementations to plug in at different points, including consensus, storage, and membership services. We can achieve concurrency at endorsers and consenters based on the transaction endorsement policy, which allows driving multiple channels of consensus as a service.
+
+##### 1.2. Deployment Scenarios
+The new architecture offers great flexibility in deployments. As the current generation, the simple 1 peer development environment, where a developer may quickly iterate over edit-compile-debug of the fabric code or a chaincode, is still intact. What change are the varieties of network deployment options, from a simple network of a few peers to a complex hundred of peers with different configurations possible.
+
+Conceptually a peer may perform all the functions (submitting, endorsing, ordering, and committing transactions); this is called full peer, or peer. A partial or light peer may perform a specific task like consensus (ordering transactions) or a combination of submitting, endorsing, and committing transactions. A member of a network generally owes a peer and/or some light peers. For high availability, a member may deploy multiple peers but 1 endorsement vote. Currently we have 2 types of peers: Validating peer (VP) and none-validating peer (NVP). We may roughly think of VP as a full peer and NVP as a light peer with submitting and committing tasks.
+
+##### 1.3. Network Deployment
+A simple network could be made up of several full peers, where each peer owed by a member with unique enrollment identity in a permissioned network. Building on this, a member may add more peers to increase availability and to support fail-over; however, these single-member peers must operate as a cluster with 1 vote on endorsement. A cluster of peers could be achieved by a shared ledger and a proxy to dispatch messages to the member peers, or a leader-followers pattern.
+
+##### 1.4. Consensus Service
+Consenters may independently operate to form a consensus network, isolating from the other peer functions (submitting, endorsing and committing transactions). This capability allows the members to set up a consensus network such that it can serve multiple blockchains, which only need to deploy light peers (without consenter enabled). The consensus network can be agnostic to the transactions enabling data isolation such that submitters may replace the transaction payload with its hash.
+
+#### 2. Detail Development Items
+The following items either come from the proposed next architecture or known enhancements to the existing functions that have been circulated as **issues**. Each item will be associated with 1 or more issues, but they are all here for the big picture.
+
+##### 2.1. Consensus
+1. Decouple consensus from peer: We've been always wanting to separate the consensus module into its own gRPC process with a simple peer interface to enable other implementation to easily plugin.
+
+1. Define consensus protocols
+1. Extracting PBFT
+1. Consensus channels: A blockchain network has 1 consensus channel by default that every peer listens on; this is called public channel. We can establish a separate channel per confidential domain where only permitted peers may subscribe to. Transactions sent to a channel will be ordered respective to each other within the channel, so a batch only contains transactions from the channel, not from any other channels.
+
+1. Dynamic membership: Allowing peers to come and go, and the blockchain network should continue to operate according to the consensus algorithm.
+
+1. Bound the number of incoming transactions
+  
+##### 2.2. Ledger
+1. Transaction rw-set: A submitter composes a transaction consisting of [header, payload, rw-set] where rw-set is the set containing the state variables that the transaction reads from (read-set) and the state variables that the transaction writes to (write-set). The rw-set is created via transaction execution simulation (not writing to database). This simulation is also done by the endorsers of the transaction to fulfill the endorsement policy of the transaction.
+
+1. Enhance API to enable pluggable datastore: Decouple the current API implementation from RocksDB to enable plugging in different datastore.
+
+1. File-based datastore: This is the default (reference) implementation, where blocks (transaction log) are stored in structured files as marshaled objects such that data replication is a matter of copying files.
+
+1. World state cache: For better performance, we need to cache the state to help submitters quickly build the rw-set.
+
+1. Ability to archive/prune "spent" transactions: To reduce the size of the ledger, peers may removed the transactions that are no longer needed (of course that transaction must have been archived) for operation. A transaction is not needed to be in the ledger when its write-set has been consumed. We don't think that it is necessary to remove the block structure since it is small and fixed, but we can retain the transaction ID in the block.
+
+1. SQL-like queries (point in time, filter): Many requests from developers to provide ability to query states or transactions with some filters.
+
+##### 2.3. Chaincode
+Currently we have 2 types of chaincodes: System and user chaincodes. System chaincode is built with the peer code and initialized during peer startup, whereas, user chaincode is built during deploy transaction and runs in a sandbox (default to Docker container).
+
+System chaincode concept allows us to reorganize the peer chaincode services into system chaincodes. For example, chaincode life-cycle (deploy, upgrade, terminate), chaincode naming, key management, etc can be implemented as system chaincodes since these are "trusted" operations which require access to the peer. 
+
+1. Life-cycle management [issue 1127](https://github.com/hyperledger/fabric/issues/1127): A chaincode begins life at deployment and ends at termination (out of service). Along this timeline, there might be several upgrades either to fix bugs or to amend functions. We have implemented deployment (via `Deploy` transaction) but have not done (completed) upgrade and terminate. Upgrading of a chaincode is not only involved code changes but also data (and potentially security) migration. We can implement chaincode life-cycle in a system chaincode, named "uber-chaincode", such that, to deploy a chaincode, we would send an `Invoke` transaction to the uber chaincode; similarly for upgrade and terminate. This means that, our transaction types now would only consist of `Invoke` and `Query`. And `Deploy` transaction is no longer needed.
+
+1. Naming service [issue 1077](https://github.com/hyperledger/fabric/issues/1077): Naming service is a system chaincode to map chaincode ID to a user-friendly name, allowing applications to use the name instead of the long ID to address a chaincode.
+ 
+1. Calling another chaincode with security: We currently have chaincode calling chaincode locally but without security. Security means both access control and transaction confidentiality, which means whether the callee is visible to the caller. Multiple confidential domains complicate the picture, so the first implementation should focus on chaincode calling chaincode within the same confidential domain. Calling a chaincode in the "public" domain should allow only queries since changes to a chaincode state requires a transaction visible to that chaincode's endorsers.
+
+1. Access control: The [TCert attributes](https://github.com/hyperledger/fabric/blob/master/docs/tech/attributes.md) provide a mechanism for the chaincode code to control whom may perform the function by matching the attributes with the intended permissions. For example, uber chaincode may control who can deploy chaincodes by adding access control logic to the `Deploy` function.
+
+##### 2.4. Membership Services
+1. TCert attributes: We continue the development of attributes as part of TCert, including backend API for external systems to inject attributes and encryption of the attribute values.
+1. Decentralization: Members of a network want ability to enroll their users.
+1. Key rotation: Ability to replace peer key as a system chaincode transaction. 
+1. HSM support: Ability to work with HSM to protect keys.
+1. Auditability: Provide auditing APIs
+
+##### 2.5. Protocol
+1. Enhance message structures: Remove unused or duplicated fields; add version number.
+1. Status codes and messages: Standardize the response message status codes and their messages.
+1. Error handling: Standardize the error messages and their handling such as when to bow out vs log and move on vs propagate up the chain.
+1. Extensions: How to extend the message protocol to allow the application to add more fields.
+
+##### 2.6. SDK
+1. Nodejs: Event handling, chaincode deployment API
+1. Java: Similar to Node.js SDK
+1. Go ? Any need for Golang SDK?
+
+##### 2.7. Transaction confidentiality
+1. Endorsers
+1. Users
+1. Event security
+
+##### 2.8. Upgrade Fabric
+We divide the fabric upgrade into 3 phases to gradually build up the capabilities.
+
+1. Bug fixes: This is applying patches to the peer code such that no backward compatibility needed. The thought here is that one may just replace the peer code with the new build, and it should resume.
+1. Protocol changes: This kind of updates requires backward compatibility.
+1. Ledger migration? We don't anticipate this kind of updates any time soon.
+
+##### 2.9. Integration (SoR)

--- a/docs/proposals/Next-Consensus-Architecture-Proposal.md
+++ b/docs/proposals/Next-Consensus-Architecture-Proposal.md
@@ -1,0 +1,444 @@
+Discuss and post comments [here](http://github.com/hyperledger/fabric/issues/1631).
+
+Authors: Christian Cachin, Konstantinos Christidis, Chet Murthy, Binh Nguyen and Marko Vukolić
+
+This page documents the architecture of a blockchain infrastructure with the roles of a blockchain node separated into roles of *peers* (who maintain state/ledger) and *consenters* (who consent on the order of transactions included in the blockchain state). In common blockchain architectures (including Hyperledger fabric as of June 2016) these roles are unified (cf. *validating peer* in Hyperledger fabric). The architecture also introduces *endorsing peers* (endorsers), as special type of peers responsible for *validating* (i.e., *endorsing*) transactions. 
+
+The architecture has the following advantages compared to the design in which peers/consenters/endorsers are unified.
+
+* **Chaincode trust flexibility.** The architecture separates *trust assumptions* for chaincodes (blockchain applications) from trust assumptions for consensus. In other words, the consensus  service may be provided by one set of nodes (consenters) and tolerate some of them to fail or misbehave, and the nodes responsible for executing and endorsing transactions of particular chaincode may be different for each chaincode.
+
+* **Scalability.** As the endorser nodes responsible for particular chaincode are orthogonal to the consenters, the system may *scale* better than if these functions were done by the same nodes. In particular, this results when different chaincodes specify disjoint endorsers, which introduces a partitioning of chaincodes between endorsers and allows parallel chaincode execution (endorsement). Besides, chaincode execution, which can potentially be costly, is removed from the critical path of the consensus service.
+
+* **Confidentiality.** The architecture also facilitates deployment chaincodes whose state is part of the blockchain state but that should remain *confidential* outside its endorsers.
+
+* **Consensus modularity.** The architecture is *modular* and allows pluggable consensus implementations.
+
+
+
+
+## Table of contents
+
+1. System architecture
+1. Basic workflow of transaction endorsement
+1. Endorsement policies
+1. Blockchain data structures
+1. State transfer and checkpointing
+1. Confidentiality (pending)
+
+---
+
+## 1. System architecture
+
+The blockchain is a distributed system consisting of many nodes that communicate with each other. The blockchain runs programs called chaincode, holds state and ledger data, and executes transactions.  The chaincode is the central element: transactions are operations invoked on the chaincode and only chaincode changes the state. Transactions have to be "validated" and only valid transactions are committed and have an effect on the state. There may exist a special chaincode for management functions and parameters, called *system chaincode*.
+
+
+### 1.1. Transactions 
+
+Transactions may be of two types:
+
+* *Deploy transactions* create new chaincode and take a program as parameter. When a deploy transaction executes successfully, the chaincode has been installed "on" the blockchain.
+
+* *Invoke transactions* perform an operation in the context of previously deployed chaincode. An invoke transaction refers to a chaincode and to one of its provided functions. When successful, the chaincode executes the specified function - which may involve modifying the corresponding state, and returning an output.    
+
+As described later, deploy transactions are special cases of invoke transactions, where a deploy transaction that creates new chaincode, corresponds to an invoke transaction on a system chaincode.   
+
+**Remark:** *This document currently assumes that a transaction either creates new chaincode or invokes an operation provided by _one_ already deployed chaincode. This document does not yet describe: a) support for cross-chaincode transactions, b) optimizations for query (read-only) transactions.*
+
+### 1.2. State 
+
+The state of the blockchain ("world state") has a simple structure and consists of a key/value store (KVS), where keys are names and values are arbitrary blobs. These entries are manipulated by the chaincodes (applications) running on the blockchain through `put`, `get`, `list`, `delete` and other KVS-operations. Keys in the KVS can be recognized from their name to belong to a particular chaincode. The state is stored persistently and updates to the state are logged.
+
+More formally, blockchain state `s` is modeled as an element of a mapping `K -> (V X N)`, where:
+
+* `K` is a set of keys
+* `V` is a set of values
+* `N` is an infinite ordered set of version numbers. Injective function `next: N -> N` takes an element of `N` and returns the next version number. 
+
+Both `V` and `N` contain a special element `\bot`, which is in case of `N` the lowest element. Initially all keys are mapped to `(\bot,\bot)`. For `s(k)=(v,ver)` we denote `v` by `s(k).value`, and `ver` by `s(k).version`.  
+
+KVS operations are modeled as follows:
+
+* `put(k,v)`, for `k\in K` and `v\in V`, takes the blockchain state `s` and changes it to `s'` such that `s'(k)=(v,next(s(k).version))` with `s'(k')=s(k')` for all `k'!=k`.   
+* `get(k)` returns `s(k)`.
+* `list()` returns the largest subset `K'` of `K` such that for every `k` in `K'`: `s(k).value!=\bot`.
+* `delete(k)` is equivalent to `put(k,\bot)`.
+
+Evolution of blockchain state (history) is kept in a *ledger*. Ledger is a hashchain of blocks of transactions. Transactions in the ledger are totally ordered. 
+
+Blockchain state and ledger are further detailed in Section 4.
+
+### 1.3. Nodes
+
+Nodes are the communication entities of the blockchain.  A "node" is only a logical function in the sense that multiple nodes of different types can run on the same physical server. What counts is how nodes are grouped in "trust domains" and associated to logical entities that control them.
+
+There are three types of nodes:
+
+1. **Client** or **submitting-client**: a thin client that submits an actual transaction-invocation.
+
+2. **Peer**: a node that commits transactions and maintains the state and a copy of the ledger. Besides, peers can have two  special roles:
+    
+    a. A **submitting peer** or **submitter**,
+
+    b. An **endorsing peer** or **endorser**. 
+
+
+3. **Consensus-service-node** or **consenter**: a node running the communication service that implements a delivery guarantee (such as atomic broadcast) typically by running consensus.
+
+Notice that consenters and clients do not maintain ledgers and blockchain state, only peers do. 
+
+The types of nodes are explained next in more detail.
+
+#### 1.3.1. Client
+
+The client represents the entity that acts on behalf of an end-user. It is stateless and must connect to a peer for communicating with the blockchain. The client may connect to any peer of its choice. Clients create and thereby invoke transactions. 
+
+#### 1.3.2. Peer
+
+A peer communicates with the consensus service and maintain the blockchain state and the ledger.  Such peers receive ordered state updates from the consensus service and apply them to the locally held state. 
+
+Peers can additionally take up one of two roles described next. 
+
+* **Submitting peer.** A *submitting peer* is a special role of a peer that provides an interface to clients, such that a client may connect to a submitting peer for invoking transactions and obtaining results.  The peer communicates with the other blockchain nodes on behalf of one or more clients for executing the transaction.
+
+
+*  **Endorsing peer.** The special function of an *endorsing peer* occurs with respect to a particular chaincode and consists in validating (i.e., *endorsing*) a transaction before it is committed. Every chaincode may specify an *endorsement policy* that may refer to a set of endorsing peers. The policy defines the necessary and sufficient conditions for a transaction to be valid (typically a set of endorsers' signatures), as described later in Sections 2 and 3. In the special case of deploy transactions that install new chaincode the (deployment) endorsement policy is specified as an endorsement policy of the system chaincode.
+
+To emphasize a peer that does not also have a role of a submitting peer or an endorsing peer, such a peer is sometimes referred to as a *committing peer*.
+
+
+#### 1.3.3. Consensus service nodes (Consenters)
+
+The *consenters* form the *consensus service*, i.e., a communication fabric that provides delivery guarantees. The consensus service can be implemented in different ways: ranging from a centralized service (used e.g., in development and testing) to distributed protocols that target different network and node fault models. 
+
+Peers are clients of the consensus service, to which the consensus service provides a shared *communication channel* offering a broadcast service for messages containing transactions.  Peers connect to the channel and may send and receive messages on the channel.  The channel supports *atomic* delivery of all messages, that is, message communication with total-order delivery and (implementation specific) reliability.  In other words, the channel outputs the same messages to all connected peers and outputs them to all peers in the same logical order.  This atomic communication guarantee is also called *total-order broadcast*, *atomic broadcast*, or *consensus* in the context of distributed systems.  The communicated messages are the candidate transactions for inclusion in the blockchain state.
+
+<!----
+**Remark (relaxed consistency guarantees).** In future revisions, relaxed ordering (consistency) notions weaker than total order but still relevant to blockchain could be applicable.*
+---->
+
+**Partitioning.** Consensus service may support multiple channels similar to the *topics* of a publish/subscribe (pub/sub) messaging system.  Clients can connects to a given channel and can then send messages and obtain the messages that arrive. Channels can be thought of as partitions - clients connecting to one channel are unaware of the existence of other channels, but clients may connect to multiple channels. For simplicity, in the rest of this document and unless explicitly mentioned otherwise, we assume consensus service consists of a single channel/topic. 
+
+
+**Consensus service API.** Peers connect to the channel provided by the consensus service, via the interface provided by the consensus service. The consensus service API  consists of two basic operations (more generally *asynchronous events*):
+
+* `broadcast(blob)`: the submitting peer calls this to broadcast an arbitrary message `blob` for dissemination over the channel. This is also called `request(blob)` in the BFT context, when sending a request to a service.
+
+* `deliver(seqno, prevhash, blob)`: the consensus service calls this on the peer to deliver the message `blob` with the specified sequence number (`seqno`) and hash of the most recently delivered blob (`prevhash`). In other words, it is an output event from the consensus service. `deliver()` is also sometimes called `notify()` in pub-sub systems or `commit()` in BFT systems.
+
+
+ Notice that consensus service clients (i.e., peers) interact with the service only through `broadcast()` and `deliver()` events.
+
+**Consensus properties.** The guarantees of the consensus service (or atomic-broadcast channel) are as follows.  They answer the following question:  *What happens to a broadcasted message and what relations exist among delivered messages?*
+    
+1. **Safety (ordering guarantee)**: As long as peers are connected for sufficiently long periods of time to the channel (they can disconnect or crash, but will restart and reconnect), they will see an *identical* series of delivered `(seqno, prevhash, blob)` messages.  This means the outputs (`deliver()` events) occur in the *same order* on all peers and according to sequence number and carry *identical content* (`blob` and `prevhash`) for the same sequence number. Note this is only a *logical order*, and a `deliver(seqno, prevhash, blob)` on one peer is not required to occur in any real-time relation to `deliver(seqno, prevhash, blob)` that outputs the same message at another peer. Put differently, given a particular `seqno`, *no* two correct peers deliver *different* `prevhash` or `blob` values. Moreover, every broadcasted blob is only delivered *once*, and no value `blob` is delivered unless some consensus client (peer) actually called `broadcast(blob)`.
+
+1. **Safety (hash chain integrity guarantee)**: The `deliver()` event contains the cryptographic hash of the previous `deliver()` event (`prevhash`). When the consensus service implements atomic broadcast guarantees, `prevhash` is the cryptographic hash of the parameters from the `deliver()` event with sequence number `seqno-1`. In other words, for two events `deliver(seqno-1, prevhash0, blob0)` and `deliver(seqno, prevhash, blob)`, `prevhash = HASH(seqno-1||prevhash0||blob0)`. 
+
+	 This establishes a hash chain across `deliver()` events, which is used to help verify the integrity of the consensus output, as discussed in Sections 4 and 5 later. In the special case of the first `deliver()` event, `prevhash` has a default value.
+      
+ 
+1. **Liveness (delivery guarantee)**: Liveness guarantees of the consensus service are specified by a consensus service implementation. The exact guarantees may depend on the network and node fault model. 
+
+	In principle, absent network faults and submitting peer faults, consensus service should guarantee that every correct peer that connects to the consensus service eventually delivers every submitted transaction. 
+
+
+
+## 2. Basic workflow of transaction endorsement
+
+In the following we outline the high-level request flow for a transaction. 
+
+**Remark:** *Notice that the following protocol **does not** assume that all transactions are deterministic, i.e., it allows for non-deterministic transactions.*
+
+### 2.1. The client creates a transaction and sends it to a submitting peer of its choice
+
+To invoke a transaction, the client sends the following message to a submitting peer `spID`. 
+
+`<SUBMIT,clientID,chaincodeID,txPayload,retryFlag,clientSig>`, where
+
+- `clientID` is the ID of the submitting client,
+- `chaincodeID` refers to the chaincode to which the transaction pertains,
+- `txPayload` is the payload containing the submitted transaction itself,
+- `retryFlag` is a boolean that tells the submitting peer whether to retry the submission of the transaction in case transaction fails,
+- `clientSig` is the client's signature on the tuple `(SUBMIT,clientID,chaincodeID,txPayload)`. 
+
+**TODO:** Decide whether to include explicitly local/logical time at the client (a timestamp).
+
+### 2.2. The submitting peer prepares a transaction and sends it to endorsers for obtaining an endorsement
+
+On reception of a `<SUBMIT,clientID,chaincodeID,txPayload,retryFlag,clientSig>` message from a client, the submitting peer first verifies the client's signature `clientSig` and then prepares a transaction. This involves submitting peer tentatively *executing* a transaction (`txPayload`), by invoking the chaincode to which the transaction refers (`chaincodeID`) and the copy of the state that the submitting peer locally holds.  
+
+As a result of the execution, the submitting peer computes a _state update_ (`stateUpdate`) and _version dependencies_ (`verDep`) - (*MVCC+postimage info* in DB language).
+
+Recall that the state consists of key/value (k/v) pairs.  All k/v entries are versioned, that is, every entry contains ordered version information, which is incremented every time when the value stored under a key is updated.  The peer that interprets the transaction records all k/v pairs accessed by the chaincode, either for reading or for writing, but the peer does not yet update its state.  More specifically:
+
+* `verDep` is a tuple `verDep=(readset,writeset)`. Given state `s` before a submitting peer executes a transaction:
+	*  for every key `k` read by the transaction, pair `(k,s(k).version)` is added to `readset`. 
+	*  for every key `k` modified by the transaction, pair `(k,s(k).version)` is added to `writeset`.
+*  additionally, for every key `k` modified by the transaction to the new value `v'`, pair `(k,v')` is added to `stateUpdate`. Alternatively, `v'` could be the delta of the new value to previous value (`s(k).value`).
+
+An implementation may combine `verDep.writeset` with `stateUpdate` into a single data structure. 
+
+Then, `tran-proposal := (spID,clientID,chaincodeID,txContentType,txContent,stateUpdate,verDep)`, 
+
+where `txContentType` defines what information pertaining to `txPayload` becomes part of `tran-proposal` as detailed below:
+
+| `txContentType` | `txContent` |
+| ------ | ----------- | 
+| `TRANSPARENT` | `txPayload` |
+|`OPAQUE`| `HASH(txPayload)` |
+|`COMMITMENT`| `Commitment(txPayload)` |
+|`NONE`| null | 
+
+Notice that the specification of function `Commitment()` is postponed to Section 6.
+
+Cryptographic hash of `tran-proposal` is used by all nodes as a unique transaction identifier `tid` (i.e., `tid=HASH(tran-proposal)`).
+
+The submitting peer then sends the transaction (i.e., `tran-proposal`) to the endorsers for the chaincode concerned.  The endorsing peers are selected according to the interpretation of the policy and the availability of peers, known by the peers. For example, the transaction could be sent to *all* endorsers of a given `chaincodeID`.  That said, some endorsers could be offline, others may object and choose not to endorse the transaction. The submitting peer tries to satisfy the policy expression with the endorsers available. 
+
+The submitting peer `spID` sends the transaction to an endorsing peer `epID` using the following message:
+
+`<PROPOSE,txPayload,tran-proposal,spSig>`
+
+where `spSig` is the signature of the submitting peer (with id `tran-proposal.spID`) on `(PROPOSE, tid)`. `txPayload` may be omitted from a `PROPOSE` message if `tran-proposal` contains `txPayload` (i.e., `tran-proposal.txContentType=TRANSPARENT`). 
+
+Finally, the submitting peer stores `tran-proposal` and `tid` in memory and waits for responses from endorsing peers.
+
+**Alternative design:** *As described here the submitting peer communicates directly with the endorsers.  This could also be a function performed by the consensus service; in this case it should be determined whether fabric has to follow atomic broadcast delivery guarantee for this or use simple peer-to-peer communication.  In that case the consensus service would also be responsible to collect the endorsements according to the policy and to return them to the submitting peer.*  
+
+**TODO:** Decide on communication between submitting peers and endorsing peers: peer-to-peer or using the consensus service.
+
+### 2.3. An endorser receives and endorses a transaction
+
+When a transaction in `tran-proposal` is delivered to a connected endorsing peer for the chaincode `tran-proposal.chaincodeID` by means of a `PROPOSE` message, the endorsing peer performs the following steps:
+
+* Endorser checks whether `txPayload` matches the corresponding hash contained within `tran-proposal` and if `spSig` verifies. If not, the endorser discards the `PROPOSE` message.  
+
+**TODO** Decide on the necessity of `spSig` verification above (in case there is authenticated point-to-point communication over TLS as in HL as of May 2016).
+
+* If the above check succeeds, the endorser simulates the transaction (using `txPayload`) and verifies that the state update and dependency information are correct. If everything is valid, the peer digitally signs the statement `(TRANSACTION-VALID, tid)` producing signature `epSig`. The endorsing peer then sends `<TRANSACTION-VALID, tid,epSig>` message to the submitting peer (`tran-proposal.spID`). 
+
+* Else, in case the transaction fails to validate, we distinguish the following cases:
+
+	a. if the endorser obtains different state updates than those in `tran-proposal.stateUpdates`, the peer signs a statement `(TRANSACTION-INVALID, tid, INCORRECT_STATE)` and sends the signed statement to the submitting peer.
+
+ 	b. if the endorser is aware of more advanced data versions than those referred to in `tran-proposal.verDeps`, it signs a statement `(TRANSACTION-INVALID, tid, STALE_VERSION)` and sends the signed statement to the submitting peer.
+
+ 	c. if the endorser does not want to endorse a transaction for any other reason (internal endorser policy, error in a transaction, etc.) it signs a statement `(TRANSACTION-INVALID, tid, REJECTED)` and sends the signed statement to the submitting peer.
+
+Notice that an endorser does not change its state in this step, the updates are not logged!
+
+**Alternative design:** *An endorsing peer may omit to inform the submitting peer about an invalid transaction altogether, without sending explicit `TRANSACTION-INVALID` notifications.*
+
+**Alternative design:** *The endorsing peer submits the `TRANSACTION-VALID`/`TRANSACTION-INVALID` statement and signature to the consensus service for delivery.*
+   
+**TODO:** Decide on alternative designs above. 
+
+### 2.4. The submitting peer collects an endorsement for a transaction and broadcasts it through consensus 
+
+The submitting peer waits until it receives enough messages and signatures on `(TRANSACTION-VALID, tid)` statements to conclude that the transaction proposal is valid.  This will depend on the chaincode endorsement policy (see also Section 3). If the endorsement policy is satisfied, the transaction has been *endorsed*; note that it is not yet committed. The collection of signatures from endorsing peers which establish that a transaction is valid is called an *endorsement*, the peer stores them in `endorsement`.
+
+If the submitting peer does not manage to collect an endorsement for a transaction proposal, it abandons this transaction and notifies the submitting client. If `retryFlag` has been originally set by the submitting client (see step 1 and the `SUBMIT` message) the submitting peer may (depending on submitting peer policies) retry the transaction (from step 2).
+  
+For transaction with a valid endorsement, we now start using the consensus-fabric. The submitting peer invokes consensus service using the `broadcast(blob)`, where `blob=(tran-proposal, endorsement)`.
+
+### 2.5. The consensus service delivers a transactions to the peers
+
+When an event `deliver(seqno, prevhash, blob)` occurs and a peer has applied all state updates for blobs with sequence number lower than `seqno`, a peer does the following:
+
+* It checks that the `blob.endorsement` is valid according to the policy of the chaincode (`blob.tran-proposal.chaincodeID`) to which it refers. (This step might be performed even without waiting for applying the state updates with sequence numbers smaller than `seqno`.)
+    
+* It verifies that the dependencies (`blob.tran-proposal.verDep`) have not been violated meanwhile.
+
+Verification of dependencies can be implemented in different ways, according to a consistency property or "isolation guarantee" that is chosen for the state updates. For example, **serializability** can be provided by requiring the version associated with each key in the `readset` or `writeset` to be equal to that key's version in the state, and rejecting transactions that do not satisfy this requirement. As another example, one can provide **snapshot isolation** when all keys in the `writeset` still have the same version as in the state as in the dependency data. The database literature contains many more isolation guarantees.
+
+**TODO:** Decide whether to insist on serializability or allow chaincode to specify isolation level.
+    
+* If all these checks pass, the transaction is valid and it is *committed*. This means that a peer appends the transaction to the ledger and subsequently applies `blob.tran-proposal.stateUpdates` to blockchain state.  Only committed transactions may change the state.
+
+* If any of these checks fail, the transaction is invalid and the peer drops the transaction.  It is important to note that invalid transactions are not committed, do not change the state, and are not recorded. 
+
+Additionally, the submitting peer notifies the client of a dropped transaction. If `retryFlag` has been originally set by the submitting client (see step 1 and the `SUBMIT` message) the submitting peer may (depending on submitting peer policies) retry the transaction (from step 2).
+
+![Illustration of the transaction flow (common-case path).](http://vukolic.com/hyperledger/flow-2.png)
+
+Figure 1. Illustration of the transaction flow (common-case path).
+
+---
+
+## 3. Endorsement policies
+
+### 3.1. Endorsement policy specification
+
+An **endorsement policy**, is a condition on what _endorses_ a transaction. An endorsement policy is specified by a `deploy` transaction that installs specific chaincode. A transaction is declared valid only if it has been endorsed according to the policy. An invoke transaction for a chaincode will first have to obtain an *endorsement* that satisfies the chaincode's policy or it will not be committed. This takes place through the interaction between the submitting peer and endorsing peers as explained in Section 2. 
+
+Formally the endorsement policy is a predicate on the transaction, endorsement, and potentially further state that evaluates to TRUE or FALSE. For deploy transactions the endorsement is obtained according to a system-wide policy (for example, from the system chaincode).
+
+Formally an endorsement policy is a predicate referring to certain variables. Potentially it may refer to:
+
+1. keys or identities relating to the chaincode (found in the metadata of the chaincode), for example, a set of endorsers;
+2. further metadata of the chaincode;
+3. elements of the transaction itself;
+4. and potentially more.
+
+The evaluation of an endorsement policy predicate must be deterministic.
+
+The list is ordered by increasing expressiveness and complexity, that is, it will be relatively simple to support policies that only refer to keys and identities of nodes.
+
+**TODO:** Decide on parameters of the endorsement policy. 
+
+The predicate may contain logical expressions and evaluates to TRUE or FALSE.  Typically the condition will use digital signatures on the transaction invocation issued by endorsing peers for the chaincode.
+
+Suppose the chaincode specifies the endorser set `E = {Alice, Bob, Charlie, Dave, Eve, Frank, George}`.  Some example policies:
+
+- A valid signature from all members of E.
+
+- A valid signature from any single member of E.
+
+- Valid signatures from endorsing peers according to the condition 
+  `(Alice OR Bob) AND (any two of: Charlie, Dave, Eve, Frank, George)`.
+
+- Valid signatures by any 5 out of the 7 endorsers. (More generally, for chaincode with `n > 3f` endorsers, valid signatures by any `2f+1` out of the `n` endorsers, or by any group of *more* than `(n+f)/2` endorsers.)
+
+- Suppose there is an assignment of "stake" or "weights" to the endorsers,
+  like `{Alice=49, Bob=15, Charlie=15, Dave=10, Eve=7, Frank=3, George=1}`,
+  where the total stake is 100: The policy requires valid signatures from a
+  set that has a majority of the stake (i.e., a group with combined stake
+  strictly more than 50), such as `{Alice, X}` with any `X` different from
+  George, or `{everyone together except Alice}`.  And so on.
+
+- The assignment of stake in the previous example condition could be static (fixed in the metadata of the chaincode) or dynamic (e.g., dependent on the state of the chaincode and be modified during the execution).
+
+How useful these policies are will depend on the application, on the desired resilience of the solution against failures or misbehavior of endorsers, and on various other properties.
+
+
+### 3.2. Implementation
+
+Typically, endorsement policies will be formulated in terms of signatures required from endorsing peers.  The metadata of the chaincode must contain the corresponding signature verification keys.
+
+An endorsement will typically consist of a set of signatures.  It can be evaluated locally by every peer or by every consenter node with access to the chaincode metadata (which includes these keys), such that this node does *not*  require interaction with another node.  Neither does a node need access to the state for verifying an endorsement.
+
+Endorsements that refer to other metadata of the chaincode can be evaluated in the same way.
+
+<!-----
+
+**DISCUSS**
+When an endorsement may refer to the current state associated with the chaincode, then it has to be specified whether an endorsement refers to the version of the state as seen by an endorser (when it issues a signature for endorsing the transaction) or whether the condition may refer to the state as seen by a consensus node (when it evaluates the conditional delivery guarantee described earlier) or by a peer that obtains a transaction delivered from the consensus service. 
+
+Endorsement policies must not be complex and cannot be "chaincode within a chaincode". The endorsement policy specification language must be limited and enforce determinism. 
+**DISCUSS**
+
+----->
+
+**TODO:** Formalize endorsement policies and design an implementation.
+
+
+
+---
+
+## 4. Blockchain data structures
+
+The blockchain consists of three data structures: a) *raw ledger*, b) *blockchain state* and c) *validated ledger*). Blockchain state and validated ledger are maintained for efficiency - they can be derived from the raw ledger. 
+
+* *Raw ledger (RL)*. The raw ledger contains all data output by the consensus service at peers. It is a sequence of `deliver(seqno, prevhash, blob)` events, which form a hash chain according to the computation of `prevhash` described before. The raw ledger contains information about both *valid* and *invalid* transactions and provides a verifiable history of all successful and unsuccessful state changes and attempts to change state, occurring during the operation of the system. 
+
+	The RL allows peers to replay the history of all transactions and to reconstruct the blockchain state (see below). It also provides submitting peer with information about *invalid* (uncommitted) transactions, on which submitting peers can act as described in Section 2.5.
+
+
+*  *(Blockchain) state*. The state is maintained by the peers (in the form of a KVS) and is derived from the raw ledger by **filtering out invalid transactions** as described in Section 2.5 (Step 5 in Figure 1) and applying valid transactions to state (by executing `put(k,v)` for every `(k,v)` pair in `stateUpdate` or, alternatively, applying state deltas with respect to previous state).
+
+	Namely, by the guarantees of consensus, all correct peers will receive an identical sequence of `deliver(seqno, prevhash, blob)` events. As the evaluation of the endorsement policy and evaluation of version dependencies of a state update (Section 2.5) are deterministic, all correct peers will also come to the same conclusion whether a transaction contained in a blob is valid.  Hence, all peers commit and apply the same sequence of transactions and update their state in the same way. 
+
+* *Validated ledger (VL)*. To maintain the abstraction of a ledger that contains only valid and committed transactions (that appears in Bitcoin, for example), peers may, in addition to state and raw ledger, maintain the *validated ledger*. This is a hash chain derived from the raw ledger by filtering out invalid transactions. 
+
+
+###4.1. Batch and block formation
+
+Instead of outputting individual transactions (blobs), the consensus service may output *batches* of blobs. In this case, the consensus service must impose and convey a deterministic ordering of the blobs within each batch. The number of blobs in a batch may be chosen dynamically by a consensus implementation. 
+
+Consensus batching does not impact the construction of the raw ledger, which remains a hash chain of blobs. But with batching, the raw ledger becomes a hash chain of batches rather than hash chain of individual blobs. 
+
+With batching, the construction of the (optional) validated ledger *blocks* proceeds as follows. As the batches in the raw ledger may contain invalid transactions (i.e., transactions with invalid endorsement or with invalid version dependencies), such transactions are filtered out by peers before a transaction in a batch becomes committed in a block. Every peer does this by itself. A block is defined as a consensus batch without the invalid transactions, that have been filtered out. Such blocks are inherently dynamic in size and may be empty. An illustration of block construction is given in the figure below.
+     ![Illustration of the transaction flow (common-case path).](http://vukolic.com/hyperledger/blocks-2.png)
+
+Figure 2. Illustration of validated ledger block formation from raw ledger batches.
+	
+
+###4.2. Chaining the blocks
+
+The batches of the raw ledger output by the consensus service form a hash chain, as described in Section 1.3.3.
+
+The blocks of the validated ledger are chained together to a hash chain by every peer. The valid and committed transactions from the batch form a block; all blocks are chained together to form a hash chain.
+
+More specifically, every block of a validated ledger contains:
+
+* The hash of the previous block.
+
+* Block number.
+
+* An ordered list of all valid transactions committed by the peers since the last block was computed (i.e., list of valid transactions in a corresponding batch).
+
+* The hash of the corresponding batch from which the current block is derived.
+
+All this information is concatenated and hashed by a peer, producing the hash of the block in the validated ledger.
+
+## 5. State transfer and checkpointing
+
+In the common case, during normal operation, a peer receives a sequence of `deliver()` events (containing batches of transactions) from the consensus service. It appends these batches to its raw ledger and updates the blockchain state and the validated ledger accordingly. 
+
+However, due to network partitions or temporary outages of peers, a peer may miss several batches in the raw ledger. In this case, a peer must *transfer state* of the raw ledger from other peers in order to catch up with the rest of the network. This section describes a way to implement this.
+
+###5.1. Raw ledger state transfer (batch transfer)
+
+To illustrate how basic *state transfer* works, assume that the last batch in a local copy of the raw ledger at a peer *p* has sequence number 25 (i.e., `seqno` of the last received `deliver()` event equals `25`). After some time peer *p* receives `deliver(seqno=54,hash53,blob)` event from the consensus service.  
+
+At this moment, peer *p* realizes that it misses batches 26-53 in its copy of the raw ledger. To obtain the missing batches, *p* resorts to peer-to-peer communication with other peers. It calls out and asks other peers for returning the missing batches. While it transfers the missing state, *p* continues listening to the consensus service for new batches. 
+
+Notice that *p* *does not need to trust any of its peers* from which it obtains the missing batches via state transfer. As *p* has the hash of the batch *53* (namely, *hash53*), which *p* trusts since it obtained that directly from the consensus service, *p* can verify the integrity of the missing batches, once all of them have arrived. The verification checks that they form a proper hash chain. 
+
+As soon as *p* has obtained all missing batches and has verified the missing batches 26-53, it can proceed to the steps of section 2.5 for each of the batches 26-54. From this *p* then constructs the blockchain state and the validated ledger. 
+
+Notice that *p* can start to speculatively reconstruct the blockchain state and the validated ledger as soon as it receives batches with lower sequence numbers, even if it still misses some batches with higher sequence numbers. However, before externalizing the state and committing blocks to the validated ledger, *p* must complete the state transfer of all missing batches (in our example, up to batch 53, inclusively) and processing of individual transferred batches as described in Section 2.5. 
+
+
+###5.2. Checkpointing
+
+The raw ledger contains invalid transactions, which may not necessarily be recorded forever. However, peers cannot simply discard raw-ledger batches and thereby prune the raw ledger once they establish the corresponding validated-ledger blocks. Namely, in this case, if a new peer joins the network, other peers could not transfer the discarded batches (in the raw ledger) to the joining peer, nor convince the joining peer of the validity of their blocks (of the validated ledger).
+
+To facilitate pruning of the raw ledger, this document describes a *checkpointing* mechanism. This mechanism establishes the validity of the validated-ledger blocks across the peer network and allows checkpointed validated-ledger blocks to replace the discarded raw-ledger batches. This, in turn, reduces storage space, as there is no need to store invalid transactions. It also reduces the work to reconstruct the state for new peers that join the network (as they do not need to establish validity of individual transactions when reconstructing the state from the raw ledger, but simply replay the state updates contained in the validated ledger). 
+
+Notice that checkpointing facilitates pruning of the raw ledger and, as such, it is only performance optimization. Checkpointing  is not necessary to make the design correct. 
+
+####5.2.1. Checkpointing protocol
+
+Checkpointing is performed periodically by the peers every *CHK* blocks, where *CHK* is a configurable parameter. To initiate a checkpoint, the peers broadcast (e.g., gossip) to other peers message `<CHECKPOINT,blocknohash,blockno,peerSig>`, where `blockno` is the current blocknumber and `blocknohash` is its respective hash, and `peerSig` is peer's signature on `(CHECKPOINT,blocknohash,blockno)`, referring to the validated ledger.
+
+A peer collects `CHECKPOINT` messages until it obtains enough correctly signed messages with matching `blockno` and `blocknohash` to establish a *valid checkpoint* (see Section 5.2.2.).
+
+Upon establishing a valid checkpoint for block number `blockno` with `blocknohash`, a peer:
+
+*  if `blockno>latestValidCheckpoint.blockno`, then a peer assigns `latestValidCheckpoint=(blocknohash,blockno)`, 
+* stores the set of respective peer signatures that constitute a valid checkpoint into the set `latestValidCheckpointProof`.
+* (optionally) prunes its raw ledger up to batch number `blockno` (inclusive).  
+
+####5.2.2. Valid checkpoints
+
+Clearly, the checkpointing protocol raises the following questions: *When can a peer prune its Raw Ledger? How many `CHECKPOINT` messages are "sufficiently many"?*. This is defined by a *checkpoint validity policy*, with (at least) two possible approaches, which may also be combined:
+
+* *Local (peer-specific) checkpoint validity policy (LCVP).* A local policy at a given peer *p* may specify a set of peers which peer *p* trusts and whose `CHECKPOINT` messages are sufficient to establish a valid checkpoint. For example, LCVP at peer *Alice* may define that *Alice* needs to receive `CHECKPOINT` message from Bob, or from *both* *Charlie* and *Dave*.
+
+* *Global checkpoint validity policy (GCVP).* A checkpoint validity policy may be specified globally. This is similar to a local peer policy, except that it is stipulated at the system (blockchain) granularity, rather than peer granularity. For instance, GCVP may specify that:
+	* each peer may trust a checkpoint if confirmed by *7* different peers. 
+	* in a deployment where every consenter is also a peer and where up to *f* consenters may be (Byzantine) faulty, each peer may trust a checkpoint if confirmed by *f+1* different consenters. 
+
+
+
+####5.2.3. Validated ledger state transfer (block transfer)
+
+Besides facilitating the pruning of the raw ledger, checkpoints enable state transfer through validated-ledger block transfers. These can partially replace raw-ledger batch transfers.
+
+Conceptually, the block transfer mechanism works similarly to batch transfer. Recall our example in which a peer *p* misses batches 26-53, and is transferring state from a peer *q* that has established a valid checkpoint at block 50. State transfer then proceeds in two steps:
+
+* First, *p* tries to obtain the validated ledger up to the checkpoint of peer *q* (at block 50). To this end, *q* sends to *p* its local (`latestValidCheckpoint,latestValidCheckpointProof`) pair. In our example `latestValidCheckpoint=(hash50,block50)`. If `latestValidCheckpointProof` satisfies the checkpoint validity policy at peer *p*, then the transfer of the blocks 26 to 50 is possible. Otherwise, peer *q* cannot convince *p* that its local checkpoint is valid. Peer *p* might then choose to proceed with raw-ledger batch transfer (Section 5.1). 
+    
+* If the transfer of blocks 26-50 was successful, peer *p* still needs to complete state transfer by fetching blocks 51-53 of the validated ledger or batches 51-53 of the raw ledger. To this end, *p* can simply follow the Raw-ledger batch transfer protocol (Section 5.1), transferring these from *q* or any other peer. Notice that the validated-ledger blocks contain hashes of respective raw-ledger batches (Section 4.2). Hence the batch transfer of the raw ledger can be done even if peer *p* does not have batch 50 in its Raw Ledger, as hash of batch 50 is included in block 50.

--- a/docs/proposals/Next-Ledger-Architecture-Proposal.md
+++ b/docs/proposals/Next-Ledger-Architecture-Proposal.md
@@ -1,0 +1,164 @@
+**Draft** / **Work in Progress**
+
+[Proposal Discussion](https://github.com/hyperledger/fabric/issues/1666)
+
+This page documents a proposal for a future ledger architecture based on community feedback. All input is welcome as the goal is to make this a community effort.
+
+##### Table of Contents  
+[Motivation](#motivation)  
+[API](#api)  
+[Point-in-Time Queries](#pointintime)  
+[Query Language](#querylanguage)
+
+<a name="motivation"/>
+## Motivation
+The motivation for exploring a new ledger architecture is based on community feedback. While the existing ledger is able to support some (but not all) of the below requirements, we wanted to explore what a new ledger would look like given all that has been learned. Based on many discussions in the community over Slack, GitHub, and the face to face hackathons, it is clear that there is a strong desire to support the following requirements:
+
+1. Point in time queries - The ability to query chaincode state at previous blocks and easily trace lineage **without** replaying transactions
+2. SQL like query language
+3. Privacy - The complete ledger may not reside on all committers
+4. Cryptographically secure ledger - Data integrity without consulting other nodes
+5. Support for consensus algorithms that provides immediate finality like PBFT
+6. Support consensus algorithms that require stochastic convergence like PoW, PoET
+7. Pruning - Ability to remove old transaction data as needed.
+8. Support separation of endorsement from consensus as described in the [Next Consensus Architecture Proposal](https://github.com/hyperledger/fabric/wiki/Next-Consensus-Architecture-Proposal). This implies that some peers may apply endorsed results to their ledger **without** executing transactions or viewing chaincode logic.
+9. API / Enginer separation. The ability to plug in different storage engines as needed.
+
+<a name="api"/>
+## API
+
+Proposed API in Go pseudocode
+
+```
+type TxSimulationRead struct {
+	ChaincodeID string
+	Key         string
+	Version     string // auto-incrementing number or previous TxId
+}
+
+type TxSimulationWrite struct {
+	Read     TxSimulationRead
+	NewValue []byte
+}
+
+type TxSimulationReadWriteSet struct {
+	ReadSet  []TxSimulationRead
+	WriteSet []TxSimulationWrite
+}
+
+type SimulatedTransaction struct {
+	// add TxSimulationReadWriteSet into payload
+	tx protos.Transaction
+}
+
+type RawBlock struct {
+	// blk contains
+	blk protos.Block
+}
+
+type BlockHeader struct {
+}
+
+type RangeScanIterator interface {
+
+	// Next moves to next key-value. Returns true if next key-value exists
+	Next() bool
+
+	// GetKeyValue returns next key-value
+	GetKeyValue() (string, []byte)
+
+	// Close releases resources occupied by the iterator
+	Close()
+}
+
+type TxSimulator interface {
+
+	// These return the most recent value for a given key
+	GetState(chaincodeID string, key string) ([]byte, error)
+	SetState(chaincodeID string, key string, value []byte)
+	GetStateRangeScanIterator(chaincodeID string, startKey string, endKey string) RangeScanIterator
+	DeleteState(chaincodeID string, key string)
+	GetStateMultipleKeys(chaincodeID string, keys []string) ([][]byte, error)
+	SetStateMultipleKeys(chaincodeID string, kvs map[string][]byte)
+	// This can be a large payload
+	CopyState(sourceChaincodeID string, destChaincodeID string) error
+	GetReadWriteSet() *TxSimulationReadWriteSet
+	HasConflicts() bool
+	Clear()
+
+	// Return transaction or value? Possibly need both?
+	ExecuteQuery(query string) []*protos.Transaction
+
+	// Returns latest transactions and previous transactions in order
+	GetTransactionsForKey(chaincodeID string, key string)  (<-chan *protos.Transaction, <-chan error, error)
+}
+
+type Ledger interface {
+
+	//NewTxSimulator is expected to be used by a transaction simulation module.
+	NewTxSimulator() (TxSimulator, error)
+
+	// Blockchain related functions
+	GetTopBlockHashes() []string // For consensus algorithms which support forking
+	GetBlockHeaders(startingBlockHash string, endingBlockHash string) []*BlockHeader // For consensus algorithms which support forking
+	GetBlocks(startingBlockHash string, endingBlockHash string) []*protos.Block // For consensus algorithms which support forking
+	SwitchTo(blockHash string) // For consensus algorithms which support forking
+	GetBlockByNumber(uint64) []*protos.Block
+
+	// State read functions to be used for read queries
+	// Returns the most recent value for a given key
+	GetState(chaincodeID string, key string) ([]byte, error)
+	GetStateRangeScanIterator(chaincodeID string, startKey string, endKey string) RangeScanIterator
+	GetStateMultipleKeys(chaincodeID string, keys []string) ([][]byte, error)
+
+	// Return transaction or value? Possibly need both?
+	ExecuteQuery(query string) []*protos.Transaction
+
+	// CommitRawBlock accepts a raw block from consensus
+	CommitRawBlock(rawBlock *RawBlock) error
+
+	// Functions used during state transfer
+	CommitBlock(block *protos.Block) error
+
+	// General functions related blockchain
+	GetBlockchainInfo() (*protos.BlockchainInfo, error)
+	GetBlockchainSize() uint64
+	VerifyChain(highBlock, lowBlock uint64) (uint64, error)
+
+	GetTransactionByID(txID string) (*protos.Transaction, error)
+
+	// Returns latest transactions and previous transactions in order
+	GetTransactionsForKey(chaincodeID string, key string)  (<-chan *protos.Transaction, <-chan error, error)
+
+	// This takes an interface to be defined by the engine
+	Prune({}interface) error
+
+
+}
+```
+
+# Engine specific thoughts
+
+<a name="pointintime"/>
+### Point-in-Time Queries
+In abstract temporal terms, there are three varieties of query important to chaincode and application developers:
+
+1. Retrieve the most recent value of a key. (type: current; ex. How much money is in Alice's account?)
+2. Retrieve the value of a key at a specific time. (type: historical; ex. What was Alice's account balance at the end of last month?)
+3. Retrieve all values of a key over time. (type: lineage; ex. Produce a statement listing all of Alice's transactions.)
+
+When formulating a query, a developer will benefit from the ability to filter, project, and relate transactions to one-another. Consider the following examples:
+
+1. Simple Filtering: Find all accounts that fell below a balance of $100 in the last month.
+2. Complex Filtering: Find all of Trudy's transactions that occurred in Iraq or Syria where the amount is above a threshold and the other party has a name that matches a regular expression.
+3. Relating: Determine if Alice has ever bought from the same gas station more than once in the same day. Feed this information into a fraud detection model.
+4. Projection: Retrieve the city, state, country, and amount of Alice's last ten transactions. This information will be fed into a risk/fraud detection model.
+
+<a name="querylanguage"/>
+### Query Language
+Developing a query language to support such a diverse range of queries will not be simple. The challenges are:
+
+1. Scaling the query language with developers as their needs grow. To date, the requests from developers have been modest. As the Hyperledger project's user base grows, so will the query complexity.
+2. There are two nearly disjoint classes of query:
+    1. Find a single value matching a set of constraints. Amenable to existing SQL and NoSQL grammars.
+    2. Find a chain or chains of transactions satisfying a set of constraints. Amenable to graph query languages, such as Neo4J's Cypher or SPARQL.

--- a/docs/proposals/System-Chaincode-Specification.md
+++ b/docs/proposals/System-Chaincode-Specification.md
@@ -1,0 +1,115 @@
+_See issues [938](https://github.com/hyperledger/fabric/issues/938) [1002](https://github.com/hyperledger/fabric/issues/1002)_
+
+System Chaincode
+================
+
+Introduction
+------------
+
+User written Chaincode runs in a container (called "user chaincode" in
+this doc) and communicates with the peer over the network. These
+chaincodes have restrictions with regards to what code they can execute.
+For example, they can only interact with the peer via \`ChaincodeStub\`
+interface such as GetState or PutState. There is a need for chaincode
+that have these restrictions relaxed. Such chaincode is broadly termed
+"System Chaincode".
+
+The purpose of system chaincode is to enable customization of certain
+behaviors of the fabric such as timer service or naming service.
+
+The simplest way to design a system chaincode is to run it in the same
+process as the Peer. This document goes into this design.
+
+In-process chaincode
+--------------------
+
+The approach is to consider the changes and generalizations needed to
+run chaincode in-process as the hosting peer.
+
+Requirements
+
+-   coexist with user chaincode
+-   adhere to same lifecycle as user chaincode - except for possibly
+    "deploy"
+-   easy to install
+
+The above requirements impose the following design principles
+
+-   design consistent with user chaincode
+-   uniform treatment of both types of chaincode in the codebase
+
+Though the impetus for the in-process chaincode design comes from
+"system chaincode", in principle the general "in process chaincode"
+design would allow any chaincode to be deployed.
+
+Key considerations for a chaincode environment
+----------------------------------------------
+
+There are two main considerations for any chaincode environment
+(container, in-process,etc)
+
+-   Runtime Considerations
+-   Lifecycle Considerations
+
+### Runtime Considerations
+
+Runtime considerations can be broadly classified into Transport and
+Execution mechanisms. The abstractions provided by the Fabric for these
+mechanisms are key to the ability to extend the system to support new
+chaincode runtimes consistent with existing ones in a fairly
+straightforward manner.
+
+### Transport mechanism
+
+Peer and chaincode communicate using ChaincodeMessages.
+
+-   the protocol is completely encapsulated via ChaincodeMessage
+-   current gRPC streaming maps nicely to Go Channels
+
+The above allow abstraction of a small section of code dealing with
+chaincode transport, leaving most of the code common to both
+environments. This is the key to the uniform treatment of runtime
+environments.
+
+### Execution mechanism
+
+The fabric provides a basic interface for a “vm”. The Docker container
+is implemented on top of this abstraction. The “vm” ([vm interface](https://github.com/hyperledger/fabric/blob/master/core/container/controller.go))
+can be used to provide an execution environment for the in-process
+runtime as well. This has the obvious benefit of encapsulating all
+execution access (deploy, launch, stop, etc) transparent to the
+implementation.
+
+Lifecycle Considerations
+------------------------
+
+| Life cycle             | Container model                                                  | In-process Model                                                                                                                                                      |
+|------------------------|------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Deploy                 | User deploys with an external request. Participates in consensus | Two possibilities +++  (1) comes up automatically with the peer, does not participate in consensus (2) user starts the chaincode with a request. Participates in consensus  |
+| Invoke/query           | User sends request                                               | User sends request                                                                                                                                                    |
+| Stop (not implemented) | User sends request                                               | User sends request                                                                                                                                                    |
+| Upgrade *** (not impemented)           |                                                                  |                                                                                                                                                                       |
++++ System chaincodes that are part of genesis block cannot/should not
+be part of consensus. E.g., bootstrapping requirements that would
+prevent them from taking part in consensus. That is not true for
+upgrading those chaincodes.
+
+So this may then be the model - “system chaincode that are in genesis
+block will not be deployed via consensus. All other chaincode deployment
+and all chaincode upgrades (including system chaincode) will be part of
+consensus.
+
+\*\*\*\* Upgrade is mentioned here just for completeness. It is an
+important part of life-cycle that should be a separate discussion unto
+itself involving devops considerations such as versioning, staging,
+staggering etc.
+
+Deploying System Chaincodes
+---------------------------
+
+System chaincodes come up with a system. System chaincodes will be
+defined in core.yaml. Minimally, a chaincode definition would contain
+the following information { Name, Path }. Each chaincode definition
+could also specify dependent chaincodes such that a chaincode will be
+brought up only if its dependent chaincodes are. The chaincodes would be
+brought up in the order specified in the list.

--- a/docs/releasenotes/Fabric-Releases.md
+++ b/docs/releasenotes/Fabric-Releases.md
@@ -1,0 +1,19 @@
+### Release [v0.5-developer-preview](https://github.com/hyperledger/fabric/tree/v0.5-developer-preview)
+June 17, 2016 This is a developer-preview release of the Hyperledger Fabric intended to exercise the release logistics and stabilize a set of capabilities for developers to try out. 
+
+##### Key Features
+1. Permissioned blockchain with immediate finality
+1. Chaincode (aka smart contract) execution environments
+   1. Docker container (user chaincode)
+   1. In-process with peer (system chaincode)
+1. Pluggable consensus with PBFT, NOOPS (development mode), SIEVE (prototype)
+1. Event framework supports pre-defined and custom events
+1. Client SDK (Node.js), basic REST APIs and CLIs
+
+##### Known Key Bugs and work in progress
+1. [#1895](https://github.com/hyperledger/fabric/issues/1895) Client SDK interfaces may crash if wrong parameter specified
+1. [#1901](https://github.com/hyperledger/fabric/issues/1901) Slow response after a few hours of stress testing
+1. [#1911](https://github.com/hyperledger/fabric/issues/1911) Missing peer event listener on the client SDK
+1. [889](https://github.com/hyperledger/fabric/issues/889)The attributes in the TCert are not encrypted. This work is still on-going
+
+

--- a/docs/releasenotes/Release-Process.md
+++ b/docs/releasenotes/Release-Process.md
@@ -1,0 +1,55 @@
+##### Procedure to cut a Fabric release:
+
+1. Create a release branch, and name it vM.m\[.p\]\[-qualifier\] where _M_ is the ```major``` release identifier, _m_ is ```minor``` release identifier, _p_ is the patch level identifier (only for LTS releases) and _-qualifier_ is from the taxonomy of release maturity labels \[TBD\].
+1. Tag the master branch with the same name as the release branch
+1. Publish release notes on [Fabric Releases](https://github.com/hyperledger/fabric/wiki/Fabric-Releases).
+1. Announce the release, linking to the release notes on Hyperledger ```fabric``` and ```general``` slack channels and ```hyperledger-fabric``` and ```hyperledger-announce``` mailing lists
+
+##### Perform if necessary:
+
+1. Select [issues](https://github.com/hyperledger/fabric/issues) to fix for the release branch and label them as such with a label with a value of the release identifier.
+1. Submit pull requests for those selected issues against the release branch.
+1. Decide on whether to merge the changes from the release branch to the master branch or requesting the authors to submit the changes on both branches. 
+1. Maintainers resolve any merge conflicts.
+
+
+___
+##### Release Taxonomy:
+
+##### Developer Preview:
+
+Not feature complete, but most functionality implemented, and any missing functionality that is committed for the production release is identified and there are specific people working on those features.  Not heavily performance tuned, but performance testing has started, and the first few hotspots identified, perhaps even addressed.  No "highest priority" issues in an unclosed state.  First-level developer documentation provided to help new developers up the learning curve.
+
+Naming convention: 0.x  where x is < 8 (Developer Preview is not used after it hits 1.0)
+
+##### Alpha:
+
+Feature complete, for all features committed to the production release.  Ready for Proof of Concept-level deployments.  Performance can be characterized in a predictable way, so that basic PoC's can be done without risk of embarrassing performance.  APIs documented.  First attempts at end-user documentation, developer docs further advanced.  No "highest priority" issues in an unclosed state.
+
+Naming convention: y.8.x, where y is 0, 1, 2 (basically the last production release) and x is the iteration of the alpha release.
+
+##### Beta:  
+
+Feature complete for all features committed to the production release, perhaps with optional features when safe to add.  Ready for Pilot-level engagements.  Performance is very well characterized and active optimizations are being done, with a target set for the Production release.  No "highest priority" or "high priority" bugs unclosed.  Dev docs complete; end-user docs mostly done. 
+
+Naming convention: y.9.x, where y is 0, 1, 2 (basically the last production release) and x is the iteration of the beta release.
+
+##### Production:
+
+An exact copy of the last iteration in the beta cycle, for a reasonable length of time (2 weeks?) during which no new highest or high priority bugs discovered, where end-user docs are considered complete, and performance/speed goals have been met.   Ready for Production-level engagements. 
+
+Naming convention: y.z.x, where y is the production release level (1, 2, 3, etc), z is the branch level (for minor improvements), and x is the iteration of the current branch.
+
+
+##### Example:
+
+Today's Fabric "Developer Preview" release is 0.5.  It could continue to 0.6, 0.7, 0.7.1.... 
+but when it's ready for Alpha, we call it 0.8, iterating to 0.8.1, 0.8.2, etc.  
+When it's ready for beta, 0.9, 0.9.1, 0.9.2, etc.  
+And when we are ready for production, 1.0.0. 
+A bugfix patch release or other small fixups, 1.0.1, 1.0.2, etc.  
+A branch would be called for when there is something small that changes behavior in some visible way: 1.1.0, 1.1.1, 1.2.0, 1.2.1, etc.
+And when it's time for a significant refactoring or rewrite or major new functionality, we go back into the cycle, but missing the "Developer Preview":
+1.8.0 is the alpha for 2.0
+1.9.0 is the beta for 2.0
+2.0.0 is the production release.

--- a/docs/releasenotes/Sprint-Release-Notes.md
+++ b/docs/releasenotes/Sprint-Release-Notes.md
@@ -1,0 +1,17 @@
+### Changes in the master branch effecting the external APIs or system behavior
+
+
+##### 4/07/2016 commit 33bc136 changed chaincode interface
+1. Deploy Transaction calls chaincode `Init` function
+2. Invoke Transaction calls chaincode `Invoke` function
+3. Query Transaction calls chaincode `Query` function
+Please see [examples](https://github.com/hyperledger/fabric/tree/master/examples/chaincode/go) for more detail
+
+
+##### 3/31/2016 POST /chaincode REST endpoint added
+
+The /chaincode endpoint was added to replace the original /devops/deploy, /devops/invoke, and /devops/query endpoints, which are now deprecated. Please see the documentation here for further explanation and examples.
+
+https://github.com/hyperledger/fabric/blob/master/docs/API/CoreAPI.md#chaincode
+
+


### PR DESCRIPTION
Move wiki sections 'Proposals' and 'Release Notes' to docs directory of code repository 
## Description

Move wiki sections 'Proposals' and 'Release Notes' to docs directory of code repository 
## Motivation and Context
1. Documentation should be versioned together with code
2. Enable PRs for proposals.

Fixes #
## How Has This Been Tested?

opened in browser
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Tamas Blummer tamas@digitalasset.com
