### PR TITLE
Fix Issue #809 - Add Error Logging for Development Chaincode

### DIFF
--- a/bddtests/docker-compose-1-devmode.yml
+++ b/bddtests/docker-compose-1-devmode.yml
@@ -11,6 +11,6 @@ ccenv:
   environment:
     - CORE_CHAINCODE_ID_NAME=testCC
     - CORE_PEER_ADDRESS=vp0:30303
-  command: bash -c "go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && $GOPATH/bin/chaincode_example02"
+  command: bash -c "GOBIN=/opt/gopath/bin go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && /opt/gopath/bin/chaincode_example02"
   links:
     - vp0

--- a/bddtests/docker-compose-1-devmode.yml
+++ b/bddtests/docker-compose-1-devmode.yml
@@ -1,0 +1,16 @@
+vp0:
+  extends:
+    file: compose-defaults.yml
+    service: vp
+  environment:
+    - CORE_PEER_ID=vp0
+  command: sh -c "sleep 5; peer node start --peer-chaincodedev"
+
+ccenv:
+  image: hyperledger/fabric-ccenv
+  environment:
+    - CORE_CHAINCODE_ID_NAME=testCC
+    - CORE_PEER_ADDRESS=vp0:30303
+  command: 'go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && $GOPATH/bin/chaincode_example02'
+  links:
+    - vp0

--- a/bddtests/docker-compose-1-devmode.yml
+++ b/bddtests/docker-compose-1-devmode.yml
@@ -4,13 +4,13 @@ vp0:
     service: vp
   environment:
     - CORE_PEER_ID=vp0
-  command: sh -c "sleep 5; peer node start --peer-chaincodedev"
+  command: sh -c "peer node start --peer-chaincodedev"
 
 ccenv:
   image: hyperledger/fabric-ccenv
   environment:
     - CORE_CHAINCODE_ID_NAME=testCC
     - CORE_PEER_ADDRESS=vp0:30303
-  command: 'go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && $GOPATH/bin/chaincode_example02'
+  command: bash -c "go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && $GOPATH/bin/chaincode_example02"
   links:
     - vp0

--- a/bddtests/peer_logging.feature
+++ b/bddtests/peer_logging.feature
@@ -1,0 +1,44 @@
+#
+# Test Logging Features of Peers
+#
+# Tags that can be used and will affect test internals:
+#  @doNotDecompose will NOT decompose the named compose_yaml after scenario ends.  Useful for setting up environment and reviewing after scenario.
+#  @chaincodeImagesUpToDate use this if all scenarios chaincode images are up to date, and do NOT require building.  BE SURE!!!
+
+Feature: Peer Logging
+    As a Fabric Developer
+    I want to verify my Peers log correctly
+
+    Scenario: Invoke is attempted after deploy in Dev Mode
+    Given we compose "docker-compose-1-devmode.yml"
+    When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
+        | arg1 |  arg2 | arg3 | arg4 |
+	    |  a   |  100  |  b   |  200 |
+    And I invoke chaincode "example2" function name "invoke" on "vp0"
+        |arg1|arg2|arg3|
+		| a  | b  | 10 |
+    Then ensure after 5 seconds there is no errors in the logs for peer vp0
+
+    Scenario: Query is attempted after deploy in Dev Mode
+    Given we compose "docker-compose-1-devmode.yml"
+    When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
+        | arg1 |  arg2 | arg3 | arg4 |
+	    |  a   |  100  |  b   |  200 |
+    And I query chaincode "example2" function name "query" on "vp0":
+            |arg1|
+            |  a |
+    Then ensure after 5 seconds there is no errors in the logs for peer vp0
+
+    Scenario: Invoke is attempted before deploy in Dev Mode
+    Given we compose "docker-compose-1-devmode.yml"
+    When I invoke chaincode "example2" function name "invoke" on "vp0"
+        |arg1|arg2|arg3|
+		| a  | b  | 10 |
+    Then I wait up to 5 seconds for an error in the logs for peer vp0
+
+    Scenario: Query is attempted before deploy in Dev Mode
+    Given we compose "docker-compose-1-devmode.yml"
+    When I query chaincode "example2" function name "query" on "vp0":
+            |arg1|
+            |  a |
+    Then I wait up to 5 seconds for an error in the logs for peer vp0

--- a/bddtests/peer_logging.feature
+++ b/bddtests/peer_logging.feature
@@ -14,31 +14,31 @@ Feature: Peer Logging
     When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
         | arg1 |  arg2 | arg3 | arg4 |
 	    |  a   |  100  |  b   |  200 |
-    And I invoke chaincode "example2" function name "invoke" on "vp0"
+    And I invoke chaincode "example02" function name "invoke" on "vp0"
         |arg1|arg2|arg3|
 		| a  | b  | 10 |
-    Then ensure after 5 seconds there is no errors in the logs for peer vp0
+    Then ensure after 2 seconds there are no errors in the logs for peer vp0
 
     Scenario: Query is attempted after deploy in Dev Mode
     Given we compose "docker-compose-1-devmode.yml"
     When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
         | arg1 |  arg2 | arg3 | arg4 |
 	    |  a   |  100  |  b   |  200 |
-    And I query chaincode "example2" function name "query" on "vp0":
-            |arg1|
-            |  a |
-    Then ensure after 5 seconds there is no errors in the logs for peer vp0
+    And I query chaincode "example02" function name "query" on "vp0":
+        |arg1|
+        |  a |
+    Then ensure after 2 seconds there are no errors in the logs for peer vp0
 
     Scenario: Invoke is attempted before deploy in Dev Mode
     Given we compose "docker-compose-1-devmode.yml"
-    When I invoke chaincode "example2" function name "invoke" on "vp0"
+    When I invoke chaincode "example02" function name "invoke" on "vp0"
         |arg1|arg2|arg3|
 		| a  | b  | 10 |
     Then I wait up to 5 seconds for an error in the logs for peer vp0
 
     Scenario: Query is attempted before deploy in Dev Mode
     Given we compose "docker-compose-1-devmode.yml"
-    When I query chaincode "example2" function name "query" on "vp0":
-            |arg1|
-            |  a |
+    When I query chaincode "example02" function name "query" on "vp0":
+        |arg1|
+        |  a |
     Then I wait up to 5 seconds for an error in the logs for peer vp0

--- a/bddtests/peer_logging.feature
+++ b/bddtests/peer_logging.feature
@@ -14,7 +14,7 @@ Feature: Peer Logging
     When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
         | arg1 |  arg2 | arg3 | arg4 |
 	    |  a   |  100  |  b   |  200 |
-    And I invoke chaincode "example02" function name "invoke" on "vp0"
+    And I invoke chaincode "testCC" function name "invoke" on "vp0"
         |arg1|arg2|arg3|
 		| a  | b  | 10 |
     Then ensure after 2 seconds there are no errors in the logs for peer vp0
@@ -24,21 +24,23 @@ Feature: Peer Logging
     When I deploy chaincode with name "testCC" and with ctor "init" to "vp0"
         | arg1 |  arg2 | arg3 | arg4 |
 	    |  a   |  100  |  b   |  200 |
-    And I query chaincode "example02" function name "query" on "vp0":
+    And I query chaincode "testCC" function name "query" on "vp0":
         |arg1|
         |  a |
     Then ensure after 2 seconds there are no errors in the logs for peer vp0
 
     Scenario: Invoke is attempted before deploy in Dev Mode
     Given we compose "docker-compose-1-devmode.yml"
-    When I invoke chaincode "example02" function name "invoke" on "vp0"
+    When I mock deploy chaincode with name "testCC"
+    And I invoke chaincode "testCC" function name "invoke" on "vp0"
         |arg1|arg2|arg3|
 		| a  | b  | 10 |
     Then I wait up to 5 seconds for an error in the logs for peer vp0
 
     Scenario: Query is attempted before deploy in Dev Mode
     Given we compose "docker-compose-1-devmode.yml"
-    When I query chaincode "example02" function name "query" on "vp0":
+    When I mock deploy chaincode with name "testCC"
+    And I query chaincode "testCC" function name "query" on "vp0":
         |arg1|
         |  a |
     Then I wait up to 5 seconds for an error in the logs for peer vp0

--- a/bddtests/steps/bdd_test_util.py
+++ b/bddtests/steps/bdd_test_util.py
@@ -80,15 +80,30 @@ def getUserRegistration(context, enrollId):
 
 def ipFromContainerNamePart(namePart, containerDataList):
     """Returns the IPAddress based upon a name part of the full container name"""
-    ip = None
-    containerNamePrefix = os.path.basename(os.getcwd()) + "_"
-    for containerData in containerDataList:
-        if containerData.containerName.startswith(containerNamePrefix + namePart):
-            ip = containerData.ipAddress
-    if ip == None:
-        raise Exception("Could not find container with namePart = {0}".format(namePart))
-    return ip
+    containerData = containerDataFromNamePart(namePart, containerDataList)
 
+    if containerData == None:
+        raise Exception("Could not find container with namePart = {0}".format(namePart))
+
+    return containerData.ipAddress
+
+def fullNameFromContainerNamePart(namePart, containerDataList):
+    containerData = containerDataFromNamePart(namePart, containerDataList)
+
+    if containerData == None:
+        raise Exception("Could not find container with namePart = {0}".format(namePart))
+
+    return containerData.containerName
+
+def containerDataFromNamePart(namePart, containerDataList):
+    containerNamePrefix = os.path.basename(os.getcwd()) + "_"
+    fullContainerName = containerNamePrefix + namePart
+
+    for containerData in containerDataList:
+        if containerData.containerName.startswith(fullContainerName):
+            return containerData
+
+    return None
 
 def getContainerDataValuesFromContext(context, aliases, callback):
     """Returns the IPAddress based upon a name part of the full container name"""

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -281,6 +281,15 @@ def getChaincodeTypeValue(chainLang):
         return 0
     return 1
 
+@when(u'I mock deploy chaincode with name "{chaincodeName}"')
+def step_impl(context, chaincodeName):
+    chaincode = {
+        "name": chaincodeName,
+        "language": "GOLANG"
+    }
+
+    context.chaincodeSpec = createChaincodeSpec(context, chaincode)
+
 @then(u'I should have received a chaincode name')
 def step_impl(context):
     if 'chaincodeSpec' in context:

--- a/bddtests/steps/peer_basic_impl.py
+++ b/bddtests/steps/peer_basic_impl.py
@@ -176,6 +176,98 @@ def step_impl(context, seconds):
 def step_impl(context, seconds):
     time.sleep(float(seconds))
 
+@when(u'I deploy lang chaincode "{chaincodePath}" of "{chainLang}" with ctor "{ctor}" to "{containerName}"')
+def step_impl(context, chaincodePath, chainLang, ctor, containerName):
+    print("Printing chaincode language " + chainLang)
+
+    chaincode = {
+        "path": chaincodePath,
+        "language": chainLang,
+        "constructor": ctor,
+        "args": getArgsFromContext(context),
+    }
+
+    deployChainCodeToContainer(context, chaincode, containerName)
+
+def getArgsFromContext(context):
+    args = []
+    if 'table' in context:
+       # There is ctor arguments
+       args = context.table[0].cells
+
+    return args
+
+@when(u'I deploy chaincode "{chaincodePath}" with ctor "{ctor}" to "{containerName}"')
+def step_impl(context, chaincodePath, ctor, containerName):
+    chaincode = {
+        "path": chaincodePath,
+        "language": "GOLANG",
+        "constructor": ctor,
+        "args": getArgsFromContext(context),
+    }
+
+    deployChainCodeToContainer(context, chaincode, containerName)
+
+@when(u'I deploy chaincode with name "{chaincodeName}" and with ctor "{ctor}" to "{containerName}"')
+def step_impl(context, chaincodeName, ctor, containerName):
+    chaincode = {
+        "name": chaincodeName,
+        "language": "GOLANG",
+        "constructor": ctor,
+        "args": getArgsFromContext(context),
+    }
+
+    deployChainCodeToContainer(context, chaincode, containerName)
+    time.sleep(2.0) # After #2068 implemented change this to only apply after a successful ping
+
+def deployChainCodeToContainer(context, chaincode, containerName):
+    ipAddress = bdd_test_util.ipFromContainerNamePart(containerName, context.compose_containers)
+    request_url = buildUrl(context, ipAddress, "/chaincode")
+    print("Requesting path = {0}".format(request_url))
+
+    chaincodeSpec = createChaincodeSpec(context, chaincode)
+    chaincodeOpPayload = createChaincodeOpPayload("deploy", chaincodeSpec)
+
+    resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeOpPayload), verify=False)
+    assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
+    context.response = resp
+    chaincodeName = resp.json()['result']['message']
+    chaincodeSpec['chaincodeID']['name'] = chaincodeName
+    context.chaincodeSpec = chaincodeSpec
+    print(json.dumps(chaincodeSpec, indent=4))
+    print("")
+
+def createChaincodeSpec(context, chaincode):
+    chaincode = validateChaincodeDictionary(chaincode)
+
+    chaincodeSpec = {
+        "type": getChaincodeTypeValue(chaincode["language"]),
+        "chaincodeID": {
+            "path" : chaincode["path"],
+            "name" : chaincode["name"]
+        },
+        "ctorMsg":  {
+            "function" : chaincode["constructor"],
+            "args" : chaincode["args"]
+        },
+    }
+
+    if 'userName' in context:
+        chaincodeSpec["secureContext"] = context.userName
+    if 'metadata' in context:
+        chaincodeSpec["metadata"] = context.metadata
+
+    return chaincodeSpec
+
+def validateChaincodeDictionary(chaincode):
+    chaincodeFields = ["path", "name", "language", "constructor", "args"]
+
+    for field in chaincodeFields:
+        if field not in chaincode:
+            chaincode[field] = ""
+
+    return chaincode
+
 def getChaincodeTypeValue(chainLang):
     if chainLang == "GOLANG":
         return 1
@@ -188,84 +280,6 @@ def getChaincodeTypeValue(chainLang):
     elif chainLang == "UNDEFINED":
         return 0
     return 1
-
-@when(u'I deploy lang chaincode "{chaincodePath}" of "{chainLang}" with ctor "{ctor}" to "{containerName}"')
-def step_impl(context, chaincodePath, chainLang, ctor, containerName):
-    print("Printing chaincode language " + chainLang)
-    ipAddress = bdd_test_util.ipFromContainerNamePart(containerName, context.compose_containers)
-    request_url = buildUrl(context, ipAddress, "/chaincode")
-    print("Requesting path = {0}".format(request_url))
-    args = []
-    if 'table' in context:
-       # There is ctor arguments
-       args = context.table[0].cells
-    #typeGolang =
-
-    # Create a ChaincodeSpec structure
-    chaincodeSpec = {
-        "type": getChaincodeTypeValue(chainLang),
-        "chaincodeID": {
-            "path" : chaincodePath,
-            "name" : ""
-        },
-        "ctorMsg":  {
-            "function" : ctor,
-            "args" : args
-        },
-    }
-    if 'userName' in context:
-        chaincodeSpec["secureContext"] = context.userName
-
-    chaincodeOpPayload = createChaincodeOpPayload("deploy", chaincodeSpec)
-
-    resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeOpPayload), verify=False)
-    assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
-    context.response = resp
-    chaincodeName = resp.json()['result']['message']
-    chaincodeSpec['chaincodeID']['name'] = chaincodeName
-    context.chaincodeSpec = chaincodeSpec
-    print(json.dumps(chaincodeSpec, indent=4))
-    print("")
-
-@when(u'I deploy chaincode "{chaincodePath}" with ctor "{ctor}" to "{containerName}"')
-def step_impl(context, chaincodePath, ctor, containerName):
-    ipAddress = bdd_test_util.ipFromContainerNamePart(containerName, context.compose_containers)
-    request_url = buildUrl(context, ipAddress, "/chaincode")
-    print("Requesting path = {0}".format(request_url))
-    args = []
-    if 'table' in context:
-          # There is ctor arguments
-          args = context.table[0].cells
-    typeGolang = 1
-
-    # Create a ChaincodeSpec structure
-    chaincodeSpec = {
-        "type": typeGolang,
-        "chaincodeID": {
-            "path" : chaincodePath,
-            "name" : ""
-        },
-        "ctorMsg":  {
-            "function" : ctor,
-            "args" : args
-        },
-        #"secureContext" : "binhn"
-    }
-    if 'userName' in context:
-        chaincodeSpec["secureContext"] = context.userName
-    if 'metadata' in context:
-        chaincodeSpec["metadata"] = context.metadata
-
-    chaincodeOpPayload = createChaincodeOpPayload("deploy", chaincodeSpec)
-
-    resp = requests.post(request_url, headers={'Content-type': 'application/json'}, data=json.dumps(chaincodeOpPayload), verify=False)
-    assert resp.status_code == 200, "Failed to POST to %s:  %s" %(request_url, resp.text)
-    context.response = resp
-    chaincodeName = resp.json()['result']['message']
-    chaincodeSpec['chaincodeID']['name'] = chaincodeName
-    context.chaincodeSpec = chaincodeSpec
-    print(json.dumps(chaincodeSpec, indent=4))
-    print("")
 
 @then(u'I should have received a chaincode name')
 def step_impl(context):

--- a/bddtests/steps/peer_logging_impl.py
+++ b/bddtests/steps/peer_logging_impl.py
@@ -1,0 +1,35 @@
+#
+# Copyright IBM Corp. 2016 All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import os.path
+import re
+import time
+import copy
+from datetime import datetime, timedelta
+from behave import *
+
+import sys, requests, json
+
+import bdd_test_util
+
+@then('I wait up to {waitTime} seconds for an error in the logs for peer {peerName}')
+def step_impl(context, waitTime, peerName):
+    pass
+
+@then('Then ensure after {waitTime} seconds there is no errors in the logs for peer {peerName}')
+def step_impl(context, waitTime, peerName):
+    pass

--- a/bddtests/steps/peer_logging_impl.py
+++ b/bddtests/steps/peer_logging_impl.py
@@ -28,7 +28,7 @@ import bdd_test_util
 
 @then(u'I wait up to {waitTime} seconds for an error in the logs for peer {peerName}')
 def step_impl(context, waitTime, peerName):
-    timeout = time.time() + waitTime
+    timeout = time.time() + float(waitTime)
     hasError = False
 
     while timeout > time.time():
@@ -49,7 +49,7 @@ def getPeerLogs(context, peerName):
     return stdout, stderr
 
 def logHasError(logText):
-    # All logs are on STDERR, this seems to be an acceptable heuristic for detecting errors
+    # This seems to be an acceptable heuristic for detecting errors
     return logText.find("-> ERRO") >= 0
 
 @then(u'ensure after {waitTime} seconds there are no errors in the logs for peer {peerName}')

--- a/core/chaincode/chaincode_support.go
+++ b/core/chaincode/chaincode_support.go
@@ -476,6 +476,11 @@ func (chaincodeSupport *ChaincodeSupport) Launch(context context.Context, t *pb.
 
 	if t.Type != pb.Transaction_CHAINCODE_DEPLOY {
 		ledger, ledgerErr := ledger.GetLedger()
+
+		if chaincodeSupport.userRunsCC {
+			chaincodeLogger.Error("You are attempting to perform an action other than Deploy on Chaincode that is not ready and you are in developer mode. Did you forget to Deploy your chaincode?")
+		}
+
 		if ledgerErr != nil {
 			return cID, cMsg, fmt.Errorf("Failed to get handle to ledger (%s)", ledgerErr)
 		}

--- a/scripts/provision/host.sh
+++ b/scripts/provision/host.sh
@@ -26,7 +26,7 @@ pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couc
 # Python grpc package for behave tests
 # Required to update six for grpcio
 pip install --ignore-installed six
-pip install 'grpcio==0.15'
+pip install --upgrade 'grpcio==0.13.1'
 
 # install ruby and apiaryio
 #apt-get install --yes ruby ruby-dev gcc

--- a/scripts/provision/host.sh
+++ b/scripts/provision/host.sh
@@ -16,6 +16,7 @@ apt-get install --yes libyaml-dev
 
 apt-get install --yes python-setuptools
 apt-get install --yes python-pip
+pip install --upgrade pip
 pip install behave
 pip install nose
 
@@ -25,7 +26,7 @@ pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couc
 # Python grpc package for behave tests
 # Required to update six for grpcio
 pip install --ignore-installed six
-pip install 'grpcio==0.13.1'
+pip install 'grpcio==0.15'
 
 # install ruby and apiaryio
 #apt-get install --yes ruby ruby-dev gcc


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Add Error message when a user attempts an action other than deploy when they are running their own chaincode and in Developer Mode
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #809 
The existing log messages were misleading for developers when they forgot to deploy chaincode before invoking or querying. This will flag that situation in the logs.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I have manually verified that an error message is generated when invoke is called on Chaincode that has not been deployed yet:

```
07:05:49.481 [chaincode] Launch -> DEBU 053 Container not in READY state(established)...send init/ready
07:05:49.483 [chaincode] Launch -> ERRO 054 You are attempting to perform an action other than Deploy on Chaincode that is not ready and you are in developer mode. Did you forget to Deploy your chaincode?
```

Unit testing this change looks overwhelming given the size of the function this is in and the lack of a mocking framework (not to mention the lack of any tests for this file at all). I am willing to try and get something in place if it is essential, otherwise I suggest testing this file should be done in another pull request.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
