### PR TITLE
Add test cases for the logging.go file

### DIFF
--- a/core/logging.go
+++ b/core/logging.go
@@ -82,6 +82,11 @@ func LoggingInit(command string) {
 	loggingLogger.Debugf("Setting default logging level to %s for command '%s'", defaultLevel, command)
 }
 
+// DefaultLoggingLevel returns the fallback value for loggers to use if parsing fails
+func DefaultLoggingLevel() logging.Level {
+	return loggingDefaultLevel
+}
+
 // Initiate 'leveled' logging to stderr.
 func init() {
 

--- a/core/logging_test.go
+++ b/core/logging_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"testing"
+
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
+)
+
+func TestLoggingLevelDefault(t *testing.T) {
+	viper.Reset()
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func TestLoggingLevelOtherThanDefault(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "warning")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, logging.WARNING)
+}
+
+func TestLoggingLevelForSpecificModule(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "core=info")
+
+	LoggingInit("")
+
+	assertModuleLoggingLevel(t, "core", logging.INFO)
+}
+
+func TestLoggingLeveltForMultipleModules(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "core=warning:test=debug")
+
+	LoggingInit("")
+
+	assertModuleLoggingLevel(t, "core", logging.WARNING)
+	assertModuleLoggingLevel(t, "test", logging.DEBUG)
+}
+
+func TestLoggingLevelForMultipleModulesAtSameLevel(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "core,test=warning")
+
+	LoggingInit("")
+
+	assertModuleLoggingLevel(t, "core", logging.WARNING)
+	assertModuleLoggingLevel(t, "test", logging.WARNING)
+}
+
+func TestLoggingLevelForModuleWithDefault(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "info:test=warning")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, logging.INFO)
+	assertModuleLoggingLevel(t, "test", logging.WARNING)
+}
+
+func TestLoggingLevelForModuleWithDefaultAtEnd(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "test=warning:info")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, logging.INFO)
+	assertModuleLoggingLevel(t, "test", logging.WARNING)
+}
+
+func TestLoggingLevelForSpecificCommand(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging.node", "error")
+
+	LoggingInit("node")
+
+	assertDefaultLoggingLevel(t, logging.ERROR)
+}
+
+func TestLoggingLevelForUnknownCommandGoesToDefault(t *testing.T) {
+	viper.Reset()
+
+	LoggingInit("unknown command")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func TestLoggingLevelInvalid(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "invalidlevel")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func TestLoggingLevelInvalidModules(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "core=invalid")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func TestLoggingLevelInvalidEmptyModule(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "=warning")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func TestLoggingLevelInvalidModuleSyntax(t *testing.T) {
+	viper.Reset()
+	viper.Set("logging_level", "type=warn=again")
+
+	LoggingInit("")
+
+	assertDefaultLoggingLevel(t, DefaultLoggingLevel())
+}
+
+func assertDefaultLoggingLevel(t *testing.T, expectedLevel logging.Level) {
+	assertModuleLoggingLevel(t, "", expectedLevel)
+}
+
+func assertModuleLoggingLevel(t *testing.T, module string, expectedLevel logging.Level) {
+	assertEquals(t, expectedLevel, logging.GetLevel(module))
+}
+
+func assertEquals(t *testing.T, expected interface{}, actual interface{}) {
+	if expected != actual {
+		t.Errorf("Expected: %v, Got: %v", expected, actual)
+	}
+}


### PR DESCRIPTION
## Description

Add test cases for the Logging Initialisation code which parses the logging configuration in core.yaml
## Motivation and Context

There were previously no tests for parsing the config in core.yaml. In the process of looking at issue #802 I decided it would be easier to fiddle with if there were tests in place.
## How Has This Been Tested?

This pull request consists of tests.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
