### PR TITLE
Only pull baseimage if a local one doesn't exist

### DIFF
--- a/scripts/provision/docker.sh
+++ b/scripts/provision/docker.sh
@@ -53,20 +53,26 @@ DOCKERHUB_NAME=$NAME:$RELEASE
 
 CURDIR=`dirname $0`
 
-echo "BUILD-CACHE: Pulling \"$DOCKERHUB_NAME\" from dockerhub.."
-docker pull $DOCKERHUB_NAME
 docker inspect $DOCKERHUB_NAME 2>&1 > /dev/null
 if [ "$?" == "0" ]; then
-    echo "BUILD-CACHE: Success!"
+    echo "BUILD-CACHE: exists!"
     BASENAME=$DOCKERHUB_NAME
 else
-    echo "BUILD-CACHE: WARNING - Build-cache unavailable, attempting local build"
-    (cd $CURDIR/../../images/base && make docker DOCKER_TAG=localbuild)
-    if [ "$?" != "0" ]; then
-        echo "ERROR: Build-cache could not be compiled locally"
-        exit -1
+    echo "BUILD-CACHE: Pulling \"$DOCKERHUB_NAME\" from dockerhub.."
+    docker pull $DOCKERHUB_NAME
+    docker inspect $DOCKERHUB_NAME 2>&1 > /dev/null
+    if [ "$?" == "0" ]; then
+	echo "BUILD-CACHE: Success!"
+	BASENAME=$DOCKERHUB_NAME
+    else
+	echo "BUILD-CACHE: WARNING - Build-cache unavailable, attempting local build"
+	(cd $CURDIR/../../images/base && make docker DOCKER_TAG=localbuild)
+	if [ "$?" != "0" ]; then
+            echo "ERROR: Build-cache could not be compiled locally"
+            exit -1
+	fi
+	BASENAME=$NAME:localbuild
     fi
-    BASENAME=$NAME:localbuild
 fi
 
 # Ensure that we have the baseimage we are expecting


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Modify scripts/provision/docker.sh such that it only pulls the baseimage from dockerhub when a local image with the same tag doesn't already exist.
## Motivation and Context

This is very useful for testing a local image.
## How Has This Been Tested?

I've run "make images" with and without a local image to make sure the script behaves as intended.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Gong Su gongsugongsu@gmail.com
