### PR TITLE
Renaming gsm to gcm.

### DIFF
--- a/core/crypto/primitives/aes/gcm.go
+++ b/core/crypto/primitives/aes/gcm.go
@@ -36,14 +36,14 @@ func (sk *aesSecretKeyImpl) GetRand() io.Reader {
 	return sk.r
 }
 
-type aes256GSMStreamCipherImpl struct {
+type aes256GCMStreamCipherImpl struct {
 	forEncryption bool
 	gcm           cipher.AEAD
 	nonceSize     int
 }
 
 // Init initializes this cipher with the passed parameters
-func (sc *aes256GSMStreamCipherImpl) Init(forEncryption bool, params primitives.CipherParameters) error {
+func (sc *aes256GCMStreamCipherImpl) Init(forEncryption bool, params primitives.CipherParameters) error {
 	var aesKey *aesSecretKeyImpl
 
 	switch sk := params.(type) {
@@ -75,7 +75,7 @@ func (sc *aes256GSMStreamCipherImpl) Init(forEncryption bool, params primitives.
 }
 
 // Process processes the byte array given in input
-func (sc *aes256GSMStreamCipherImpl) Process(msg []byte) ([]byte, error) {
+func (sc *aes256GCMStreamCipherImpl) Process(msg []byte) ([]byte, error) {
 	if sc.forEncryption {
 		nonce, err := sc.generateNonce()
 		if err != nil {
@@ -105,14 +105,14 @@ func (sc *aes256GSMStreamCipherImpl) Process(msg []byte) ([]byte, error) {
 	return out, nil
 }
 
-func (sc *aes256GSMStreamCipherImpl) generateNonce() ([]byte, error) {
+func (sc *aes256GCMStreamCipherImpl) generateNonce() ([]byte, error) {
 	return primitives.GetRandomBytes(sc.nonceSize)
 }
 
-type aes256GSMStreamCipherSPIImpl struct {
+type aes256GCMStreamCipherSPIImpl struct {
 }
 
-func (spi *aes256GSMStreamCipherSPIImpl) GenerateKey() (primitives.SecretKey, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) GenerateKey() (primitives.SecretKey, error) {
 	key, err := primitives.GetRandomBytes(32)
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (spi *aes256GSMStreamCipherSPIImpl) GenerateKey() (primitives.SecretKey, er
 	return &aesSecretKeyImpl{key, rand.Reader}, nil
 }
 
-func (spi *aes256GSMStreamCipherSPIImpl) GenerateKeyAndSerialize() (primitives.SecretKey, []byte, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) GenerateKeyAndSerialize() (primitives.SecretKey, []byte, error) {
 	key, err := primitives.GetRandomBytes(32)
 	if err != nil {
 		return nil, nil, err
@@ -130,7 +130,7 @@ func (spi *aes256GSMStreamCipherSPIImpl) GenerateKeyAndSerialize() (primitives.S
 	return &aesSecretKeyImpl{key, rand.Reader}, utils.Clone(key), nil
 }
 
-func (spi *aes256GSMStreamCipherSPIImpl) NewSecretKey(r io.Reader, params interface{}) (primitives.SecretKey, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) NewSecretKey(r io.Reader, params interface{}) (primitives.SecretKey, error) {
 	switch t := params.(type) {
 	case []byte:
 		if len(t) != 32 {
@@ -146,8 +146,8 @@ func (spi *aes256GSMStreamCipherSPIImpl) NewSecretKey(r io.Reader, params interf
 }
 
 // NewStreamCipherForEncryptionFromKey creates a new StreamCipher for encryption from a secret key
-func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromKey(secret primitives.SecretKey) (primitives.StreamCipher, error) {
-	sc := aes256GSMStreamCipherImpl{}
+func (spi *aes256GCMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromKey(secret primitives.SecretKey) (primitives.StreamCipher, error) {
+	sc := aes256GCMStreamCipherImpl{}
 	if err := sc.Init(true, secret); err != nil {
 		return nil, err
 	}
@@ -156,13 +156,13 @@ func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromKey(sec
 }
 
 // NewStreamCipherForDecryptionFromKey creates a new StreamCipher for decryption from a secret key
-func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromSerializedKey(secret []byte) (primitives.StreamCipher, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromSerializedKey(secret []byte) (primitives.StreamCipher, error) {
 	key, err := spi.NewSecretKey(nil, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	sc := aes256GSMStreamCipherImpl{}
+	sc := aes256GCMStreamCipherImpl{}
 	if err := sc.Init(true, key); err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForEncryptionFromSeriali
 }
 
 // NewStreamCipherForDecryptionFromKey creates a new StreamCipher for decryption from a secret key
-func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromKey(secret primitives.SecretKey) (primitives.StreamCipher, error) {
-	sc := aes256GSMStreamCipherImpl{}
+func (spi *aes256GCMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromKey(secret primitives.SecretKey) (primitives.StreamCipher, error) {
+	sc := aes256GCMStreamCipherImpl{}
 	if err := sc.Init(false, secret); err != nil {
 		return nil, err
 	}
@@ -181,13 +181,13 @@ func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromKey(sec
 }
 
 // NewStreamCipherForDecryptionFromKey creates a new StreamCipher for decryption from a secret key
-func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromSerializedKey(secret []byte) (primitives.StreamCipher, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromSerializedKey(secret []byte) (primitives.StreamCipher, error) {
 	key, err := spi.NewSecretKey(nil, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	sc := aes256GSMStreamCipherImpl{}
+	sc := aes256GCMStreamCipherImpl{}
 	if err := sc.Init(false, key); err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (spi *aes256GSMStreamCipherSPIImpl) NewStreamCipherForDecryptionFromSeriali
 }
 
 // SerializePrivateKey serializes a private key
-func (spi *aes256GSMStreamCipherSPIImpl) SerializeSecretKey(secret primitives.SecretKey) ([]byte, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) SerializeSecretKey(secret primitives.SecretKey) ([]byte, error) {
 	if secret == nil {
 		return nil, nil
 	}
@@ -210,14 +210,14 @@ func (spi *aes256GSMStreamCipherSPIImpl) SerializeSecretKey(secret primitives.Se
 }
 
 // DeserializePrivateKey deserializes to a private key
-func (spi *aes256GSMStreamCipherSPIImpl) DeserializeSecretKey(bytes []byte) (primitives.SecretKey, error) {
+func (spi *aes256GCMStreamCipherSPIImpl) DeserializeSecretKey(bytes []byte) (primitives.SecretKey, error) {
 	if len(bytes) >= 32 {
 		return &aesSecretKeyImpl{bytes[:32], rand.Reader}, nil
 	}
 	return nil, primitives.ErrInvalidKeyParameter
 }
 
-// NewAES256GSMSPI returns a new SPI instance for AES256 in GSM mode
-func NewAES256GSMSPI() primitives.StreamCipherSPI {
-	return &aes256GSMStreamCipherSPIImpl{}
+// NewAES256GCMSPI returns a new SPI instance for AES256 in GCM mode
+func NewAES256GCMSPI() primitives.StreamCipherSPI {
+	return &aes256GCMStreamCipherSPIImpl{}
 }

--- a/core/crypto/primitives/aes/gcm_test.go
+++ b/core/crypto/primitives/aes/gcm_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 )
 
-func TestAES256GSMSPIGenerateKey(t *testing.T) {
-	spi := NewAES256GSMSPI()
+func TestAES256GCMSPIGenerateKey(t *testing.T) {
+	spi := NewAES256GCMSPI()
 
 	// Generate Key
 	key, err := spi.GenerateKey()
@@ -63,8 +63,8 @@ func TestAES256GSMSPIGenerateKey(t *testing.T) {
 	}
 }
 
-func TestAES256GSMSPIGenerateKeyAndSerialize(t *testing.T) {
-	spi := NewAES256GSMSPI()
+func TestAES256GCMSPIGenerateKeyAndSerialize(t *testing.T) {
+	spi := NewAES256GCMSPI()
 
 	// Generate Key and serialize
 	key, keySer, err := spi.GenerateKeyAndSerialize()
@@ -119,8 +119,8 @@ func TestAES256GSMSPIGenerateKeyAndSerialize(t *testing.T) {
 	}
 }
 
-func TestAES256GSMSPINewStreamCipher(t *testing.T) {
-	spi := NewAES256GSMSPI()
+func TestAES256GCMSPINewStreamCipher(t *testing.T) {
+	spi := NewAES256GCMSPI()
 
 	_, err := spi.NewStreamCipherForEncryptionFromKey(nil)
 	if err == nil {
@@ -154,8 +154,8 @@ func TestAES256GSMSPINewStreamCipher(t *testing.T) {
 
 }
 
-func TestAES256GSMSPIDencryption(t *testing.T) {
-	spi := NewAES256GSMSPI()
+func TestAES256GCMSPIDencryption(t *testing.T) {
+	spi := NewAES256GCMSPI()
 
 	// Generate Key
 	key, err := spi.GenerateKey()
@@ -190,8 +190,8 @@ func TestAES256GSMSPIDencryption(t *testing.T) {
 
 }
 
-func TestAES256GSMSPI(t *testing.T) {
-	spi := NewAES256GSMSPI()
+func TestAES256GCMSPI(t *testing.T) {
+	spi := NewAES256GCMSPI()
 
 	// Gen Key
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

This PR contains refactoring of the package crypto/primitives/aes.  As noted in #2111, there was a misspelling of the encryption mode. It was GSM, it is now GCM.

Notice that AES-GCM is not currently used. It is there to support the next processing transaction module.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2111
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

The PR does not change the functionality of the encryption.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
