### PR TITLE
Add untracked Go files to docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,9 @@ build/image/src/.dummy: build/image/base/.dummy $(PROJECT_FILES)
 	@echo "Building docker src-image"
 	@mkdir -p $(@D)
 	@cat images/src/Dockerfile.in > $(@D)/Dockerfile
-	@git ls-files | tar -jcT - > $(@D)/gopath.tar.bz2
+	@git ls-files | tar -cT - > $(@D)/gopath.tar
+	@tar --update -f $(@D)/gopath.tar `find * -name *.go` # Include Go files not tracked by Git (issue #2158)
+	@bzip2 -f $(@D)/gopath.tar
 	docker build -t $(PROJECT_NAME)-src:latest $(@D)
 	@touch $@
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Allows untracked Go files to be added to the docker src image so that local changes do not have to be checked in to be used during development
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes issue #2158.
During development new Go files will be created, this allows Devs to use these files in the docker containers without checking them in.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

This is not a code change, so I have not added any new test cases. I have tested this by running `make checks` which has verified this hasn't broken any of the build process.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
