### PR TITLE
Addressing Issue #2145: Transaction's certificate validation

### DIFF
--- a/core/crypto/client_tx.go
+++ b/core/crypto/client_tx.go
@@ -17,11 +17,12 @@ limitations under the License.
 package crypto
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/crypto/primitives"
 	"github.com/hyperledger/fabric/core/crypto/utils"
 	obc "github.com/hyperledger/fabric/protos"
-	"fmt"
 )
 
 func (client *clientImpl) createTransactionNonce() ([]byte, error) {

--- a/core/crypto/crypto_test.go
+++ b/core/crypto/crypto_test.go
@@ -757,6 +757,19 @@ func TestPeerDeployTransaction(t *testing.T) {
 		}
 		tx.Cert = oldCert
 
+		// Test self signed certificate Cert
+		oldCert = tx.Cert
+		rawSelfSignedCert, _, err := primitives.NewSelfSignedCert()
+		if err != nil {
+			t.Fatalf("Failed creating self signed cert [%s]", err)
+		}
+		tx.Cert = rawSelfSignedCert
+		_, err = peer.TransactionPreValidation(tx)
+		if err == nil {
+			t.Fatalf("Pre Validatiotn should fail. Invalid Cert. %s", err)
+		}
+		tx.Cert = oldCert
+
 		// Test invalid Signature
 		oldSig = tx.Signature
 		tx.Signature = []byte{0, 1, 2, 3, 4}

--- a/core/crypto/peer_impl.go
+++ b/core/crypto/peer_impl.go
@@ -69,7 +69,27 @@ func (peer *peerImpl) TransactionPreValidation(tx *obc.Transaction) (*obc.Transa
 			return tx, err
 		}
 
-		// TODO: verify cert
+		// Verify transaction certificate against root
+		// DER to x509
+		x509Cert, err := primitives.DERToX509Certificate(tx.Cert)
+		if err != nil {
+			peer.Debugf("Failed parsing certificate [% x]: [%s].", tx.Cert, err)
+
+			return tx, err
+		}
+
+		// 1. Get rid of the extensions that cannot be checked now
+		x509Cert.UnhandledCriticalExtensions = nil
+		// 2. Check against TCA certPool
+		if _, err = primitives.CheckCertAgainRoot(x509Cert, peer.tcaCertPool); err != nil {
+			peer.Warningf("Failed verifing certificate against TCA cert pool [%s].", err.Error())
+			// 3. Check against ECA certPool, if this check also fails then return an error
+			if _, err = primitives.CheckCertAgainRoot(x509Cert, peer.ecaCertPool); err != nil {
+				peer.Warningf("Failed verifing certificate against ECA cert pool [%s].", err.Error())
+
+				return tx, fmt.Errorf("Certificate has not been signed by a trusted authority. [%s]", err)
+			}
+		}
 
 		// 3. Marshall tx without signature
 		signature := tx.Signature


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

This PR introduces code to ensure that the certificate attached to a transaction is valid meaning that it has been signed by the either the ECA or the TCA.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2145 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

The tests has been enhanced to verify that a transaction with an invalid certificate fails verification.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Angelo De Caro adc@zurich.ibm.com
