### PR TITLE
add ability to unregister for events

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -307,9 +307,10 @@ func TestMain(m *testing.M) {
 	fmt.Printf("Starting events server\n")
 	go grpcServer.Serve(lis)
 
+	var regTimeout = 5
 	done := make(chan struct{})
 	adapter = &Adapter{notfy: done}
-	obcEHClient = consumer.NewEventsClient(peerAddress, adapter)
+	obcEHClient, _ = consumer.NewEventsClient(peerAddress, regTimeout, adapter)
 	if err = obcEHClient.Start(); err != nil {
 		fmt.Printf("could not start chat %s\n", err)
 		obcEHClient.Stop()

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -47,30 +47,35 @@ func (a *Adapter) GetInterestedEvents() ([]*ehpb.Interest, error) {
 	return []*ehpb.Interest{
 		&ehpb.Interest{EventType: ehpb.EventType_BLOCK},
 		&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: "event1"}}},
-		&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: ""}}},
+		&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: "event2"}}},
 	}, nil
 	//return []*ehpb.Interest{&ehpb.Interest{EventType: ehpb.EventType_BLOCK}}, nil
 }
-
-func (a *Adapter) Recv(msg *ehpb.Event) (bool, error) {
-	//fmt.Printf("Adapter received %+v\n", msg.Event)
-	switch x := msg.Event.(type) {
-	case *ehpb.Event_Block:
-	case *ehpb.Event_ChaincodeEvent:
-	case nil:
-		// The field is not set.
-		fmt.Printf("event not set\n")
-		return false, fmt.Errorf("event not set")
-	default:
-		fmt.Printf("unexpected type %T\n", x)
-		return false, fmt.Errorf("unexpected type %T", x)
-	}
+func (a *Adapter) updateCountNotify() {
 	a.Lock()
 	a.count--
 	if a.count <= 0 {
 		a.notfy <- struct{}{}
 	}
 	a.Unlock()
+}
+
+func (a *Adapter) Recv(msg *ehpb.Event) (bool, error) {
+	switch x := msg.Event.(type) {
+	case *ehpb.Event_Block:
+		a.updateCountNotify()
+	case *ehpb.Event_ChaincodeEvent:
+		a.updateCountNotify()
+	case *ehpb.Event_Register:
+		a.updateCountNotify()
+	case *ehpb.Event_Unregister:
+		a.updateCountNotify()
+	case nil:
+		// The field is not set.
+		return false, fmt.Errorf("event not set")
+	default:
+		return false, fmt.Errorf("unexpected type %T", x)
+	}
 	return true, nil
 }
 
@@ -107,17 +112,13 @@ func TestReceiveMessage(t *testing.T) {
 		t.Logf("Error sending message %s", err)
 	}
 
-	//receive 2 messages
-	for i := 0; i < 2; i++ {
-		select {
-		case <-adapter.notfy:
-		case <-time.After(5 * time.Second):
-			t.Fail()
-			t.Logf("timed out on messge")
-		}
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
 	}
 }
-
 func TestReceiveAnyMessage(t *testing.T) {
 	var err error
 
@@ -144,6 +145,42 @@ func TestReceiveAnyMessage(t *testing.T) {
 		}
 	}
 }
+func TestReceiveCCWildcard(t *testing.T) {
+	var err error
+
+	adapter.count = 1
+	obcEHClient.RegisterASync([]*ehpb.Interest{&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: ""}}}})
+
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
+	}
+
+	adapter.count = 1
+	emsg := createTestChaincodeEvent("0xffffffff", "wildcardevent")
+	if err = producer.Send(emsg); err != nil {
+		t.Fail()
+		t.Logf("Error sending message %s", err)
+	}
+
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
+	}
+	adapter.count = 1
+	obcEHClient.UnregisterASync([]*ehpb.Interest{&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: ""}}}})
+
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
+	}
+}
 
 func TestFailReceive(t *testing.T) {
 	var err error
@@ -161,6 +198,56 @@ func TestFailReceive(t *testing.T) {
 		t.Logf("should NOT have received event1")
 	case <-time.After(2 * time.Second):
 	}
+}
+
+func TestUnregister(t *testing.T) {
+	var err error
+	obcEHClient.RegisterASync([]*ehpb.Interest{&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: "event10"}}}})
+
+	adapter.count = 1
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
+	}
+
+	emsg := createTestChaincodeEvent("0xffffffff", "event10")
+	if err = producer.Send(emsg); err != nil {
+		t.Fail()
+		t.Logf("Error sending message %s", err)
+	}
+
+	adapter.count = 1
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("timed out on messge")
+	}
+	obcEHClient.UnregisterASync([]*ehpb.Interest{&ehpb.Interest{EventType: ehpb.EventType_CHAINCODE, RegInfo: &ehpb.Interest_ChaincodeRegInfo{ChaincodeRegInfo: &ehpb.ChaincodeReg{ChaincodeID: "0xffffffff", EventName: "event10"}}}})
+	adapter.count = 1
+	select {
+	case <-adapter.notfy:
+	case <-time.After(2 * time.Second):
+		t.Fail()
+		t.Logf("should have received unreg")
+	}
+
+	adapter.count = 1
+	emsg = createTestChaincodeEvent("0xffffffff", "event10")
+	if err = producer.Send(emsg); err != nil {
+		t.Fail()
+		t.Logf("Error sending message %s", err)
+	}
+
+	select {
+	case <-adapter.notfy:
+		t.Fail()
+		t.Logf("should NOT have received event1")
+	case <-time.After(5 * time.Second):
+	}
+
 }
 
 func BenchmarkMessages(b *testing.B) {

--- a/events/producer/events.go
+++ b/events/producer/events.go
@@ -34,7 +34,6 @@ import (
 //and the big lock should have no performance impact
 //
 type handlerList interface {
-	//find() *handler
 	add(ie *pb.Interest, h *handler) (bool, error)
 	del(ie *pb.Interest, h *handler) (bool, error)
 	foreach(ie *pb.Event, action func(h *handler))
@@ -42,13 +41,11 @@ type handlerList interface {
 
 type genericHandlerList struct {
 	sync.RWMutex
-	// this map used as a list - add/del/iterate
 	handlers map[*handler]bool
 }
 
 type chaincodeHandlerList struct {
 	sync.RWMutex
-	// this map used as a list - add/del/iterate
 	handlers map[string]map[string]map[*handler]bool
 }
 
@@ -113,7 +110,6 @@ func (hl *chaincodeHandlerList) del(ie *pb.Interest, h *handler) (bool, error) {
 		//the handler is not registered for the event type
 		return false, fmt.Errorf("handler not registered for event name %s for chaincode ID %s", ie.GetChaincodeRegInfo().EventName, ie.GetChaincodeRegInfo().ChaincodeID)
 	}
-
 	//remove the handler from the map
 	delete(handlerMap, h)
 
@@ -276,10 +272,11 @@ func AddEventType(eventType pb.EventType) error {
 }
 
 func registerHandler(ie *pb.Interest, h *handler) error {
-	producerLogger.Debugf("registerHandler %s", ie.EventType)
+	//producerLogger.Debugf("registerHandler %s", ie.EventType)
 
 	gEventProcessor.Lock()
 	defer gEventProcessor.Unlock()
+
 	if hl, ok := gEventProcessor.eventConsumers[ie.EventType]; !ok {
 		return fmt.Errorf("event type %s does not exist", ie.EventType)
 	} else if _, err := hl.add(ie, h); err != nil {
@@ -290,10 +287,11 @@ func registerHandler(ie *pb.Interest, h *handler) error {
 }
 
 func deRegisterHandler(ie *pb.Interest, h *handler) error {
-	producerLogger.Debugf("deRegisterHandler %s", ie.EventType)
+	//producerLogger.Debugf("deRegisterHandler %s", ie.EventType)
 
 	gEventProcessor.Lock()
 	defer gEventProcessor.Unlock()
+
 	if hl, ok := gEventProcessor.eventConsumers[ie.EventType]; !ok {
 		return fmt.Errorf("event type %s does not exist", ie.EventType)
 	} else if _, err := hl.del(ie, h); err != nil {

--- a/events/producer/events.go
+++ b/events/producer/events.go
@@ -272,7 +272,7 @@ func AddEventType(eventType pb.EventType) error {
 }
 
 func registerHandler(ie *pb.Interest, h *handler) error {
-	//producerLogger.Debugf("registerHandler %s", ie.EventType)
+	producerLogger.Debugf("registerHandler %s", ie.EventType)
 
 	gEventProcessor.Lock()
 	defer gEventProcessor.Unlock()
@@ -287,7 +287,7 @@ func registerHandler(ie *pb.Interest, h *handler) error {
 }
 
 func deRegisterHandler(ie *pb.Interest, h *handler) error {
-	//producerLogger.Debugf("deRegisterHandler %s", ie.EventType)
+	producerLogger.Debugf("deRegisterHandler %s", ie.EventType)
 
 	gEventProcessor.Lock()
 	defer gEventProcessor.Unlock()

--- a/events/producer/handler.go
+++ b/events/producer/handler.go
@@ -25,84 +25,84 @@ import (
 type handler struct {
 	ChatStream pb.Events_ChatServer
 	doneChan   chan bool
-	registered bool
 	// PM: this should be a list, add/del, iterate
-	interestedEvents []*pb.Interest
+	interestedEvents map[pb.Interest]*pb.Interest
 }
 
 func newEventHandler(stream pb.Events_ChatServer) (*handler, error) {
 	d := &handler{
 		ChatStream: stream,
 	}
+	d.interestedEvents = make(map[pb.Interest]*pb.Interest)
 	d.doneChan = make(chan bool)
 	return d, nil
 }
 
-func (d *handler) addInterest(interest *pb.Interest) {
-	n := len(d.interestedEvents)
-	if n == cap(d.interestedEvents) {
-		// Slice is full; must grow.
-		// We double its size and add 1, so if the size is zero we still grow.
-		newSlice := make([]*pb.Interest, len(d.interestedEvents), 2*len(d.interestedEvents)+1)
-		copy(newSlice, d.interestedEvents)
-		d.interestedEvents = newSlice
-	}
-	d.interestedEvents = d.interestedEvents[0 : n+1]
-	d.interestedEvents[n] = interest
-}
-
 // Stop stops this handler
 func (d *handler) Stop() error {
-	d.deregister()
+	d.deregisterAll()
+	d.interestedEvents = nil
 	d.doneChan <- true
-	d.registered = false
 	return nil
 }
 
 func (d *handler) register(iMsg []*pb.Interest) error {
-	//TODO add the handler to the map for the interested events
-	//if successfully done, continue....
+	// Could consider passing interest array to registerHandler
+	// and only lock once for entire array here
 	for _, v := range iMsg {
 		if err := registerHandler(v, d); err != nil {
 			producerLogger.Errorf("could not register %s", v)
 			continue
 		}
-		d.addInterest(v)
+		d.interestedEvents[*v] = v
 	}
 
 	return nil
 }
 
-func (d *handler) deregister() {
-	for _, v := range d.interestedEvents {
+func (d *handler) deregister(iMsg []*pb.Interest) error {
+	for _, v := range iMsg {
 		if err := deRegisterHandler(v, d); err != nil {
 			producerLogger.Errorf("could not deregister %s", v)
 			continue
 		}
-		v = nil
+		d.interestedEvents[*v] = nil
 	}
-	// PM the following should release slice and its elements for GC?
-	d.interestedEvents = nil
+	return nil
+}
+
+func (d *handler) deregisterAll() {
+	for k, v := range d.interestedEvents {
+		if err := deRegisterHandler(v, d); err != nil {
+			producerLogger.Errorf("could not deregister %s", v)
+			continue
+		}
+		d.interestedEvents[k] = nil
+	}
 }
 
 // HandleMessage handles the Openchain messages for the Peer.
 func (d *handler) HandleMessage(msg *pb.Event) error {
-	producerLogger.Debug("Handling Event")
-	eventsObj := msg.GetRegister()
-	if eventsObj == nil {
-		return fmt.Errorf("Invalid object from consumer %v", msg.GetEvent())
+	//producerLogger.Debug("Handling Event")
+	switch msg.Event.(type) {
+	case *pb.Event_Register:
+		eventsObj := msg.GetRegister()
+		if err := d.register(eventsObj.Events); err != nil {
+			return fmt.Errorf("Could not register events %s", err)
+		}
+	case *pb.Event_Unregister:
+		eventsObj := msg.GetUnregister()
+		if err := d.deregister(eventsObj.Events); err != nil {
+			return fmt.Errorf("Could not unregister events %s", err)
+		}
+	case nil:
+	default:
+		return fmt.Errorf("Invalide type from client %T", msg.Event)
 	}
-
-	if err := d.register(eventsObj.Events); err != nil {
-		return fmt.Errorf("Could not register events %s", err)
-	}
-
 	//TODO return supported events.. for now just return the received msg
 	if err := d.ChatStream.Send(msg); err != nil {
 		return fmt.Errorf("Error sending response to %v:  %s", msg, err)
 	}
-
-	d.registered = true
 
 	return nil
 }

--- a/events/producer/handler.go
+++ b/events/producer/handler.go
@@ -51,6 +51,8 @@ func getInterestKey(interest pb.Interest) string {
 	switch interest.EventType {
 	case pb.EventType_BLOCK:
 		key = "/" + strconv.Itoa(int(pb.EventType_BLOCK))
+	case pb.EventType_REJECTION:
+		key = "/" + strconv.Itoa(int(pb.EventType_REJECTION))
 	case pb.EventType_CHAINCODE:
 		key = "/" + strconv.Itoa(int(pb.EventType_CHAINCODE)) + "/" + interest.GetChaincodeRegInfo().ChaincodeID + "/" + interest.GetChaincodeRegInfo().EventName
 	default:

--- a/examples/events/block-listener/block-listener.go
+++ b/examples/events/block-listener/block-listener.go
@@ -65,7 +65,7 @@ func createEventClient(eventAddress string, listenToRejections bool) *adapter {
 	done := make(chan *pb.Event_Block)
 	reject := make(chan *pb.Event_Rejection)
 	adapter := &adapter{notfy: done, rejected: reject, listenToRejections: listenToRejections}
-	obcEHClient = consumer.NewEventsClient(eventAddress, adapter)
+	obcEHClient, _ = consumer.NewEventsClient(eventAddress, 5, adapter)
 	if err := obcEHClient.Start(); err != nil {
 		fmt.Printf("could not start chat %s\n", err)
 		obcEHClient.Stop()

--- a/protos/api.pb.go
+++ b/protos/api.pb.go
@@ -41,6 +41,7 @@ It has these top-level messages:
 	Interest
 	Register
 	Rejection
+	Unregister
 	Event
 	Transaction
 	TransactionBlock
@@ -52,6 +53,7 @@ It has these top-level messages:
 	PeerID
 	PeerEndpoint
 	PeersMessage
+	PeersAddresses
 	HelloMessage
 	Message
 	Response

--- a/protos/events.pb.go
+++ b/protos/events.pb.go
@@ -156,7 +156,7 @@ func (m *Register) GetEvents() []*Interest {
 // string type - "rejection"
 type Rejection struct {
 	Tx       *Transaction `protobuf:"bytes,1,opt,name=tx" json:"tx,omitempty"`
-	ErrorMsg string       `protobuf:"bytes,2,opt,name=ErrorMsg" json:"ErrorMsg,omitempty"`
+	ErrorMsg string       `protobuf:"bytes,2,opt,name=errorMsg" json:"errorMsg,omitempty"`
 }
 
 func (m *Rejection) Reset()         { *m = Rejection{} }
@@ -171,6 +171,21 @@ func (m *Rejection) GetTx() *Transaction {
 }
 
 // ---------- producer events ---------
+type Unregister struct {
+	Events []*Interest `protobuf:"bytes,1,rep,name=events" json:"events,omitempty"`
+}
+
+func (m *Unregister) Reset()         { *m = Unregister{} }
+func (m *Unregister) String() string { return proto.CompactTextString(m) }
+func (*Unregister) ProtoMessage()    {}
+
+func (m *Unregister) GetEvents() []*Interest {
+	if m != nil {
+		return m.Events
+	}
+	return nil
+}
+
 // Event is used by
 //  - consumers (adapters) to send Register
 //  - producer to advertise supported types and events
@@ -180,6 +195,7 @@ type Event struct {
 	//	*Event_Block
 	//	*Event_ChaincodeEvent
 	//	*Event_Rejection
+	//	*Event_Unregister
 	Event isEvent_Event `protobuf_oneof:"Event"`
 }
 
@@ -203,11 +219,15 @@ type Event_ChaincodeEvent struct {
 type Event_Rejection struct {
 	Rejection *Rejection `protobuf:"bytes,4,opt,name=rejection,oneof"`
 }
+type Event_Unregister struct {
+	Unregister *Unregister `protobuf:"bytes,5,opt,name=unregister,oneof"`
+}
 
 func (*Event_Register) isEvent_Event()       {}
 func (*Event_Block) isEvent_Event()          {}
 func (*Event_ChaincodeEvent) isEvent_Event() {}
 func (*Event_Rejection) isEvent_Event()      {}
+func (*Event_Unregister) isEvent_Event()     {}
 
 func (m *Event) GetEvent() isEvent_Event {
 	if m != nil {
@@ -244,6 +264,13 @@ func (m *Event) GetRejection() *Rejection {
 	return nil
 }
 
+func (m *Event) GetUnregister() *Unregister {
+	if x, ok := m.GetEvent().(*Event_Unregister); ok {
+		return x.Unregister
+	}
+	return nil
+}
+
 // XXX_OneofFuncs is for the internal use of the proto package.
 func (*Event) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), []interface{}) {
 	return _Event_OneofMarshaler, _Event_OneofUnmarshaler, []interface{}{
@@ -251,6 +278,7 @@ func (*Event) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, 
 		(*Event_Block)(nil),
 		(*Event_ChaincodeEvent)(nil),
 		(*Event_Rejection)(nil),
+		(*Event_Unregister)(nil),
 	}
 }
 
@@ -276,6 +304,11 @@ func _Event_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 	case *Event_Rejection:
 		b.EncodeVarint(4<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Rejection); err != nil {
+			return err
+		}
+	case *Event_Unregister:
+		b.EncodeVarint(5<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Unregister); err != nil {
 			return err
 		}
 	case nil:
@@ -319,6 +352,14 @@ func _Event_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) 
 		msg := new(Rejection)
 		err := b.DecodeMessage(msg)
 		m.Event = &Event_Rejection{msg}
+		return true, err
+	case 5: // Event.unregister
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(Unregister)
+		err := b.DecodeMessage(msg)
+		m.Event = &Event_Unregister{msg}
 		return true, err
 	default:
 		return false, nil

--- a/protos/events.proto
+++ b/protos/events.proto
@@ -64,6 +64,10 @@ message Rejection {
 }
 
 //---------- producer events ---------
+message Unregister {
+    repeated Interest events = 1;
+}
+
 //Event is used by
 //  - consumers (adapters) to send Register
 //  - producer to advertise supported types and events
@@ -71,13 +75,16 @@ message Event {
     //TODO need timestamp
 
     oneof Event {
-        //consumer events
+        //Register consumer sent event
         Register register = 1;
 
         //producer events
         Block block = 2;
         ChaincodeEvent chaincodeEvent = 3;
         Rejection rejection = 4;
+
+        //Unregister consumer sent events
+        Unregister unregister = 5;
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Added new unregister message and associated infrastructure to enable unregistering for single event interests
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

We need the ability for an application to signal that it no longer requires a particular event without closing the tcp connection.

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

This PR adds new test cases for unregistration.

<!-- Describe in detail how you tested your changes. -->

Via the new test cases and also ensured that the example event logging utility still worked.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Patrick Mullaney pm.mullaney@gmail.com
