### PR TITLE
core/rest: Fix delete enrollment with empty ID (for v0.5-developer-preview)

### DIFF
--- a/core/rest/rest_api.go
+++ b/core/rest/rest_api.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -182,6 +183,37 @@ func getRESTFilePath() string {
 	return localStore
 }
 
+// isEnrollmentIDValid returns true if the given enrollmentID matches the valid
+// pattern defined in the configuration.
+func isEnrollmentIDValid(enrollmentID string) (bool, error) {
+	pattern := viper.GetString("rest.validPatterns.enrollmentID")
+	if pattern == "" {
+		return false, errors.New("Missing configuration key rest.validPatterns.enrollmentID")
+	}
+	return regexp.MatchString(pattern, enrollmentID)
+}
+
+// validateEnrollmentIDParameter checks whether the given enrollmentID is
+// valid: if valid, returns true and does nothing; if not, writes the HTTP
+// error response and returns false.
+func validateEnrollmentIDParameter(rw web.ResponseWriter, enrollmentID string) bool {
+	validID, err := isEnrollmentIDValid(enrollmentID)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(rw).Encode(restResult{Error: err.Error()})
+		restLogger.Errorf("Error when validating enrollment ID: %s", err)
+		return false
+	}
+	if !validID {
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(restResult{Error: "Invalid enrollment ID parameter"})
+		restLogger.Errorf("Invalid enrollment ID parameter '%s'.\n", enrollmentID)
+		return false
+	}
+
+	return true
+}
+
 // Register confirms the enrollmentID and secret password of the client with the
 // CA and stores the enrollment certificate and key in the Devops server.
 func (s *ServerOpenchainREST) Register(rw web.ResponseWriter, req *web.Request) {
@@ -218,6 +250,10 @@ func (s *ServerOpenchainREST) Register(rw web.ResponseWriter, req *web.Request) 
 		fmt.Fprintf(rw, "{\"Error\": \"enrollId and enrollSecret may not be blank.\"}")
 		restLogger.Error("{\"Error\": \"enrollId and enrollSecret may not be blank.\"}")
 
+		return
+	}
+
+	if !validateEnrollmentIDParameter(rw, loginSpec.EnrollId) {
 		return
 	}
 
@@ -288,6 +324,10 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
 
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
+
 	// Retrieve the REST data storage path
 	// Returns /var/hyperledger/production/client/
 	localStore := getRESTFilePath()
@@ -302,8 +342,6 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 		fmt.Fprintf(rw, "{\"Error\": \"User %s must log in.\"}", enrollmentID)
 		restLogger.Infof("User '%s' must log in.\n", enrollmentID)
 	}
-
-	return
 }
 
 // DeleteEnrollmentID removes the login token of the specified user from the
@@ -313,6 +351,10 @@ func (s *ServerOpenchainREST) GetEnrollmentID(rw web.ResponseWriter, req *web.Re
 func (s *ServerOpenchainREST) DeleteEnrollmentID(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	// Retrieve the REST data storage path
 	// Returns /var/hyperledger/production/client/
@@ -367,6 +409,10 @@ func (s *ServerOpenchainREST) DeleteEnrollmentID(rw web.ResponseWriter, req *web
 func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	restLogger.Debugf("REST received enrollment certificate retrieval request for registrationID '%s'", enrollmentID)
 
@@ -452,6 +498,10 @@ func (s *ServerOpenchainREST) GetEnrollmentCert(rw web.ResponseWriter, req *web.
 func (s *ServerOpenchainREST) GetTransactionCert(rw web.ResponseWriter, req *web.Request) {
 	// Parse out the user enrollment ID
 	enrollmentID := req.PathParams["id"]
+
+	if !validateEnrollmentIDParameter(rw, enrollmentID) {
+		return
+	}
 
 	restLogger.Debugf("REST received transaction certificate retrieval request for registrationID '%s'", enrollmentID)
 

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -25,6 +25,11 @@ rest:
     # The address that the REST service will listen on for incoming requests.
     address: 0.0.0.0:5000
 
+    validPatterns:
+
+        # Valid enrollment ID pattern in URLs: At least one character long, and
+        # all characters are A-Z, a-z, 0-9 or _.
+        enrollmentID: '^\w+$'
 
 ###############################################################################
 #


### PR DESCRIPTION
## Description

Per @srderson 's request, cherry-picked the relevant code from #2006 into the `v0.5-developer-preview` branch (note that there's also a tag named `v0.5-developer-preview` and it's quite confusing).
## Motivation and Context

See #2006 .
## How Has This Been Tested?

No REST API unit tests in this branch.

Tested the new peer with the invalid (empty) ID:

```
$ curl -v -XDELETE http://127.0.0.1:5000/registrar//
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
> DELETE /registrar// HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 127.0.0.1:5000
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Access-Control-Allow-Headers: accept, content-type
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Date: Sat, 02 Jul 2016 03:29:54 GMT
< Content-Length: 44
< 
{"Error":"Invalid enrollment ID parameter"}
```
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Dov Murik dmurik@us.ibm.com
