### PR TITLE
Fix Issue #653 - Incorrect Logging Levels

### DIFF
--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -511,7 +511,7 @@ func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.
 		var targz io.Reader = bytes.NewBuffer(cds.CodePackage)
 		_, err = chaincodeSupport.launchAndWaitForRegister(context, cds, cID, t.Uuid, cLang, targz)
 		if err != nil {
-			chaincodeLogger.Debugf("launchAndWaitForRegister failed %s", err)
+			chaincodeLogger.Errorf("launchAndWaitForRegister failed %s", err)
 			return cID, cMsg, err
 		}
 	}
@@ -520,11 +520,11 @@ func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.
 		//send init (if (f,args)) and wait for ready state
 		err = chaincodeSupport.sendInitOrReady(context, t.Uuid, chaincode, f, initargs, chaincodeSupport.ccStartupTimeout, t, depTx)
 		if err != nil {
-			chaincodeLogger.Debugf("sending init failed(%s)", err)
+			chaincodeLogger.Errorf("sending init failed(%s)", err)
 			err = fmt.Errorf("Failed to init chaincode(%s)", err)
 			errIgnore := chaincodeSupport.Stop(context, cds)
 			if errIgnore != nil {
-				chaincodeLogger.Debugf("stop failed %s(%s)", errIgnore, err)
+				chaincodeLogger.Errorf("stop failed %s(%s)", errIgnore, err)
 			}
 		}
 		chaincodeLogger.Debug("sending init completed")

--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -312,7 +312,7 @@ func (handler *Handler) processStream() error {
 			}
 			chaincodeLogger.Debugf("[%s]Received message %s from shim", shortuuid(in.Uuid), in.Type.String())
 			if in.Type.String() == pb.ChaincodeMessage_ERROR.String() {
-				chaincodeLogger.Debugf("Got error: %s", string(in.Payload))
+				chaincodeLogger.Errorf("Got error: %s", string(in.Payload))
 			}
 
 			// we can spin off another Recv again
@@ -358,7 +358,7 @@ func (handler *Handler) processStream() error {
 		if nsInfo != nil && nsInfo.sendToCC {
 			chaincodeLogger.Debugf("[%s]sending state message %s", shortuuid(in.Uuid), in.Type.String())
 			if err = handler.serialSend(in); err != nil {
-				chaincodeLogger.Debugf("[%s]serial sending received error %s", shortuuid(in.Uuid), err)
+				chaincodeLogger.Errorf("[%s]serial sending received error %s", shortuuid(in.Uuid), err)
 				return fmt.Errorf("[%s]serial sending received error %s", shortuuid(in.Uuid), err)
 			}
 		}
@@ -465,7 +465,7 @@ func (handler *Handler) deleteUUIDEntry(uuid string) {
 	if handler.uuidMap != nil {
 		delete(handler.uuidMap, uuid)
 	} else {
-		chaincodeLogger.Warningf("UUID %s not found!", uuid)
+		chaincodeLogger.Errorf("UUID %s not found!", uuid)
 	}
 }
 
@@ -597,7 +597,7 @@ func (handler *Handler) handleGetState(msg *pb.ChaincodeMessage) {
 		uniqueReq := handler.createUUIDEntry(msg.Uuid)
 		if !uniqueReq {
 			// Drop this request
-			chaincodeLogger.Debug("Another state request pending for this Uuid. Cannot process.")
+			chaincodeLogger.Error("Another state request pending for this Uuid. Cannot process.")
 			return
 		}
 
@@ -678,7 +678,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 		uniqueReq := handler.createUUIDEntry(msg.Uuid)
 		if !uniqueReq {
 			// Drop this request
-			chaincodeLogger.Debug("Another state request pending for this Uuid. Cannot process.")
+			chaincodeLogger.Error("Another state request pending for this Uuid. Cannot process.")
 			return
 		}
 
@@ -694,7 +694,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 		unmarshalErr := proto.Unmarshal(msg.Payload, rangeQueryState)
 		if unmarshalErr != nil {
 			payload := []byte(unmarshalErr.Error())
-			chaincodeLogger.Debugf("Failed to unmarshall range query request. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed to unmarshall range query request. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -705,7 +705,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 		if ledgerErr != nil {
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(ledgerErr.Error())
-			chaincodeLogger.Debugf("Failed to get ledger. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed to get ledger. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -717,7 +717,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 		if err != nil {
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())
-			chaincodeLogger.Debugf("Failed to get ledger scan iterator. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed to get ledger scan iterator. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -736,7 +736,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 			decryptedValue, decryptErr := handler.decrypt(msg.Uuid, value)
 			if decryptErr != nil {
 				payload := []byte(decryptErr.Error())
-				chaincodeLogger.Debugf("Failed decrypt value. Sending %s", pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("Failed decrypt value. Sending %s", pb.ChaincodeMessage_ERROR)
 				serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 
 				rangeIter.Close()
@@ -763,7 +763,7 @@ func (handler *Handler) handleRangeQueryState(msg *pb.ChaincodeMessage) {
 
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())
-			chaincodeLogger.Debugf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -814,7 +814,7 @@ func (handler *Handler) handleRangeQueryStateNext(msg *pb.ChaincodeMessage) {
 		unmarshalErr := proto.Unmarshal(msg.Payload, rangeQueryStateNext)
 		if unmarshalErr != nil {
 			payload := []byte(unmarshalErr.Error())
-			chaincodeLogger.Debugf("Failed to unmarshall state range next query request. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed to unmarshall state range next query request. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -824,7 +824,7 @@ func (handler *Handler) handleRangeQueryStateNext(msg *pb.ChaincodeMessage) {
 
 		if rangeIter == nil {
 			payload := []byte("Range query iterator not found")
-			chaincodeLogger.Debugf("Range query iterator not found. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Range query iterator not found. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -838,7 +838,7 @@ func (handler *Handler) handleRangeQueryStateNext(msg *pb.ChaincodeMessage) {
 			decryptedValue, decryptErr := handler.decrypt(msg.Uuid, value)
 			if decryptErr != nil {
 				payload := []byte(decryptErr.Error())
-				chaincodeLogger.Debugf("Failed decrypt value. Sending %s", pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("Failed decrypt value. Sending %s", pb.ChaincodeMessage_ERROR)
 				serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 
 				rangeIter.Close()
@@ -865,7 +865,7 @@ func (handler *Handler) handleRangeQueryStateNext(msg *pb.ChaincodeMessage) {
 
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())
-			chaincodeLogger.Debugf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -900,7 +900,7 @@ func (handler *Handler) handleRangeQueryStateClose(msg *pb.ChaincodeMessage) {
 		uniqueReq := handler.createUUIDEntry(msg.Uuid)
 		if !uniqueReq {
 			// Drop this request
-			chaincodeLogger.Debug("Another state request pending for this Uuid. Cannot process.")
+			chaincodeLogger.Error("Another state request pending for this Uuid. Cannot process.")
 			return
 		}
 
@@ -916,7 +916,7 @@ func (handler *Handler) handleRangeQueryStateClose(msg *pb.ChaincodeMessage) {
 		unmarshalErr := proto.Unmarshal(msg.Payload, rangeQueryStateClose)
 		if unmarshalErr != nil {
 			payload := []byte(unmarshalErr.Error())
-			chaincodeLogger.Debugf("Failed to unmarshall state range query close request. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed to unmarshall state range query close request. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -934,7 +934,7 @@ func (handler *Handler) handleRangeQueryStateClose(msg *pb.ChaincodeMessage) {
 
 			// Send error msg back to chaincode. GetState will not trigger event
 			payload := []byte(err.Error())
-			chaincodeLogger.Debugf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("Failed marshall resopnse. Sending %s", pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -988,7 +988,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 		// First check if this UUID is a transaction; error otherwise
 		if !handler.getIsTransaction(msg.Uuid) {
 			payload := []byte(fmt.Sprintf("Cannot handle %s in query context", msg.Type.String()))
-			chaincodeLogger.Debugf("[%s]Cannot handle %s in query context. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Cannot handle %s in query context. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
 			errMsg := &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			handler.triggerNextState(errMsg, true)
 			return
@@ -999,7 +999,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 		uniqueReq := handler.createUUIDEntry(msg.Uuid)
 		if !uniqueReq {
 			// Drop this request
-			chaincodeLogger.Debug("Another request pending for this Uuid. Cannot process.")
+			chaincodeLogger.Error("Another request pending for this Uuid. Cannot process.")
 			return
 		}
 
@@ -1015,7 +1015,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 		if ledgerErr != nil {
 			// Send error msg back to chaincode and trigger event
 			payload := []byte(ledgerErr.Error())
-			chaincodeLogger.Debugf("[%s]Failed to handle %s. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Failed to handle %s. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
 			triggerNextStateMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -1029,7 +1029,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 			unmarshalErr := proto.Unmarshal(msg.Payload, putStateInfo)
 			if unmarshalErr != nil {
 				payload := []byte(unmarshalErr.Error())
-				chaincodeLogger.Debugf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 				triggerNextStateMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 				return
 			}
@@ -1053,7 +1053,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 			unmarshalErr := proto.Unmarshal(msg.Payload, chaincodeSpec)
 			if unmarshalErr != nil {
 				payload := []byte(unmarshalErr.Error())
-				chaincodeLogger.Debugf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 				triggerNextStateMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 				return
 			}
@@ -1069,7 +1069,7 @@ func (handler *Handler) enterBusyState(e *fsm.Event, state string) {
 			_, chaincodeInput, launchErr := handler.chaincodeSupport.Launch(context.Background(), transaction)
 			if launchErr != nil {
 				payload := []byte(launchErr.Error())
-				chaincodeLogger.Debugf("[%s]Failed to launch invoked chaincode. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("[%s]Failed to launch invoked chaincode. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 				triggerNextStateMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 				return
 			}
@@ -1137,7 +1137,7 @@ func (handler *Handler) enterReadyState(e *fsm.Event, state string) {
 	if ok && msg.ChaincodeEvent != nil && msg.ChaincodeEvent.Payload != nil {
 		var err error
 		if msg.Payload, err = handler.encrypt(msg.Uuid, msg.Payload); nil != err {
-			chaincodeLogger.Debug("[%s]Failed to encrypt chaincode event payload", msg.Uuid)
+			chaincodeLogger.Errorf("[%s]Failed to encrypt chaincode event payload", msg.Uuid)
 			msg.Payload = []byte(fmt.Sprintf("Failed to encrypt chaincode event payload %s", err.Error()))
 			msg.Type = pb.ChaincodeMessage_ERROR
 		}
@@ -1230,7 +1230,7 @@ func (handler *Handler) setChaincodeSecurityContext(tx *pb.Transaction, msg *pb.
 		msg.SecurityContext.CallerSign = tx.Signature
 		binding, err := handler.getSecurityBinding(tx)
 		if err != nil {
-			chaincodeLogger.Debugf("Failed getting binding [%s]", err)
+			chaincodeLogger.Errorf("Failed getting binding [%s]", err)
 			return err
 		}
 		msg.SecurityContext.Binding = binding
@@ -1239,13 +1239,13 @@ func (handler *Handler) setChaincodeSecurityContext(tx *pb.Transaction, msg *pb.
 		if tx.Type == pb.Transaction_CHAINCODE_INVOKE || tx.Type == pb.Transaction_CHAINCODE_QUERY {
 			cis := &pb.ChaincodeInvocationSpec{}
 			if err := proto.Unmarshal(tx.Payload, cis); err != nil {
-				chaincodeLogger.Debugf("Failed getting payload [%s]", err)
+				chaincodeLogger.Errorf("Failed getting payload [%s]", err)
 				return err
 			}
 
 			ctorMsgRaw, err := proto.Marshal(cis.ChaincodeSpec.GetCtorMsg())
 			if err != nil {
-				chaincodeLogger.Debugf("Failed getting ctorMsgRaw [%s]", err)
+				chaincodeLogger.Errorf("Failed getting ctorMsgRaw [%s]", err)
 				return err
 			}
 
@@ -1311,7 +1311,7 @@ func (handler *Handler) handleQueryChaincode(msg *pb.ChaincodeMessage) {
 		uniqueReq := handler.createUUIDEntry(msg.Uuid)
 		if !uniqueReq {
 			// Drop this request
-			chaincodeLogger.Debugf("[%s]Another request pending for this Uuid. Cannot process.", shortuuid(msg.Uuid))
+			chaincodeLogger.Errorf("[%s]Another request pending for this Uuid. Cannot process.", shortuuid(msg.Uuid))
 			return
 		}
 
@@ -1331,7 +1331,7 @@ func (handler *Handler) handleQueryChaincode(msg *pb.ChaincodeMessage) {
 		unmarshalErr := proto.Unmarshal(msg.Payload, chaincodeSpec)
 		if unmarshalErr != nil {
 			payload := []byte(unmarshalErr.Error())
-			chaincodeLogger.Debugf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Unable to decipher payload. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -1347,7 +1347,7 @@ func (handler *Handler) handleQueryChaincode(msg *pb.ChaincodeMessage) {
 		_, chaincodeInput, launchErr := handler.chaincodeSupport.Launch(context.Background(), transaction)
 		if launchErr != nil {
 			payload := []byte(launchErr.Error())
-			chaincodeLogger.Debugf("[%s]Failed to launch invoked chaincode. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Failed to launch invoked chaincode. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -1364,7 +1364,7 @@ func (handler *Handler) handleQueryChaincode(msg *pb.ChaincodeMessage) {
 		if execErr != nil {
 			// Send error msg back to chaincode and trigger event
 			payload := []byte(execErr.Error())
-			chaincodeLogger.Debugf("[%s]Failed to handle %s. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Failed to handle %s. Sending %s", shortuuid(msg.Uuid), msg.Type.String(), pb.ChaincodeMessage_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}
@@ -1394,7 +1394,7 @@ func (handler *Handler) HandleMessage(msg *pb.ChaincodeMessage) error {
 		handler.deleteIsTransaction(msg.Uuid)
 		var err error
 		if msg.Payload, err = handler.encrypt(msg.Uuid, msg.Payload); nil != err {
-			chaincodeLogger.Debugf("[%s]Failed to encrypt query result %s", msg.Uuid, string(msg.Payload))
+			chaincodeLogger.Errorf("[%s]Failed to encrypt query result %s", msg.Uuid, string(msg.Payload))
 			msg.Payload = []byte(fmt.Sprintf("Failed to encrypt query result %s", err.Error()))
 			msg.Type = pb.ChaincodeMessage_QUERY_ERROR
 		}
@@ -1417,7 +1417,7 @@ func (handler *Handler) HandleMessage(msg *pb.ChaincodeMessage) error {
 			// Check if this UUID is a transaction
 			if !handler.getIsTransaction(msg.Uuid) {
 				payload := []byte(fmt.Sprintf("[%s]Cannot handle %s in query context", msg.Uuid, msg.Type.String()))
-				chaincodeLogger.Debugf("[%s]Cannot handle %s in query context. Sending %s", msg.Uuid, msg.Type.String(), pb.ChaincodeMessage_ERROR)
+				chaincodeLogger.Errorf("[%s]Cannot handle %s in query context. Sending %s", msg.Uuid, msg.Type.String(), pb.ChaincodeMessage_ERROR)
 				errMsg := &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid}
 				handler.serialSend(errMsg)
 				return fmt.Errorf("Cannot handle %s in query context", msg.Type.String())
@@ -1430,7 +1430,7 @@ func (handler *Handler) HandleMessage(msg *pb.ChaincodeMessage) error {
 	eventErr := handler.FSM.Event(msg.Type.String(), msg)
 	filteredErr := filterError(eventErr)
 	if filteredErr != nil {
-		chaincodeLogger.Debugf("[%s]Failed to trigger FSM event %s: %s", msg.Uuid, msg.Type.String(), filteredErr)
+		chaincodeLogger.Errorf("[%s]Failed to trigger FSM event %s: %s", msg.Uuid, msg.Type.String(), filteredErr)
 	}
 
 	return filteredErr
@@ -1444,7 +1444,7 @@ func filterError(errFromFSMEvent error) error {
 				// Only allow NoTransitionError's, all others are considered true error.
 				return errFromFSMEvent
 			}
-			chaincodeLogger.Debugf("Ignoring NoTransitionError: %s", noTransitionErr)
+			chaincodeLogger.Warningf("Ignoring NoTransitionError: %s", noTransitionErr)
 		}
 		if canceledErr, ok := errFromFSMEvent.(*fsm.CanceledError); ok {
 			if canceledErr.Err != nil {
@@ -1452,7 +1452,7 @@ func filterError(errFromFSMEvent error) error {
 				return canceledErr
 				//t.Error("expected only 'NoTransitionError'")
 			}
-			chaincodeLogger.Debugf("Ignoring CanceledError: %s", canceledErr)
+			chaincodeLogger.Warningf("Ignoring CanceledError: %s", canceledErr)
 		}
 	}
 	return nil

--- a/core/chaincode/shim/handler.go
+++ b/core/chaincode/shim/handler.go
@@ -231,7 +231,7 @@ func (handler *Handler) handleInit(msg *pb.ChaincodeMessage) {
 		if err != nil {
 			payload := []byte(err.Error())
 			// Send ERROR message to chaincode support and change state
-			chaincodeLogger.Debugf("[%s]Init failed. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
+			chaincodeLogger.Errorf("[%s]Init failed. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_ERROR)
 			nextStateMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_ERROR, Payload: payload, Uuid: msg.Uuid, ChaincodeEvent: stub.chaincodeEvent}
 			return
 		}
@@ -345,7 +345,7 @@ func (handler *Handler) handleQuery(msg *pb.ChaincodeMessage) {
 		if err != nil {
 			payload := []byte(err.Error())
 			// Send ERROR message to chaincode support and change state
-			chaincodeLogger.Debugf("[%s]Query execution failed. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_QUERY_ERROR)
+			chaincodeLogger.Errorf("[%s]Query execution failed. Sending %s", shortuuid(msg.Uuid), pb.ChaincodeMessage_QUERY_ERROR)
 			serialSendMsg = &pb.ChaincodeMessage{Type: pb.ChaincodeMessage_QUERY_ERROR, Payload: payload, Uuid: msg.Uuid}
 			return
 		}

--- a/core/container/vm.go
+++ b/core/container/vm.go
@@ -122,7 +122,7 @@ func (vm *VM) buildChaincodeContainerUsingDockerfilePackageBytes(spec *pb.Chainc
 		OutputStream: outputbuf,
 	}
 	if err := vm.Client.BuildImage(opts); err != nil {
-		vmLogger.Debugf("Failed Chaincode docker build:\n%s\n", outputbuf.String())
+		vmLogger.Errorf("Failed Chaincode docker build:\n%s\n", outputbuf.String())
 		return fmt.Errorf("Error building Chaincode container: %s", err)
 	}
 	return nil

--- a/core/crypto/client_impl.go
+++ b/core/crypto/client_impl.go
@@ -268,12 +268,12 @@ func (client *clientImpl) init(id string, pwd []byte) error {
 func (client *clientImpl) close() (err error) {
 	if client.tCertPool != nil {
 		if err = client.tCertPool.Stop(); err != nil {
-			client.Debugf("Failed closing TCertPool [%s]", err)
+			client.Errorf("Failed closing TCertPool [%s]", err)
 		}
 	}
 
 	if err = client.nodeImpl.close(); err != nil {
-		client.Debugf("Failed closing node [%s]", err)
+		client.Errorf("Failed closing node [%s]", err)
 	}
 	return
 }

--- a/core/crypto/client_ks.go
+++ b/core/crypto/client_ks.go
@@ -28,13 +28,13 @@ func (client *clientImpl) initKeyStore() error {
 	// create tables
 	client.Debugf("Create Table if not exists [TCert] at [%s].", client.conf.getKeyStorePath())
 	if _, err := client.ks.sqlDB.Exec("CREATE TABLE IF NOT EXISTS TCerts (id INTEGER, attrhash VARCHAR, cert BLOB, prkz BLOB, PRIMARY KEY (id))"); err != nil {
-		client.Debugf("Failed creating table [%s].", err)
+		client.Errorf("Failed creating table [%s].", err)
 		return err
 	}
 
 	client.Debugf("Create Table if not exists [UsedTCert] at [%s].", client.conf.getKeyStorePath())
 	if _, err := client.ks.sqlDB.Exec("CREATE TABLE IF NOT EXISTS UsedTCert (id INTEGER, attrhash VARCHAR, cert BLOB, prkz BLOB, PRIMARY KEY (id))"); err != nil {
-		client.Debugf("Failed creating table [%s].", err)
+		client.Errorf("Failed creating table [%s].", err)
 		return err
 	}
 

--- a/core/crypto/client_tca.go
+++ b/core/crypto/client_tca.go
@@ -78,7 +78,7 @@ func (client *clientImpl) loadTCertOwnerKDFKey() error {
 	client.Debug("Loading TCertOwnerKDFKey...")
 
 	if !client.ks.isAliasSet(client.conf.getTCertOwnerKDFKeyFilename()) {
-		client.Debug("Failed loading TCertOwnerKDFKey. Key is missing.")
+		client.Error("Failed loading TCertOwnerKDFKey. Key is missing.")
 
 		return nil
 	}
@@ -100,7 +100,7 @@ func (client *clientImpl) getTCertFromExternalDER(der []byte) (tCert, error) {
 	// DER to x509
 	x509Cert, err := primitives.DERToX509Certificate(der)
 	if err != nil {
-		client.Debugf("Failed parsing certificate [% x]: [%s].", der, err)
+		client.Errorf("Failed parsing certificate [% x]: [%s].", der, err)
 
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (client *clientImpl) getTCertFromDER(certBlk *TCertDBBlock) (certBlock *TCe
 	// DER to x509
 	x509Cert, err := primitives.DERToX509Certificate(certBlk.tCertDER)
 	if err != nil {
-		client.Debugf("Failed parsing certificate [% x]: [%s].", certBlk.tCertDER, err)
+		client.Errorf("Failed parsing certificate [% x]: [%s].", certBlk.tCertDER, err)
 
 		return
 	}
@@ -382,7 +382,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 	// Contact the TCA
 	TCertOwnerKDFKey, certDERs, err := client.callTCACreateCertificateSet(num, attributes)
 	if err != nil {
-		client.Debugf("Failed contacting TCA [%s].", err.Error())
+		client.Errorf("Failed contacting TCA [%s].", err.Error())
 
 		return err
 	}
@@ -418,7 +418,7 @@ func (client *clientImpl) getTCertsFromTCA(attrhash string, attributes []string,
 		x509Cert, err := primitives.DERToX509Certificate(certDERs[i].Cert)
 		prek0 := certDERs[i].Prek0
 		if err != nil {
-			client.Debugf("Failed parsing certificate [% x]: [%s].", certDERs[i].Cert, err)
+			client.Errorf("Failed parsing certificate [% x]: [%s].", certDERs[i].Cert, err)
 
 			continue
 		}

--- a/core/crypto/crypto_settings.go
+++ b/core/crypto/crypto_settings.go
@@ -63,7 +63,7 @@ func Init() (err error) {
 
 	log.Debugf("Working at security level [%d]", securityLevel)
 	if err = primitives.InitSecurityLevel(hashAlgorithm, securityLevel); err != nil {
-		log.Debugf("Failed setting security level: [%s]", err)
+		log.Errorf("Failed setting security level: [%s]", err)
 
 		return
 	}

--- a/core/crypto/node_ks.go
+++ b/core/crypto/node_ks.go
@@ -325,13 +325,13 @@ func (ks *keyStore) createKeyStoreIfNotExists() error {
 	if !missing {
 		// Check keystore file
 		missing, err = utils.FileMissing(ks.node.conf.getKeyStorePath(), ks.node.conf.getKeyStoreFilename())
-		ks.node.Debugf("Keystore [%s] missing [%t]:[%s]", ks.node.conf.getKeyStoreFilePath(), missing, utils.ErrToString(err))
+		ks.node.Errorf("Keystore [%s] missing [%t]:[%s]", ks.node.conf.getKeyStoreFilePath(), missing, utils.ErrToString(err))
 	}
 
 	if missing {
 		err := ks.createKeyStore()
 		if err != nil {
-			ks.node.Errorf("Failed creating db At [%s]: ", ks.node.conf.getKeyStoreFilePath(), err.Error())
+			ks.node.Errorf("Failed creating db At [%s]: [%s]", ks.node.conf.getKeyStoreFilePath(), err.Error())
 			return nil
 		}
 	}

--- a/core/crypto/node_ks.go
+++ b/core/crypto/node_ks.go
@@ -331,7 +331,7 @@ func (ks *keyStore) createKeyStoreIfNotExists() error {
 	if missing {
 		err := ks.createKeyStore()
 		if err != nil {
-			ks.node.Debugf("Failed creating db At [%s]: ", ks.node.conf.getKeyStoreFilePath(), err.Error())
+			ks.node.Errorf("Failed creating db At [%s]: ", ks.node.conf.getKeyStoreFilePath(), err.Error())
 			return nil
 		}
 	}

--- a/core/crypto/peer_ks.go
+++ b/core/crypto/peer_ks.go
@@ -27,7 +27,7 @@ func (peer *peerImpl) initKeyStore() error {
 	// create tables
 	peer.Debugf("Create Table [%s] if not exists", "Certificates")
 	if _, err := peer.ks.sqlDB.Exec("CREATE TABLE IF NOT EXISTS Certificates (id VARCHAR, certsign BLOB, certenc BLOB, PRIMARY KEY (id))"); err != nil {
-		peer.Debugf("Failed creating table [%s].", err.Error())
+		peer.Errorf("Failed creating table [%s].", err.Error())
 		return err
 	}
 

--- a/core/devops.go
+++ b/core/devops.go
@@ -251,7 +251,7 @@ func (d *Devops) invokeOrQuery(ctx context.Context, chaincodeInvocationSpec *pb.
 	} else {
 		if !invoke && nil != sec && viper.GetBool("security.privacy") {
 			if resp.Msg, err = sec.DecryptQueryResult(transaction, resp.Msg); nil != err {
-				devopsLogger.Debugf("Failed decrypting query transaction result %s", string(resp.Msg[:]))
+				devopsLogger.Errorf("Failed decrypting query transaction result %s", string(resp.Msg[:]))
 				//resp = &pb.Response{Status: pb.Response_FAILURE, Msg: []byte(err.Error())}
 			}
 		}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Replace a number of Debug log statements with Error log statements as they were reporting errors, not debug information.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #653 
It will be easier for users to determine why things are not working if errors are reported correctly.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

There is no logic changes, so hence no new unit tests.
I have ensured the code builds.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
