### PR TITLE
Fixes #1401

### DIFF
--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -97,11 +97,14 @@ peer:
 
     # The Address this Peer will listen on
     listenAddress: 0.0.0.0:30303
-    # The Address this Peer will bind to for providing services
+
+    # The Address advertised to other services that will connect to this Peer
+    # Chaincode deployment will use this to create chaincode docker containers
+    # (This is NOT a binding address for the listening port)
     address: 0.0.0.0:30303
-    # Whether the Peer should programmatically determine the address to bind to.
-    # This case is useful for docker containers.
-    addressAutoDetect: false
+
+    # Whether to override the IP/hostname portion of peer.address with a local, non-loopback IP address 
+    addressAutoDetect: true
 
     # Setting for runtime.GOMAXPROCS(n). If n < 1, it does not change the current setting
     gomaxprocs: -1


### PR DESCRIPTION
## Description

Updated peer/core.yaml configuration descriptions to be more consistent with their actual use and behaviour. Changed peer.addressAutoDetect=true so that it will work out-of-the-box in the simplest cases.
## Motivation and Context

The previous description implied peer.address was used as the listening / binding address of the peer. This is what peer.listenAddress is used for.
The default of peer.addressAutoDetect=false also makes little sense as for the "false" flag to work, you MUST have defined peer.address to a valid address. When it is "true" then at least it will work in simple deployments.
Fixes #1404 
## How Has This Been Tested?

Tested with `make unit-test`. No new features, so no new tests.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Brad Gorman bgorman@au1.ibm.com
