### PR TITLE
Fixes #1827 : Added new golang test cases for ECA Registrar feature

### DIFF
--- a/membersrvc/ca/eca_test.go
+++ b/membersrvc/ca/eca_test.go
@@ -35,12 +35,14 @@ import (
 )
 
 type User struct {
-	enrollID        string
-	enrollPwd       []byte
-	enrollPrivKey   *ecdsa.PrivateKey
-	role            int
-	affiliation     string
-	affiliationRole string
+	enrollID               string
+	enrollPwd              []byte
+	enrollPrivKey          *ecdsa.PrivateKey
+	role                   int
+	affiliation            string
+	affiliationRole        string
+	registrarRoles         []string
+	registrarDelegateRoles []string
 }
 
 var (
@@ -49,6 +51,14 @@ var (
 	testUser    = User{enrollID: "testUser", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
 	testUser2   = User{enrollID: "testUser2", role: 1, affiliation: "institution_a", affiliationRole: "00001"}
 	testAuditor = User{enrollID: "testAuditor", role: 8}
+	testClient1 = User{enrollID: "testClient1", role: 1, affiliation: "institution_a", affiliationRole: "00001",
+		registrarRoles: []string{"client"}, registrarDelegateRoles: []string{"client"}}
+	testClient2 = User{enrollID: "testClient2", role: 1, affiliation: "institution_a", affiliationRole: "00001",
+		registrarRoles: []string{"client"}}
+	testClient3 = User{enrollID: "testClient2", role: 1, affiliation: "institution_a", affiliationRole: "00001",
+		registrarRoles: []string{"client"}}
+	testPeer = User{enrollID: "testPeer", role: 2, affiliation: "institution_a", affiliationRole: "00001",
+		registrarRoles: []string{"peer"}}
 )
 
 //helper function for multiple tests
@@ -160,8 +170,12 @@ func registerUser(registrar User, user *User) error {
 		Role:        pb.Role(user.role),
 		Account:     user.affiliation,
 		Affiliation: user.affiliationRole,
-		Registrar:   &pb.Registrar{Id: &pb.Identity{Id: registrar.enrollID}},
-		Sig:         nil}
+		Registrar: &pb.Registrar{
+			Id:            &pb.Identity{Id: registrar.enrollID},
+			Roles:         user.registrarRoles,
+			DelegateRoles: user.registrarDelegateRoles,
+		},
+		Sig: nil}
 
 	//sign the req
 	hash := primitives.NewHash()
@@ -286,6 +300,70 @@ func TestRegisterUserNonRegistrar(t *testing.T) {
 	if err == nil {
 		t.Fatal("User without registrar metadata should not be able to register a new user")
 	}
+	t.Logf("Expected an error and indeed received: [%s]", err.Error())
+}
+
+//testAdmin should NOT be able to register testPeer since testAdmin's
+//delegateRoles field DOES NOT contain the value "peer"
+func TestRegisterUserPeer(t *testing.T) {
+
+	err := registerUser(testAdmin, &testPeer)
+
+	if err == nil {
+		t.Fatal("User without appropriate delegateRoles should not be able to register a new user")
+	}
+	t.Logf("Expected an error and indeed received: [%s]", err.Error())
+}
+
+//testAdmin should be able to register testClient1 since testAdmin's
+//delegateRoles field contains the value "client"
+func TestRegisterUserClient(t *testing.T) {
+
+	err := registerUser(testAdmin, &testClient1)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+//testClient1 registered in the previous test should be able to enroll
+func TestCreateCertificatePairClient(t *testing.T) {
+
+	err := enrollUser(&testClient1)
+
+	if err != nil {
+		t.Fatalf("Failed to enroll testClient1: [%s]", err.Error())
+	}
+}
+
+//testClient1 should be able to register testClient2 since testClient1's
+//delegateRoles field contains the value "client"
+func TestRegisterUserClientAsRegistrar(t *testing.T) {
+
+	err := registerUser(testClient1, &testClient2)
+
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+}
+
+//testClient2 should NOT be able to register testClient3 since testClient2's
+//delegateRoles field is empty
+func TestRegisterUserNoDelegateRoles(t *testing.T) {
+
+	err := enrollUser(&testClient2)
+
+	if err != nil {
+		t.Fatalf("Failed to enroll testClient2: [%s]", err.Error())
+	}
+
+	err = registerUser(testClient2, &testClient3)
+
+	if err == nil {
+		t.Fatal("User without delegateRoles should not be able to register a new user")
+	}
+
 	t.Logf("Expected an error and indeed received: [%s]", err.Error())
 }
 


### PR DESCRIPTION
This change adds new golang test cases for ECA Registrar features.   
## Description

Test cases have been created to check registration behavior with various combinations of roles and delegateRoles for users
## Motivation and Context

It increases code coverage tests for ECA registrar feature
Fixes #1827 
## How Has This Been Tested?

Changes have been tested by running "go test -v"
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Sudeepta Bhuyan sudeepta29@gmail.com
