### PR TITLE
Fix #1959 Print version info

### DIFF
--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -23,25 +23,29 @@ To view the currently available CLI commands, execute the following:
 You will see output similar to the example below (**NOTE:** rootcommand below is hardcoded in [main.go](https://github.com/hyperledger/fabric/blob/master/main.go). Currently, the build will create a *peer* executable file).
 
 ```
-    Usage:
+    Usage: 
+      peer [flags]
       peer [command]
-
-    Available Commands:
+    
+    Available Commands: 
+      version     Print fabric peer version.
       node        node specific commands.
       network     network specific commands.
       chaincode   chaincode specific commands.
       help        Help about any command
-
+    
     Flags:
       -h, --help[=false]: help for peer
           --logging-level="": Default logging level and overrides, see core.yaml for full syntax
-
-
+          --test.coverprofile="coverage.cov": Done
+      -v, --version[=false]: Show current version number of fabric peer server
+    
+    
     Use "peer [command] --help" for more information about a command.
 
 ```
 
-The `peer` command supports several subcommands, as shown above. To
+The `peer` command supports several subcommands and flags, as shown above. To
 facilitate its use in scripted applications, the `peer` command always
 produces a non-zero return code in the event of command failure. Upon success,
 many of the subcommands produce a result on **stdout** as shown in the table
@@ -49,6 +53,7 @@ below:
 
 Command | **stdout** result in the event of success
 --- | ---
+`peer version`     | String form of `peer.version` defined in [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml)
 `node start`       | N/A
 `node status`      | String form of [StatusCode](https://github.com/hyperledger/fabric/blob/master/protos/server_admin.proto#L36)
 `node stop`        | String form of [StatusCode](https://github.com/hyperledger/fabric/blob/master/protos/server_admin.proto#L36)

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -53,7 +53,7 @@ below:
 
 Command | **stdout** result in the event of success
 --- | ---
-`peer version`     | String form of `peer.version` defined in [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml)
+`version`          | String form of `peer.version` defined in [core.yaml](https://github.com/hyperledger/fabric/blob/master/peer/core.yaml)
 `node start`       | N/A
 `node status`      | String form of [StatusCode](https://github.com/hyperledger/fabric/blob/master/protos/server_admin.proto#L36)
 `node stop`        | String form of [StatusCode](https://github.com/hyperledger/fabric/blob/master/protos/server_admin.proto#L36)

--- a/docs/API/CoreAPI.md
+++ b/docs/API/CoreAPI.md
@@ -33,14 +33,14 @@ You will see output similar to the example below (**NOTE:** rootcommand below is
       network     network specific commands.
       chaincode   chaincode specific commands.
       help        Help about any command
-    
+
     Flags:
       -h, --help[=false]: help for peer
           --logging-level="": Default logging level and overrides, see core.yaml for full syntax
           --test.coverprofile="coverage.cov": Done
       -v, --version[=false]: Show current version number of fabric peer server
-    
-    
+
+
     Use "peer [command] --help" for more information about a command.
 
 ```

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -62,10 +62,12 @@ logging:
     #
     # Developers: Please see fabric/docs/dev-setup/logging-control.md for more
     # options.
+    peer: warning
 
     node:      info
     network:   warning
     chaincode: warning
+    version: warning
 
 ###############################################################################
 #

--- a/peer/main.go
+++ b/peer/main.go
@@ -95,7 +95,7 @@ var mainCmd = &cobra.Command{
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print fabric peer version.",
-	Long:  `Print current version number of fabric peer server.`,
+	Long:  `Print current version of fabric peer server.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		core.LoggingInit("version")
 	},
@@ -263,7 +263,7 @@ func main() {
 	// Define command-line flags that are valid for all peer commands and
 	// subcommands.
 	mainFlags := mainCmd.PersistentFlags()
-	mainFlags.BoolVarP(&versionFlag, "version", "v", false, "Show current version number of fabric peer server")
+	mainFlags.BoolVarP(&versionFlag, "version", "v", false, "Display current version of fabric peer server")
 
 	mainFlags.String("logging-level", "", "Default logging level and overrides, see core.yaml for full syntax")
 	viper.BindPFlag("logging_level", mainFlags.Lookup("logging-level"))

--- a/peer/main.go
+++ b/peer/main.go
@@ -77,6 +77,31 @@ var mainCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return core.CacheConfiguration()
 	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		core.LoggingInit("peer")
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if versionFlag {
+			showVersion()
+		} else {
+			cmd.HelpFunc()(cmd, args)
+		}
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print fabric peer version.",
+	Long:  `Print current version number of fabric peer server.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		core.LoggingInit("version")
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		showVersion()
+	},
 }
 
 var nodeCmd = &cobra.Command{
@@ -184,6 +209,9 @@ var (
 	customIDGenAlg          string
 )
 
+// Peer command version flag
+var versionFlag bool
+
 var chaincodeCmd = &cobra.Command{
 	Use:   chainFuncName,
 	Short: fmt.Sprintf("%s specific commands.", chainFuncName),
@@ -235,6 +263,8 @@ func main() {
 	// Define command-line flags that are valid for all peer commands and
 	// subcommands.
 	mainFlags := mainCmd.PersistentFlags()
+	mainFlags.BoolVarP(&versionFlag, "version", "v", false, "Show current version number of fabric peer server")
+
 	mainFlags.String("logging-level", "", "Default logging level and overrides, see core.yaml for full syntax")
 	viper.BindPFlag("logging_level", mainFlags.Lookup("logging-level"))
 	testCoverProfile := ""
@@ -272,8 +302,8 @@ func main() {
 	nodeStopCmd.Flags().StringVar(&stopPidFile, "stop-peer-pid-file", viper.GetString("peer.fileSystemPath"), "Location of peer pid local file, for forces kill")
 	nodeCmd.AddCommand(nodeStopCmd)
 
+	mainCmd.AddCommand(versionCmd)
 	mainCmd.AddCommand(nodeCmd)
-
 	// Set the flags on the login command.
 	networkLoginCmd.PersistentFlags().StringVarP(&loginPW, "password", "p", undefinedParamValue, "The password for user. You will be requested to enter the password if this flag is not specified.")
 
@@ -381,6 +411,11 @@ func getSecHelper() (crypto.Peer, error) {
 		}
 	})
 	return secHelper, err
+}
+
+func showVersion() {
+	version := viper.GetString("peer.version")
+	fmt.Printf("Fabric peer server version %s\n", version)
 }
 
 func serve(args []string) error {


### PR DESCRIPTION
## Description

Add version command and --version/-v flag for peer service.
## Motivation and Context

Fixes #1959 
## How Has This Been Tested?

make checks successful
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:Kai Chen ckaiwh@cn.ibm.com
