### PR TITLE
Fix #769 - Remove crypto package log level handling

### DIFF
--- a/core/crypto/crypto_settings.go
+++ b/core/crypto/crypto_settings.go
@@ -29,22 +29,7 @@ var (
 // Init initializes the crypto layer. It load from viper the security level
 // and the logging setting.
 func Init() (err error) {
-	// Init log
-	log.ExtraCalldepth++
-
-	level, err := logging.LogLevel(viper.GetString("logging.crypto"))
-	if err == nil {
-		// No error, use the setting
-		logging.SetLevel(level, "crypto")
-		log.Infof("Log level recognized '%s', set to %s", viper.GetString("logging.crypto"),
-			logging.GetLevel("crypto"))
-	} else {
-		log.Warningf("Log level not recognized '%s', defaulting to %s: %s", viper.GetString("logging.crypto"),
-			logging.GetLevel("crypto"), err)
-	}
-
 	// Init security level
-
 	securityLevel := 256
 	if viper.IsSet("security.level") {
 		ovveride := viper.GetInt("security.level")

--- a/core/crypto/crypto_settings_test.go
+++ b/core/crypto/crypto_settings_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/op/go-logging"
+	"github.com/spf13/viper"
+)
+
+func TestCryptoInitInheritsLoggingLevel(t *testing.T) {
+	logging.SetLevel(logging.WARNING, "crypto")
+
+	Init()
+
+	assertCryptoLoggingLevel(t, logging.WARNING)
+}
+
+func TestCryptoInitDoesntOverrideLoggingLevel(t *testing.T) {
+	logging.SetLevel(logging.WARNING, "crypto")
+	viper.Set("logging.crypto", "info")
+
+	Init()
+
+	assertCryptoLoggingLevel(t, logging.WARNING)
+}
+
+func assertCryptoLoggingLevel(t *testing.T, expected logging.Level) {
+	actual := logging.GetLevel("crypto")
+
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+	}
+}

--- a/peer/core.yaml
+++ b/peer/core.yaml
@@ -56,18 +56,16 @@ logging:
     #
     # 3. The environment variables CORE_LOGGING_[NODE|NETWORK|CHAINCODE]
     #    otherwise apply to the respective peer commands if defined as non-empty
-    #    strings. 
+    #    strings.
     #
     # 4. Otherwise, the specifications below apply.
     #
     # Developers: Please see fabric/docs/dev-setup/logging-control.md for more
-    # options. 
+    # options.
 
     node:      info
     network:   warning
     chaincode: warning
-
-    crypto:    info # This should not be here; See issue #769
 
 ###############################################################################
 #


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Remove log level retreval from crypto_settings.go and the configuration value from core.yaml
Add tests to prevent regressions
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #769. Prevents confusion on how logging is done by removing the override of the crypto package logging level.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Added test cases to ensure that the logging level doesn't get overridden. 
Manually verified that the crypto logs were following the level of the peer command.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
