### PR TITLE
[AES-CBC] Added more Unit-Tests 

### DIFF
--- a/core/crypto/primitives/aes_test.go
+++ b/core/crypto/primitives/aes_test.go
@@ -217,13 +217,13 @@ func TestCBCEncryptCBCPKCS7Decrypt_ExpectingFailure(t *testing.T) {
 
 	var msg = []byte("a 16 byte messag")
 
-	encrypted, encErr := CBCEncrypt(key, msg)
+	encrypted, encErr := primitives.CBCEncrypt(key, msg)
 
 	if encErr != nil {
 		t.Fatalf("Error encrypting message %v", encErr)
 	}
 
-	decrypted, dErr := CBCPKCS7Decrypt(key, encrypted)
+	decrypted, dErr := primitives.CBCPKCS7Decrypt(key, encrypted)
 
 	if dErr != nil {
 		// expected behaviour, decryption fails.
@@ -252,13 +252,13 @@ func TestCBCPKCS7EncryptCBCDecrypt_ExpectingCorruptMessage(t *testing.T) {
 	//                0123456789ABCDEF
 	var msg = []byte("a 16 byte messag")
 
-	encrypted, encErr := CBCPKCS7Encrypt(key, msg)
+	encrypted, encErr := primitives.CBCPKCS7Encrypt(key, msg)
 
 	if encErr != nil {
 		t.Fatalf("Error encrypting message %v", encErr)
 	}
 
-	decrypted, dErr := CBCDecrypt(key, encrypted)
+	decrypted, dErr := primitives.CBCDecrypt(key, encrypted)
 
 	if dErr != nil {
 		t.Fatalf("Error encrypting message %v, %v", dErr, decrypted)
@@ -289,7 +289,7 @@ func TestCBCPKCS7Encrypt_EmptyText(t *testing.T) {
 	var msg = []byte("")
 	t.Log("Message length: ", len(msg))
 
-	cipher, encErr := CBCPKCS7Encrypt(key, msg)
+	cipher, encErr := primitives.CBCPKCS7Encrypt(key, msg)
 	if encErr != nil {
 		t.Fatalf("Error encrypting message %v", encErr)
 	}
@@ -321,7 +321,7 @@ func TestCBCEncrypt_EmptyText(t *testing.T) {
 	var msg = []byte("")
 	t.Log("Message length: ", len(msg))
 
-	cipher, encErr := CBCEncrypt(key, msg)
+	cipher, encErr := primitives.CBCEncrypt(key, msg)
 	if encErr != nil {
 		t.Fatalf("Error encrypting message %v", encErr)
 	}
@@ -348,13 +348,13 @@ func TestCBCPKCS7Encrypt_IVIsRandom(t *testing.T) {
 
 	var msg = []byte("a message to encrypt")
 
-	cipher1, err := CBCPKCS7Encrypt(key, msg)
+	cipher1, err := primitives.CBCPKCS7Encrypt(key, msg)
 	if err != nil {
 		t.Fatalf("Error encrypting the message.")
 	}
 
 	// expecting a different IV if same message is encrypted with same key
-	cipher2, err := CBCPKCS7Encrypt(key, msg)
+	cipher2, err := primitives.CBCPKCS7Encrypt(key, msg)
 	if err != nil {
 		t.Fatalf("Error encrypting the message.")
 	}
@@ -381,7 +381,7 @@ func TestCBCPKCS7Encrypt_CipherLengthCorrect(t *testing.T) {
 	// --> expected cipher length = IV length (1 block) + 1 block message
 	//     =
 	var msg = []byte("short message")
-	cipher, err := CBCPKCS7Encrypt(key, msg)
+	cipher, err := primitives.CBCPKCS7Encrypt(key, msg)
 	if err != nil {
 		t.Fatal("Error encrypting the message.", cipher)
 	}
@@ -407,8 +407,8 @@ func TestCBCEncryptCBCDecrypt_KeyMismatch(t *testing.T) {
 
 	var msg = []byte("a message to be encrypted")
 
-	encrypted, _ := CBCEncrypt(key, msg)
-	decrypted, _ := CBCDecrypt(decryptionKey, encrypted)
+	encrypted, _ := primitives.CBCEncrypt(key, msg)
+	decrypted, _ := primitives.CBCDecrypt(decryptionKey, encrypted)
 
 	if string(msg[:]) == string(decrypted[:]) {
 		t.Fatalf("Encryption->Decryption with different keys shouldn't return original message")
@@ -424,13 +424,13 @@ func TestCBCEncryptCBCDecrypt(t *testing.T) {
 
 	var msg = []byte("a 16 byte messag")
 
-	encrypted, encErr := CBCEncrypt(key, msg)
+	encrypted, encErr := primitives.CBCEncrypt(key, msg)
 
 	if encErr != nil {
 		t.Fatalf("Error encrypting message %v", encErr)
 	}
 
-	decrypted, dErr := CBCDecrypt(key, encrypted)
+	decrypted, dErr := primitives.CBCDecrypt(key, encrypted)
 
 	if dErr != nil {
 		t.Fatalf("Error encrypting message %v", dErr)
@@ -441,4 +441,3 @@ func TestCBCEncryptCBCDecrypt(t *testing.T) {
 	}
 
 }
-

--- a/core/crypto/primitives/aes_test.go
+++ b/core/crypto/primitives/aes_test.go
@@ -380,15 +380,19 @@ func TestCBCPKCS7Encrypt_CipherLengthCorrect(t *testing.T) {
 	// length of message < aes.BlockSize (16 bytes)
 	// --> expected cipher length = IV length (1 block) + 1 block message
 	//     =
-	var msg = []byte("short message")
-	cipher, err := primitives.CBCPKCS7Encrypt(key, msg)
-	if err != nil {
-		t.Fatal("Error encrypting the message.", cipher)
-	}
+	var msg = []byte("0123456789ABCDEF")
 
-	expectedLength := aes.BlockSize + aes.BlockSize
-	if len(cipher) != expectedLength {
-		t.Fatalf("Cipher length incorrect: expected %d, got %d", expectedLength, len(cipher))
+	for i := 1; i < aes.BlockSize; i++ {
+
+		cipher, err := primitives.CBCPKCS7Encrypt(key, msg[:i])
+		if err != nil {
+			t.Fatal("Error encrypting the message.", cipher)
+		}
+
+		expectedLength := aes.BlockSize + aes.BlockSize
+		if len(cipher) != expectedLength {
+			t.Fatalf("Cipher length incorrect: expected %d, got %d", expectedLength, len(cipher))
+		}
 	}
 }
 

--- a/core/crypto/primitives/aes_test.go
+++ b/core/crypto/primitives/aes_test.go
@@ -267,7 +267,7 @@ func TestCBCPKCS7EncryptCBCDecrypt_ExpectingCorruptMessage(t *testing.T) {
 	if string(msg[:]) != string(decrypted[:aes.BlockSize]) {
 		t.Log("msg: ", msg)
 		t.Log("decrypted: ", decrypted[:aes.BlockSize])
-		t.Fatalf("Encryption->Decryption with same key should result in original message")
+		t.Fatal("Encryption->Decryption with same key should result in original message")
 	}
 
 	if !bytes.Equal(decrypted[aes.BlockSize:], bytes.Repeat([]byte{byte(aes.BlockSize)}, aes.BlockSize)) {
@@ -356,7 +356,7 @@ func TestCBCPKCS7Encrypt_IVIsRandom(t *testing.T) {
 	// expecting a different IV if same message is encrypted with same key
 	cipher2, err := primitives.CBCPKCS7Encrypt(key, msg)
 	if err != nil {
-		t.Fatalf("Error encrypting the message.")
+		t.Fatal("Error encrypting the message.")
 	}
 
 	iv1 := cipher1[:aes.BlockSize]
@@ -415,7 +415,7 @@ func TestCBCEncryptCBCDecrypt_KeyMismatch(t *testing.T) {
 	decrypted, _ := primitives.CBCDecrypt(decryptionKey, encrypted)
 
 	if string(msg[:]) == string(decrypted[:]) {
-		t.Fatalf("Encryption->Decryption with different keys shouldn't return original message")
+		t.Fatal("Encryption->Decryption with different keys shouldn't return original message")
 	}
 
 }
@@ -441,7 +441,7 @@ func TestCBCEncryptCBCDecrypt(t *testing.T) {
 	}
 
 	if string(msg[:]) != string(decrypted[:]) {
-		t.Fatalf("Encryption->Decryption with same key should result in original message")
+		t.Fatal("Encryption->Decryption with same key should result in original message")
 	}
 
 }

--- a/core/crypto/primitives/aes_test.go
+++ b/core/crypto/primitives/aes_test.go
@@ -416,3 +416,29 @@ func TestCBCEncryptCBCDecrypt_KeyMismatch(t *testing.T) {
 
 }
 
+func TestCBCEncryptCBCDecrypt(t *testing.T) {
+	// Encrypt with CBCEncrypt and Decrypt with CBCDecrypt
+
+	key := make([]byte, 32)
+	rand.Reader.Read(key)
+
+	var msg = []byte("a 16 byte messag")
+
+	encrypted, encErr := CBCEncrypt(key, msg)
+
+	if encErr != nil {
+		t.Fatalf("Error encrypting message %v", encErr)
+	}
+
+	decrypted, dErr := CBCDecrypt(key, encrypted)
+
+	if dErr != nil {
+		t.Fatalf("Error encrypting message %v", dErr)
+	}
+
+	if string(msg[:]) != string(decrypted[:]) {
+		t.Fatalf("Encryption->Decryption with same key should result in original message")
+	}
+
+}
+

--- a/core/crypto/primitives/aes_test.go
+++ b/core/crypto/primitives/aes_test.go
@@ -275,3 +275,66 @@ func TestCBCPKCS7EncryptCBCDecrypt_ExpectingCorruptMessage(t *testing.T) {
 	}
 
 }
+
+func TestCBCPKCS7Encrypt_EmptyText(t *testing.T) {
+	// Encrypt an empty message. Mainly to document
+	// a borderline case. Checking as well that the
+	// cipher length is as expected.
+
+	key := make([]byte, 32)
+	rand.Reader.Read(key)
+
+	t.Log("Generated key: ", key)
+
+	var msg = []byte("")
+	t.Log("Message length: ", len(msg))
+
+	cipher, encErr := CBCPKCS7Encrypt(key, msg)
+	if encErr != nil {
+		t.Fatalf("Error encrypting message %v", encErr)
+	}
+
+	t.Log("Cipher length: ", len(cipher))
+
+	// expected cipher length: 32
+	// with padding, at least one block gets encrypted
+	// the first block is the IV
+	var expectedLength = aes.BlockSize + aes.BlockSize
+
+	if len(cipher) != expectedLength {
+		t.Fatalf("Cipher length is wrong. Expected %d, got %d",
+			expectedLength, len(cipher))
+	}
+	t.Log("Cipher: ", cipher)
+}
+
+func TestCBCEncrypt_EmptyText(t *testing.T) {
+	// Encrypt an empty message. Mainly to document
+	// a borderline case. Checking as well that the
+	// cipher length is as expected.
+
+	key := make([]byte, 32)
+	rand.Reader.Read(key)
+
+	t.Log("Generated key: ", key)
+
+	var msg = []byte("")
+	t.Log("Message length: ", len(msg))
+
+	cipher, encErr := CBCEncrypt(key, msg)
+	if encErr != nil {
+		t.Fatalf("Error encrypting message %v", encErr)
+	}
+
+	t.Log("Cipher length: ", len(cipher))
+
+	// expected cipher length: aes.BlockSize
+	// the first and only block is the IV
+	var expectedLength = aes.BlockSize
+
+	if len(cipher) != expectedLength {
+		t.Fatalf("Cipher length is wrong. Expected %d, got %d",
+			expectedLength, len(cipher))
+	}
+	t.Log("Cipher: ", cipher)
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Added a couple of tests to test and document the behaviour of the CBC functions in `core/crypto/primitives/aes.go`. Especially two edge cases when a message is encrypted with `CBCEncrypt`  attempted to be decrypted with `CBCPKCS7Decrypt` and vice versa. The work has been done with the assistance of @JonathanLevi. 
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

We want to add more unit tests to lock/document and verify their correct/expected/standard/compliant behavior.

This is part of #2127 Add a family of AES-CBC related tests
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

N/A. Should be covered in the future by make unit-test
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Johannes Weissmann jo@starsheriff.eu
