### PR TITLE
Split travis build into multiple jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
 sudo: required
 services:
  - docker
+env:
+    - TEST_TARGET=unit-test
+    - TEST_TARGET=behave
 
 before_install:
 
@@ -39,14 +42,14 @@ before_script:
  - sudo rm -rf /var/hyperledger/ && sudo mkdir /var/hyperledger/ && sudo chown $USER:$USER /var/hyperledger
  - cd /$HOME/gopath/src/github.com/hyperledger/fabric
  - make linter
- - make unit-test
 
 script:
 
- - echo "Executing Behave test scripts"
+ - echo "Executing Tests"
  - cd $HOME/gopath/src/github.com/hyperledger/fabric
  - sed -i -e 's/172.17.0.1:2375\b/'"$ip:$port"'/g' $HOME/gopath/src/github.com/hyperledger/fabric/bddtests/compose-defaults.yml
- - make behave BEHAVE_OPTS="-D logs=Y -o testsummary.log"
+ - export BEHAVE_OPTS="-D logs=Y -o testsummary.log" #Defined to both jobs.
+ - make $TEST_TARGET
 
 after_failure:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

In order to reduce build times I propose split travis build into two jobs:
- A job for unit tests.
- A job for behave tests.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Travis has a time restriction of 50 minutes per job, sometimes, as in #2128 the error "The job exceeded the maximum time limit for jobs, and has been terminated." is showed. Splitting the build into two jobs could help to minimize the occurrences of this error.  
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [X] This change requires no new documentation.
- [X] This change requires no new tests.
- [X] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Andres Garagiola andresgaragiola@gmail.com / garagiol@ar.ibm.com
