### PR TITLE
Close iter sync#issue2088

### DIFF
--- a/core/chaincode/chaincodetest.yaml
+++ b/core/chaincode/chaincodetest.yaml
@@ -377,7 +377,7 @@ chaincode:
 
     # timeout in millisecs for starting up a container and waiting for Register
     # to come through. 1sec should be plenty for chaincode unit tests
-    startuptimeout: 1000
+    startuptimeout: 30000
 
     #timeout in millisecs for deploying chaincode from a remote repository.
     deploytimeout: 60000

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -1490,11 +1490,21 @@ func TestGetRows(t *testing.T) {
 	args = []string{}
 
 	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
-	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
 
-	if err != nil {
+	var retval []byte
+	_, _, retval, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
+
+	if err != nil || retval == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	if string(retval) != "250" {
+		t.Fail()
+		t.Logf("Invalid return value <%s>: %s", chaincodeID, string(retval))
 		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return
@@ -1505,11 +1515,19 @@ func TestGetRows(t *testing.T) {
 	args = []string{}
 
 	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
-	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
+	_, _, retval, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
 
-	if err != nil {
+	if err != nil || retval == nil {
 		t.Fail()
 		t.Logf("Error invoking <%s>: %s", chaincodeID, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	if string(retval) != "250" {
+		t.Fail()
+		t.Logf("Invalid return value <%s>: %s", chaincodeID, string(retval))
 		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
 		closeListenerAndSleep(lis)
 		return

--- a/core/chaincode/exectransaction_test.go
+++ b/core/chaincode/exectransaction_test.go
@@ -1432,6 +1432,93 @@ func TestGetEvent(t *testing.T) {
 	closeListenerAndSleep(lis)
 }
 
+// TestGetRows tests two ways of getting rows
+func TestGetRows(t *testing.T) {
+	var opts []grpc.ServerOption
+	if viper.GetBool("peer.tls.enabled") {
+		creds, err := credentials.NewServerTLSFromFile(viper.GetString("peer.tls.cert.file"), viper.GetString("peer.tls.key.file"))
+		if err != nil {
+			grpclog.Fatalf("Failed to generate credentials %v", err)
+		}
+		opts = []grpc.ServerOption{grpc.Creds(creds)}
+	}
+	grpcServer := grpc.NewServer(opts...)
+	viper.Set("peer.fileSystemPath", "/var/hyperledger/test/tmpdb")
+
+	//use a different address than what we usually use for "peer"
+	//we override the peerAddress set in chaincode_support.go
+	peerAddress := "0.0.0.0:21212"
+
+	lis, err := net.Listen("tcp", peerAddress)
+	if err != nil {
+		t.Fail()
+		t.Logf("Error starting peer listener %s", err)
+		return
+	}
+
+	getPeerEndpoint := func() (*pb.PeerEndpoint, error) {
+		return &pb.PeerEndpoint{ID: &pb.PeerID{Name: "testpeer"}, Address: peerAddress}, nil
+	}
+
+	ccStartupTimeout := time.Duration(chaincodeStartupTimeoutDefault) * time.Millisecond
+	pb.RegisterChaincodeSupportServer(grpcServer, NewChaincodeSupport(DefaultChain, getPeerEndpoint, false, ccStartupTimeout, nil))
+
+	go grpcServer.Serve(lis)
+
+	var ctxt = context.Background()
+
+	url := "github.com/hyperledger/fabric/examples/chaincode/go/largerowsiterator"
+	cID := &pb.ChaincodeID{Path: url}
+
+	args := []string{}
+	f := "init"
+
+	spec := &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+
+	_, err = deploy(ctxt, spec)
+	chaincodeID := spec.ChaincodeID.Name
+	if err != nil {
+		t.Fail()
+		t.Logf("Error initializing chaincode %s(%s)", chaincodeID, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	//invoke using GetRows
+	f = ""
+	args = []string{}
+
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
+
+	if err != nil {
+		t.Fail()
+		t.Logf("Error invoking <%s>: %s", chaincodeID, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	//invoke using GetRows2
+	f = "new"
+	args = []string{}
+
+	spec = &pb.ChaincodeSpec{Type: 1, ChaincodeID: cID, CtorMsg: &pb.ChaincodeInput{Function: f, Args: args}}
+	_, _, _, err = invoke(ctxt, spec, pb.Transaction_CHAINCODE_QUERY)
+
+	if err != nil {
+		t.Fail()
+		t.Logf("Error invoking <%s>: %s", chaincodeID, err)
+		GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+		closeListenerAndSleep(lis)
+		return
+	}
+
+	GetChain(DefaultChain).Stop(ctxt, &pb.ChaincodeDeploymentSpec{ChaincodeSpec: spec})
+	closeListenerAndSleep(lis)
+}
+
 func TestMain(m *testing.M) {
 	SetupTestConfig()
 	os.Exit(m.Run())

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -596,7 +596,7 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 		//copy rows to a larger channel
 		if len(rows) == cap(rows) {
 			tmprows := make(chan Row, cap(rows)+64)
-			for i := 0;  i < len(rows);  i++ {
+			for i := 0; i < len(rows); i++ {
 				var ok bool
 				if row, ok = <-rows; !ok {
 					break
@@ -618,7 +618,7 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 
 }
 
-// GetRows2 is identical to GetRows except 
+// GetRows2 is identical to GetRows except
 //    1) does not have the overhead of buffering all rows into the returned channel
 //    2) returns an additional func() which user needs to call to close the iterator
 //       see examples/chaincode/go/largerowsiterator/largerowsiterator.go

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -596,7 +596,11 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 		//copy rows to a larger channel
 		if len(rows) == cap(rows) {
 			tmprows := make(chan Row, cap(rows)+64)
-			for i := 0; i < len(rows); i++ {
+
+			//need to save of len when dealing with
+			//mutable channel
+			sz := len(rows)
+			for i := 0; i < sz; i++ {
 				var ok bool
 				if row, ok = <-rows; !ok {
 					break

--- a/core/chaincode/shim/chaincode.go
+++ b/core/chaincode/shim/chaincode.go
@@ -541,6 +541,8 @@ func (stub *ChaincodeStub) GetRow(tableName string, key []Column) (Row, error) {
 // all rows that have A, C and any value for D as their key. GetRows could
 // also be called with A only to return all rows that have A and any value
 // for C and D as their key.
+//
+// recommend using GetRows2 as a more efficient implementation
 func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, error) {
 
 	keyString, err := buildKeyString(tableName, key)
@@ -572,7 +574,85 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 	if err != nil {
 		return nil, fmt.Errorf("Error fetching rows: %s", err)
 	}
+
 	defer iter.Close()
+
+	//start with 128 but make more if necesssary
+	rows := make(chan Row, 128)
+
+	//at the end of this call all rows are obtained
+	for iter.HasNext() {
+		_, rowBytes, err := iter.Next()
+		if err != nil {
+			break
+		}
+
+		var row Row
+		err = proto.Unmarshal(rowBytes, &row)
+		if err != nil {
+			break
+		}
+
+		//copy rows to a larger channel
+		if len(rows) == cap(rows) {
+			tmprows := make(chan Row, cap(rows)+64)
+			for i := 0;  i < len(rows);  i++ {
+				var ok bool
+				if row, ok = <-rows; !ok {
+					break
+				}
+				tmprows <- row
+			}
+			close(rows)
+
+			rows = tmprows
+			tmprows = nil
+		}
+
+		rows <- row
+
+	}
+	close(rows)
+
+	return rows, nil
+
+}
+
+// GetRows2 is identical to GetRows except 
+//    1) does not have the overhead of buffering all rows into the returned channel
+//    2) returns an additional func() which user needs to call to close the iterator
+//       see examples/chaincode/go/largerowsiterator/largerowsiterator.go
+func (stub *ChaincodeStub) GetRows2(tableName string, key []Column) (func(), <-chan Row, error) {
+
+	keyString, err := buildKeyString(tableName, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	table, err := stub.getTable(tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Need to check for special case where table has a single column
+	if len(table.GetColumnDefinitions()) < 2 && len(key) > 0 {
+
+		row, err := stub.GetRow(tableName, key)
+		if err != nil {
+			return nil, nil, err
+		}
+		rows := make(chan Row)
+		go func() {
+			rows <- row
+			close(rows)
+		}()
+		return nil, rows, nil
+	}
+
+	iter, err := stub.RangeQueryState(keyString+"1", keyString+":")
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error fetching rows: %s", err)
+	}
 
 	rows := make(chan Row)
 
@@ -580,13 +660,13 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 		for iter.HasNext() {
 			_, rowBytes, err := iter.Next()
 			if err != nil {
-				close(rows)
+				break
 			}
 
 			var row Row
 			err = proto.Unmarshal(rowBytes, &row)
 			if err != nil {
-				close(rows)
+				break
 			}
 
 			rows <- row
@@ -595,7 +675,12 @@ func (stub *ChaincodeStub) GetRows(tableName string, key []Column) (<-chan Row, 
 		close(rows)
 	}()
 
-	return rows, nil
+	closeFunc := func() {
+		iter.Close()
+	}
+
+	//user has to call closeFunc and close the iterator after reading rows
+	return closeFunc, rows, nil
 
 }
 

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -436,7 +436,7 @@ func (handler *Handler) handleGetState(key string, uuid string) ([]byte, error) 
 	// Create the channel on which to communicate the response from validating peer
 	respChan, uniqueReqErr := handler.createChannel(uuid)
 	if uniqueReqErr != nil {
-		chaincodeLogger.Debug("Another state request pending for this Uuid. Cannot process.")
+		chaincodeLogger.Errorf("[%s]Another state request pending for this Uuid. Cannot process.", shortuuid(uuid))
 		return nil, uniqueReqErr
 	}
 

--- a/examples/chaincode/go/largerowsiterator/largerowsiterator.go
+++ b/examples/chaincode/go/largerowsiterator/largerowsiterator.go
@@ -44,17 +44,18 @@ func (lrc *largeRowsetChaincode) Init(db *shim.ChaincodeStub, function string, a
 		{"Name", shim.ColumnDefinition_STRING, false},
 		{"Bank", shim.ColumnDefinition_STRING, false},
 	}); err != nil {
-		return nil, err
+		//just assume the table exists and was populated
+		return nil, nil
 	}
 
-	for i := 0; i < 250;  i++ {
+	for i := 0; i < 250; i++ {
 		col1 := fmt.Sprintf("Key_%d", i)
 		col2 := fmt.Sprintf("Name_%d", i)
 		col3 := fmt.Sprintf("Bank_%d", i)
-		if _, err := lrc.retInAdd(db.InsertRow("Investor", shim.Row{[]*shim.Column{
-			&shim.Column{&shim.Column_String_{col1}},
-			&shim.Column{&shim.Column_String_{col2}},
-			&shim.Column{&shim.Column_String_{col3}},
+		if _, err := lrc.retInAdd(db.InsertRow("Investor", shim.Row{Columns: []*shim.Column{
+			&shim.Column{Value: &shim.Column_String_{String_: col1}},
+			&shim.Column{Value: &shim.Column_String_{String_: col2}},
+			&shim.Column{Value: &shim.Column_String_{String_: col3}},
 		}})); err != nil {
 			return nil, err
 		}
@@ -68,7 +69,7 @@ func (lrc *largeRowsetChaincode) Invoke(db *shim.ChaincodeStub, function string,
 	return nil, nil
 }
 
-// Query callback representing the query of a chaincode. 
+// Query callback representing the query of a chaincode.
 // If function is "old", will use GetRows (inefficient)
 // Otherwise, will use GetRows2 where caller should class close
 func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
@@ -86,7 +87,7 @@ func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, 
 		if err != nil {
 			return nil, err
 		}
-	} else { 
+	} else {
 		//method 2, more efficient but we have close call close
 		// 1. Call GetRows2()
 		closeIter, rowChannel, err = db.GetRows2(model, []shim.Column{})
@@ -94,12 +95,12 @@ func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, 
 			return nil, err
 		}
 	}
-	
+
 	// 2. Fetch all the rows
 	var rows []*shim.Row
 	for {
 		select {
-			case row, ok := <-rowChannel:
+		case row, ok := <-rowChannel:
 			if !ok {
 				rowChannel = nil
 			} else {

--- a/examples/chaincode/go/largerowsiterator/largerowsiterator.go
+++ b/examples/chaincode/go/largerowsiterator/largerowsiterator.go
@@ -47,7 +47,7 @@ func (lrc *largeRowsetChaincode) Init(db *shim.ChaincodeStub, function string, a
 		return nil, err
 	}
 
-	for i := 0; i < 1000;  i++ {
+	for i := 0; i < 250;  i++ {
 		col1 := fmt.Sprintf("Key_%d", i)
 		col2 := fmt.Sprintf("Name_%d", i)
 		col3 := fmt.Sprintf("Bank_%d", i)
@@ -102,7 +102,7 @@ func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, 
 			case row, ok := <-rowChannel:
 			if !ok {
 				rowChannel = nil
-				} else {
+			} else {
 				rows = append(rows, &row)
 			}
 		}

--- a/examples/chaincode/go/largerowsiterator/largerowsiterator.go
+++ b/examples/chaincode/go/largerowsiterator/largerowsiterator.go
@@ -1,0 +1,135 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+type largeRowsetChaincode struct {
+}
+
+func (lrc *largeRowsetChaincode) retInAdd(ok bool, err error) ([]byte, error) {
+	if err != nil {
+		return nil, fmt.Errorf("operation failed. %s", err)
+	}
+	if !ok {
+		return nil, errors.New("operation failed. Row with given key already exists")
+	}
+	return nil, nil
+}
+
+// Init called for initializing the chaincode
+func (lrc *largeRowsetChaincode) Init(db *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	// Create a new table
+	if err := db.CreateTable("Investor", []*shim.ColumnDefinition{
+		{Name: "Key", Type: shim.ColumnDefinition_STRING, Key: true},
+		{"Name", shim.ColumnDefinition_STRING, false},
+		{"Bank", shim.ColumnDefinition_STRING, false},
+	}); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < 1000;  i++ {
+		col1 := fmt.Sprintf("Key_%d", i)
+		col2 := fmt.Sprintf("Name_%d", i)
+		col3 := fmt.Sprintf("Bank_%d", i)
+		if _, err := lrc.retInAdd(db.InsertRow("Investor", shim.Row{[]*shim.Column{
+			&shim.Column{&shim.Column_String_{col1}},
+			&shim.Column{&shim.Column_String_{col2}},
+			&shim.Column{&shim.Column_String_{col3}},
+		}})); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+// Run callback representing the invocation of a chaincode
+func (lrc *largeRowsetChaincode) Invoke(db *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	return nil, nil
+}
+
+// Query callback representing the query of a chaincode. 
+// If function is "old", will use GetRows (inefficient)
+// Otherwise, will use GetRows2 where caller should class close
+func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, args []string) ([]byte, error) {
+	model := "Investor"
+
+	//if we call GetRows2, call closeIter
+	var closeIter func()
+
+	var rowChannel <-chan shim.Row
+	var err error
+	if function == "" || function == "old" {
+		//method 1, not efficient for large row set
+		// 1. Call GetRows()
+		rowChannel, err = db.GetRows(model, []shim.Column{})
+		if err != nil {
+			return nil, err
+		}
+	} else { 
+		//method 2, more efficient but we have close call close
+		// 1. Call GetRows2()
+		closeIter, rowChannel, err = db.GetRows2(model, []shim.Column{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	
+	// 2. Fetch all the rows
+	var rows []*shim.Row
+	for {
+		select {
+			case row, ok := <-rowChannel:
+			if !ok {
+				rowChannel = nil
+				} else {
+				rows = append(rows, &row)
+			}
+		}
+
+		if rowChannel == nil {
+			break
+		}
+	}
+
+	// 4. make sure to close iterator if necessary
+	if closeIter != nil {
+		closeIter()
+	}
+
+	// 5. Query some other functions immediately which access to KVS
+	col1 := shim.Column{Value: &shim.Column_String_{String_: "Key_2"}}
+	row, err := db.GetRow(model, []shim.Column{col1})
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(row.Columns[1].GetString_()), nil
+}
+
+func main() {
+	err := shim.Start(new(largeRowsetChaincode))
+	if err != nil {
+		fmt.Printf("Error starting the chaincode: %s", err)
+	}
+}

--- a/examples/chaincode/go/largerowsiterator/largerowsiterator.go
+++ b/examples/chaincode/go/largerowsiterator/largerowsiterator.go
@@ -48,7 +48,9 @@ func (lrc *largeRowsetChaincode) Init(db *shim.ChaincodeStub, function string, a
 		return nil, nil
 	}
 
-	for i := 0; i < 250; i++ {
+	//don't change this... unit test case depends on this
+	totalRows := 250
+	for i := 0; i < totalRows; i++ {
 		col1 := fmt.Sprintf("Key_%d", i)
 		col2 := fmt.Sprintf("Name_%d", i)
 		col3 := fmt.Sprintf("Bank_%d", i)
@@ -120,12 +122,12 @@ func (lrc *largeRowsetChaincode) Query(db *shim.ChaincodeStub, function string, 
 
 	// 5. Query some other functions immediately which access to KVS
 	col1 := shim.Column{Value: &shim.Column_String_{String_: "Key_2"}}
-	row, err := db.GetRow(model, []shim.Column{col1})
+	_, err = db.GetRow(model, []shim.Column{col1})
 	if err != nil {
 		return nil, err
 	}
 
-	return []byte(row.Columns[1].GetString_()), nil
+	return []byte(fmt.Sprintf("%d", len(rows))), nil
 }
 
 func main() {


### PR DESCRIPTION
Make GetRows buffer all the rows followed by a synchronous close of the iterator.

Also, provide a more efficient implementation with GetRows2 that does not buffer all rows by pushing it to the chaincode developer to close the iterator when done in the chaincode.
## Description

GetRows was returning a channel for iterating over the rows. The rows were sent to the channel from a go routine. This does not let one close the iterator cleanly (without elaborate coordination at least) in a manner that does not disrupt the state machine or the on going communication. 

The fix was to get all the rows into the channel before returning to the user. This allows GetRows to cleanly close the iterator when done.

While it works, there is the drawback of burden on memory when the rowset is large. Also, it does not allow the chaincode to complete in the middle of iteration (loosely analogous to XML processing with DOM vs SAX).

GetRows2 fixes the above problem by 
- retaining the "fetch row at a time" pattern from original GetRow
- in addition returning a closure back to the user. It is now the burden on the user to close the iterator when done
## Motivation and Context

Avoids race between transaction end and closing iterator when using GetRows.

Fixes #2088
## How Has This Been Tested?

Used a modified version of the sample program provided in #2088 (renamed to largerowsiterator.go) in a unit test case.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] I have either added documentation to cover my changes or this change requires no new documentation.
- [X] I have either added unit tests to cover my changes or this change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: muralisr@us.ibm.com
