### PR TITLE
Fixed ./dump_db_stats.go:67: openchainDB.Close undefined (type *db.Op…

### DIFF
--- a/tools/dbutility/dump_db_stats.go
+++ b/tools/dbutility/dump_db_stats.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	openchainDB := db.GetDBHandle()
-	defer openchainDB.Close()
+	defer openchainDB.DB.Close()
 	fmt.Println()
 	scan(openchainDB, "blockchainCF", openchainDB.BlockchainCF, blockDetailPrinter)
 	fmt.Println()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Simple change to allow script to execute. Was getting an error complaining about a missing Close method
## Motivation and Context

dump_db_stats.go will not run: ./dump_db_stats.go:67: openchainDB.Close undefined (type *db.Op…

Fixes #
## How Has This Been Tested?

No testing needed. Script ran as expected.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:

Signed-off-by: Luis Bathen lbathen@gmail.com
