### PR TITLE
Fix bugs in hlc.ts-The this notation in function private newNetModeTr…

### DIFF
--- a/sdk/node/src/hfc.ts
+++ b/sdk/node/src/hfc.ts
@@ -1769,11 +1769,11 @@ export class TransactionContext extends events.EventEmitter {
                         let nonceRaw = new Buffer(self.nonce);
                         let bindingMsg = Buffer.concat([certRaw, nonceRaw]);
                         // debug('========== Binding Msg [%s]', bindingMsg.toString('hex'));
-                        this.binding = new Buffer(self.chain.cryptoPrimitives.hash(bindingMsg), 'hex');
-                        // debug('========== Binding [%s]', this.binding.toString('hex'));
+                        self.binding = new Buffer(self.chain.cryptoPrimitives.hash(bindingMsg), 'hex');
+                        // debug('========== Binding [%s]', self.binding.toString('hex'));
                         let ctor = chaincodeSpec.getCtorMsg().toBuffer();
                         // debug('========== Ctor [%s]', ctor.toString('hex'));
-                        let txmsg = Buffer.concat([ctor, this.binding]);
+                        let txmsg = Buffer.concat([ctor, self.binding]);
                         // debug('========== Payload||binding [%s]', txmsg.toString('hex'));
                         let mdsig = self.chain.cryptoPrimitives.ecdsaSign(request.userCert.privateKey.getPrivate('hex'), txmsg);
                         let sigma = new Buffer(mdsig.toDER());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

In the file sdk/node/src/hfc.ts, in the function newNetModeTransaction, in the if block "if (request.userCert) {}", change "this" to "self". 
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2157
The "this" is not referred to the correct object. Which lead to the following error:
/opt/gopath/src/github.com/hyperledger/fabric/sdk/node/lib/hlc.js:1342
                        this.binding = new Buffer(self.chain.cryptoPrimitives.
                                     ^
TypeError: Cannot set property 'binding' of undefined
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

First, go to /opt/gopath/src/github.com/hyperledger/fabric/sdk/node/ and make to build.
Then, start membersrvc and peer in net mode. Enroll a user and deploy a chaincode. In the deployrequest, add the userCert gotten from getNextTCert of member object.
The error is removed with the above changes.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: zhoy zhang.4746@osu.edu
…ansaction is not recognized. Change it to self.Fixed #2157
