### PR TITLE
moved grpc related python code to separate module fixes #2064

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,15 +80,8 @@ unit-test: peer-image gotools
 .PHONY: images
 images: $(patsubst %,build/image/%/.dummy, $(IMAGES))
 
-build/behave/.grpc-dummy:
-	sudo pip install -q 'grpcio==0.13.1'
-	mkdir -p build/behave
-	touch build/behave/.grpc-dummy
+behave-deps: images peer
 
-behave-grpc: build/behave/.grpc-dummy
-
-
-behave-deps: images peer behave-grpc
 behave: behave-deps
 	@echo "Running behave tests"
 	@cd bddtests; behave $(BEHAVE_OPTS)

--- a/bddtests/steps/bdd_grpc_util.py
+++ b/bddtests/steps/bdd_grpc_util.py
@@ -1,0 +1,143 @@
+
+# Copyright IBM Corp. 2016 All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import re
+import subprocess
+import devops_pb2
+import fabric_pb2
+import chaincode_pb2
+
+import bdd_test_util
+
+from grpc.beta import implementations
+
+def getSecretForUserRegistration(userRegistration):
+    return devops_pb2.Secret(enrollId=userRegistration.secretMsg['enrollId'],enrollSecret=userRegistration.secretMsg['enrollSecret'])
+
+def getTxResult(context, enrollId):
+    '''Returns the TransactionResult using the enrollId supplied'''
+    assert 'users' in context, "users not found in context. Did you register a user?"
+    assert 'compose_containers' in context, "compose_containers not found in context"
+
+    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
+    stub = devops_pb2.beta_create_Devops_stub(channel)
+    
+    txRequest = devops_pb2.TransactionRequest(transactionUuid = context.transactionID)
+    response = stub.GetTransactionResult(txRequest, 2)
+    assert response.status == fabric_pb2.Response.SUCCESS, 'Failure getting Transaction Result from {0}, for user "{1}":  {2}'.format(userRegistration.composeService,enrollId, response.msg)
+    # Now grab the TransactionResult from the Msg bytes
+    txResult = fabric_pb2.TransactionResult()
+    txResult.ParseFromString(response.msg)
+    return txResult
+
+def getGRPCChannel(ipAddress):
+    channel = implementations.insecure_channel(ipAddress, 30303)
+    print("Returning GRPC for address: {0}".format(ipAddress))
+    return channel
+
+def getGRPCChannelAndUser(context, enrollId):
+    '''Returns a tuple of GRPC channel and UserRegistration instance.  The channel is open to the composeService that the user registered with.'''
+    userRegistration = bdd_test_util.getUserRegistration(context, enrollId)
+
+    # Get the IP address of the server that the user registered on
+    ipAddress = bdd_test_util.ipFromContainerNamePart(userRegistration.composeService, context.compose_containers)
+
+    channel = getGRPCChannel(ipAddress)
+
+    return (channel, userRegistration) 
+
+
+def getDeployment(context, ccAlias):
+    '''Return a deployment with chaincode alias from prior deployment, or None if not found'''
+    deployment = None
+    if 'deployments' in context:
+        pass
+    else:
+        context.deployments = {}
+    if ccAlias in context.deployments:
+        deployment = context.deployments[ccAlias] 
+    # else:
+    #     raise Exception("Deployment alias not found: '{0}'.  Are you sure you have deployed a chaincode with this alias?".format(ccAlias)) 
+    return deployment
+
+def deployChaincode(context, enrollId, chaincodePath, ccAlias, ctor):
+    '''Deploy a chaincode with the specified alias for the specfied enrollId'''
+    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
+    stub = devops_pb2.beta_create_Devops_stub(channel)
+
+    # Make sure deployment alias does NOT already exist
+    assert getDeployment(context, ccAlias) == None, "Deployment alias already exists: '{0}'.".format(ccAlias)
+
+    args = getArgsFromContextForUser(context, enrollId)
+    ccSpec = chaincode_pb2.ChaincodeSpec(type = chaincode_pb2.ChaincodeSpec.GOLANG,
+        chaincodeID = chaincode_pb2.ChaincodeID(name="",path=chaincodePath),
+        ctorMsg = chaincode_pb2.ChaincodeInput(function = ctor, args = args))
+    ccSpec.secureContext = userRegistration.getUserName()
+    if 'metadata' in context:
+        ccSpec.metadata = context.metadata
+    try:
+        ccDeploymentSpec = stub.Deploy(ccSpec, 60)
+        ccSpec.chaincodeID.name = ccDeploymentSpec.chaincodeSpec.chaincodeID.name
+        context.grpcChaincodeSpec = ccSpec
+        context.deployments[ccAlias] = ccSpec
+    except:
+        del stub
+        raise
+
+def invokeChaincode(context, enrollId, ccAlias, functionName):
+    # Get the deployment for the supplied chaincode alias
+    deployedCcSpec = getDeployment(context, ccAlias)
+    assert deployedCcSpec != None, "Deployment NOT found for chaincode alias '{0}'".format(ccAlias)
+
+    # Create a new ChaincodeSpec by copying the deployed one
+    newChaincodeSpec = chaincode_pb2.ChaincodeSpec()
+    newChaincodeSpec.CopyFrom(deployedCcSpec)
+    
+    # Update hte chaincodeSpec ctorMsg for invoke
+    args = getArgsFromContextForUser(context, enrollId)
+    
+    chaincodeInput = chaincode_pb2.ChaincodeInput(function = functionName, args = args ) 
+    newChaincodeSpec.ctorMsg.CopyFrom(chaincodeInput)
+
+    ccInvocationSpec = chaincode_pb2.ChaincodeInvocationSpec(chaincodeSpec = newChaincodeSpec)
+
+    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
+    
+    stub = devops_pb2.beta_create_Devops_stub(channel)
+    response = stub.Invoke(ccInvocationSpec,2)
+    return response
+
+def getArgsFromContextForUser(context, enrollId):
+    # Update the chaincodeSpec ctorMsg for invoke
+    args = []
+    if 'table' in context:
+       # There are function arguments
+       userRegistration = bdd_test_util.getUserRegistration(context, enrollId)
+       # Allow the user to specify expressions referencing tags in the args list
+       pattern = re.compile('\{(.*)\}$')
+       for arg in context.table[0].cells:
+          m = pattern.match(arg)
+          if m:
+              # tagName reference found in args list
+              tagName = m.groups()[0]
+              # make sure the tagName is found in the users tags
+              assert tagName in userRegistration.tags, "TagName '{0}' not found for user '{1}'".format(tagName, userRegistration.getUserName())
+              args.append(userRegistration.tags[tagName])
+          else:
+              #No tag referenced, pass the arg
+              args.append(arg)
+    return args

--- a/bddtests/steps/bdd_test_util.py
+++ b/bddtests/steps/bdd_test_util.py
@@ -17,11 +17,6 @@
 import os
 import re
 import subprocess
-import devops_pb2
-import fabric_pb2
-import chaincode_pb2
-
-from grpc.beta import implementations
 
 def cli_call(context, arg_list, expect_success=True):
     """Executes a CLI command in a subprocess and return the results.
@@ -57,10 +52,6 @@ class UserRegistration:
 
     def getUserName(self):
         return self.secretMsg['enrollId']
-
-    def getSecret(self):
-        return devops_pb2.Secret(enrollId=self.secretMsg['enrollId'],enrollSecret=self.secretMsg['enrollSecret'])
-
 
 # Registerses a user on a specific composeService
 def registerUser(context, secretMsg, composeService):
@@ -98,119 +89,6 @@ def ipFromContainerNamePart(namePart, containerDataList):
         raise Exception("Could not find container with namePart = {0}".format(namePart))
     return ip
 
-def getTxResult(context, enrollId):
-    '''Returns the TransactionResult using the enrollId supplied'''
-    assert 'users' in context, "users not found in context. Did you register a user?"
-    assert 'compose_containers' in context, "compose_containers not found in context"
-
-    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
-    stub = devops_pb2.beta_create_Devops_stub(channel)
-    
-    txRequest = devops_pb2.TransactionRequest(transactionUuid = context.transactionID)
-    response = stub.GetTransactionResult(txRequest, 2)
-    assert response.status == fabric_pb2.Response.SUCCESS, 'Failure getting Transaction Result from {0}, for user "{1}":  {2}'.format(userRegistration.composeService,enrollId, response.msg)
-    # Now grab the TransactionResult from the Msg bytes
-    txResult = fabric_pb2.TransactionResult()
-    txResult.ParseFromString(response.msg)
-    return txResult
-
-def getGRPCChannel(ipAddress):
-    channel = implementations.insecure_channel(ipAddress, 30303)
-    print("Returning GRPC for address: {0}".format(ipAddress))
-    return channel
-
-def getGRPCChannelAndUser(context, enrollId):
-    '''Returns a tuple of GRPC channel and UserRegistration instance.  The channel is open to the composeService that the user registered with.'''
-    userRegistration = getUserRegistration(context, enrollId)
-
-    # Get the IP address of the server that the user registered on
-    ipAddress = ipFromContainerNamePart(userRegistration.composeService, context.compose_containers)
-
-    channel = getGRPCChannel(ipAddress)
-
-    return (channel, userRegistration) 
-
-
-def getDeployment(context, ccAlias):
-    '''Return a deployment with chaincode alias from prior deployment, or None if not found'''
-    deployment = None
-    if 'deployments' in context:
-        pass
-    else:
-        context.deployments = {}
-    if ccAlias in context.deployments:
-        deployment = context.deployments[ccAlias] 
-    # else:
-    #     raise Exception("Deployment alias not found: '{0}'.  Are you sure you have deployed a chaincode with this alias?".format(ccAlias)) 
-    return deployment
-
-def deployChaincode(context, enrollId, chaincodePath, ccAlias, ctor):
-    '''Deploy a chaincode with the specified alias for the specfied enrollId'''
-    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
-    stub = devops_pb2.beta_create_Devops_stub(channel)
-
-    # Make sure deployment alias does NOT already exist
-    assert getDeployment(context, ccAlias) == None, "Deployment alias already exists: '{0}'.".format(ccAlias)
-
-    args = getArgsFromContextForUser(context, enrollId)
-    ccSpec = chaincode_pb2.ChaincodeSpec(type = chaincode_pb2.ChaincodeSpec.GOLANG,
-        chaincodeID = chaincode_pb2.ChaincodeID(name="",path=chaincodePath),
-        ctorMsg = chaincode_pb2.ChaincodeInput(function = ctor, args = args))
-    ccSpec.secureContext = userRegistration.getUserName()
-    if 'metadata' in context:
-        ccSpec.metadata = context.metadata
-    try:
-        ccDeploymentSpec = stub.Deploy(ccSpec, 60)
-        ccSpec.chaincodeID.name = ccDeploymentSpec.chaincodeSpec.chaincodeID.name
-        context.grpcChaincodeSpec = ccSpec
-        context.deployments[ccAlias] = ccSpec
-    except:
-        del stub
-        raise
-
-def invokeChaincode(context, enrollId, ccAlias, functionName):
-    # Get the deployment for the supplied chaincode alias
-    deployedCcSpec = getDeployment(context, ccAlias)
-    assert deployedCcSpec != None, "Deployment NOT found for chaincode alias '{0}'".format(ccAlias)
-
-    # Create a new ChaincodeSpec by copying the deployed one
-    newChaincodeSpec = chaincode_pb2.ChaincodeSpec()
-    newChaincodeSpec.CopyFrom(deployedCcSpec)
-    
-    # Update hte chaincodeSpec ctorMsg for invoke
-    args = getArgsFromContextForUser(context, enrollId)
-    
-    chaincodeInput = chaincode_pb2.ChaincodeInput(function = functionName, args = args ) 
-    newChaincodeSpec.ctorMsg.CopyFrom(chaincodeInput)
-
-    ccInvocationSpec = chaincode_pb2.ChaincodeInvocationSpec(chaincodeSpec = newChaincodeSpec)
-
-    (channel, userRegistration) = getGRPCChannelAndUser(context, enrollId)
-    
-    stub = devops_pb2.beta_create_Devops_stub(channel)
-    response = stub.Invoke(ccInvocationSpec,2)
-    return response
-
-def getArgsFromContextForUser(context, enrollId):
-    # Update the chaincodeSpec ctorMsg for invoke
-    args = []
-    if 'table' in context:
-       # There are function arguments
-       userRegistration = getUserRegistration(context, enrollId)
-       # Allow the user to specify expressions referencing tags in the args list
-       pattern = re.compile('\{(.*)\}$')
-       for arg in context.table[0].cells:
-          m = pattern.match(arg)
-          if m:
-              # tagName reference found in args list
-              tagName = m.groups()[0]
-              # make sure the tagName is found in the users tags
-              assert tagName in userRegistration.tags, "TagName '{0}' not found for user '{1}'".format(tagName, userRegistration.getUserName())
-              args.append(userRegistration.tags[tagName])
-          else:
-              #No tag referenced, pass the arg
-              args.append(arg)
-    return args
 
 def getContainerDataValuesFromContext(context, aliases, callback):
     """Returns the IPAddress based upon a name part of the full container name"""

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -538,7 +538,7 @@ def compose_op(context, op):
     # Loop through services and start/stop them, and modify the container data list if successful.
     for service in services:
        context.compose_output, context.compose_error, context.compose_returncode = \
-           bdd_test_util.cli_call(context, ["docker-compose", "-f", context.compose_yaml, op, service], expect_success=True)
+           bdd_test_util.cli_call(context, ["docker-compose"] + fileArgsToDockerCompose + [op, service], expect_success=True)
        assert context.compose_returncode == 0, "docker-compose failed to {0} {0}".format(op, service)
        if op == "stop" or op == "pause":
            context.compose_containers = [containerData for containerData in context.compose_containers if containerData.composeService != service]

--- a/scripts/provision/host.sh
+++ b/scripts/provision/host.sh
@@ -22,9 +22,18 @@ pip install nose
 # updater-server, update-engine, and update-service-common dependencies (for running locally)
 pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3
 
+# Python grpc package for behave tests
+# Required to update six for grpcio
+
+pip install --ignore-installed six
+pip install 'grpcio==0.13.1'
+
 # install ruby and apiaryio
 #apt-get install --yes ruby ruby-dev gcc
 #gem install apiaryio
 
 # Install Tcl prerequisites for busywork
 apt-get install --yes tcl tclx tcllib
+
+# Install NPM for the SDK
+apt-get install --yes npm


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Moved the pip install of the python grpc package from the Makefile to the hosts.sh file. This will require developers perform a vagrant destroy/up cycle. Also moved all grpc related usage in python to bdd_grpc_util.py module. This PR fixes issue #2064. Same fix has been applied in fabric master branch with PR#1940.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #
#2064
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Implemented these changes in fabric master branch with PR #1940 and observed builds are working as expected.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:thoomu@us.ibm.com
