### PR TITLE
Changes for Node.js UT automation

### DIFF
--- a/sdk/node/bin/run-unit-tests.sh
+++ b/sdk/node/bin/run-unit-tests.sh
@@ -1,11 +1,14 @@
 #
 # Run the unit tests associated with the node.js client sdk
 #
+
+# Variable to store error results
+NODE_ERR_CODE=0
+
 main() {
    # Initialization
    init
 
-   {
    # Start member services
    startMemberServices
 
@@ -20,8 +23,6 @@ main() {
    # Stop peer and member services
    stopPeer
    stopMemberServices
-
-   } 2>&1 | tee $LOGDIR/log
 }
 
 # initialization & cleanup
@@ -117,8 +118,9 @@ postExample() {
 # $1 is name of example to prepare on disk
 prepareExampleForDeployInNetworkMode() {
    SRCDIR=$EXAMPLES/$1
-   if [ ! -d $SRC_DIR ]; then
+   if [ ! -d $SRCDIR ]; then
       echo "FATAL ERROR: directory does not exist: $SRCDIR"
+      NODE_ERR_CODE=1
       exit 1;
    fi
    DSTDIR=$GOPATH/src/github.com/$1
@@ -141,8 +143,9 @@ prepareExampleForDeployInNetworkMode() {
 # $1 is the name of the sample to start
 startExampleInDevMode() {
    SRCDIR=$EXAMPLES/$1
-   if [ ! -d $SRC_DIR ]; then
+   if [ ! -d $SRCDIR ]; then
       echo "FATAL ERROR: directory does not exist: $SRCDIR"
+      NODE_ERR_CODE=1
       exit 1;
    fi
    EXE=$SRCDIR/$1
@@ -163,6 +166,10 @@ stopExampleInDevMode() {
 runRegistrarTests() {
    echo "BEGIN running registrar tests ..."
    node $UNITTEST/registrar.js
+   if [ $? -ne 0 ]; then
+      echo "ERROR running registrar tests!"
+      NODE_ERR_CODE=1
+   fi
    echo "END running registrar tests"
 }
 
@@ -170,6 +177,10 @@ runChainTests() {
    echo "BEGIN running chain-tests ..."
    preExample chaincode_example02 mycc1
    node $UNITTEST/chain-tests.js
+   if [ $? -ne 0 ]; then
+      echo "ERROR running chain-tests!"
+      NODE_ERR_CODE=1
+   fi
    postExample chaincode_example02
    echo "END running chain-tests"
 }
@@ -178,6 +189,10 @@ runAssetMgmtTests() {
    echo "BEGIN running asset-mgmt tests ..."
    preExample asset_management mycc2
    node $UNITTEST/asset-mgmt.js
+   if [ $? -ne 0 ]; then
+      echo "ERROR running asset-mgmt tests!"
+      NODE_ERR_CODE=1
+   fi
    postExample asset_management
    echo "END running asset-mgmt tests"
 }
@@ -186,6 +201,10 @@ runAssetMgmtWithRolesTests() {
    echo "BEGIN running asset management with roles tests ..."
    preExample asset_management_with_roles mycc3
    node $UNITTEST/asset-mgmt-with-roles.js
+   if [ $? -ne 0 ]; then
+      echo "ERROR running asset management with roles tests!"
+      NODE_ERR_CODE=1
+   fi
    postExample asset_management_with_roles
    echo "END running asset management with roles tests"
 }
@@ -203,6 +222,7 @@ startProcess() {
       echo "$3 is started"
    else
       echo "ERROR: $3 failed to start; see $2"
+      NODE_ERR_CODE=1
       exit 1
    fi
 }
@@ -218,3 +238,8 @@ killProcess() {
 }
 
 main
+
+if [ "$NODE_ERR_CODE" != "0" ]; then
+  echo "ERROR: Error executing run-unit-tests.sh. Exiting with status code '1'."
+  exit 1
+fi

--- a/sdk/node/test/unit/asset-mgmt-with-roles.js
+++ b/sdk/node/test/unit/asset-mgmt-with-roles.js
@@ -150,6 +150,7 @@ test('setup asset management with roles', function (t) {
     setup(function(err) {
         if (err) {
             t.fail("error: "+err.toString());
+            // Exit the test script after a failure
             process.exit(1);
         } else {
             t.pass("setup successful");
@@ -160,14 +161,22 @@ test('setup asset management with roles', function (t) {
 test('assign asset management with roles', function (t) {
     t.plan(1);
     alice.getUserCert(["role", "account"], function (err, aliceCert) {
-        if (err) fail(t, "Failed getting Application certificate for Alice.");
+        if (err) {
+          fail(t, "Failed getting Application certificate for Alice.");
+          // Exit the test script after a failure
+          process.exit(1);
+        }
         assignOwner(assigner, aliceCert.encode().toString('base64'), function(err) {
             if (err) {
                 t.fail("error: "+err.toString());
+                // Exit the test script after a failure
+                process.exit(1);
             } else {
                 checkOwner(assigner, aliceAccount, function(err) {
                     if(err){
                         t.fail("error: "+err.toString());
+                        // Exit the test script after a failure
+                        process.exit(1);
                     } else {
                         t.pass("assign successful");
                     }
@@ -181,10 +190,16 @@ test('not assign asset management with roles', function (t) {
     t.plan(1);
 
     bob.getUserCert(["role", "account"], function (err, bobCert) {
-        if (err) fail(t, "Failed getting Application certificate for Alice.");
+        if (err) {
+          fail(t, "Failed getting Application certificate for Alice.");
+          // Exit the test script after a failure
+          process.exit(1);
+        }
         assignOwner(alice, bobCert.encode().toString('base64'), function(err) {
             if (err) {
                 t.fail("error: "+err.toString());
+                // Exit the test script after a failure
+                process.exit(1);
             } else {
                 checkOwner(alice, bobAccount, function(err) {
                     if(err){
@@ -192,6 +207,8 @@ test('not assign asset management with roles', function (t) {
                     } else {
                         err = new Error ("this user should not have been allowed to assign");
                         t.fail("error: "+err.toString());
+                        // Exit the test script after a failure
+                        process.exit(1);
                     }
                 });
             }

--- a/sdk/node/test/unit/asset-mgmt.js
+++ b/sdk/node/test/unit/asset-mgmt.js
@@ -101,11 +101,19 @@ function fail(t, msg, err) {
 test('Enroll the registrar', function (t) {
     // Get the WebAppAdmin member
     chain.getUser(registrar.name, function (err, user) {
-        if (err) return fail(t, "get registrar", err);
+        if (err) {
+            fail(t, "get registrar", err);
+            // Exit the test script after a failure
+            process.exit(1);
+        }
         // Enroll the WebAppAdmin user with the certificate authority using
         // the one time password hard coded inside the membersrvc.yaml.
         user.enroll(registrar.secret, function (err) {
-            if (err) return fail(t, "enroll registrar", err);
+            if (err) {
+                fail(t, "enroll registrar", err);
+                // Exit the test script after a failure
+                process.exit(1);
+            }
             chain.setRegistrar(user);
             pass(t, "enrolled " + registrar.name);
         });
@@ -114,10 +122,18 @@ test('Enroll the registrar', function (t) {
 
 test('Enroll Alice', function (t) {
     getUser('Alice', function (err, user) {
-        if (err) return fail(t, "enroll Alice", err);
+        if (err) {
+            fail(t, "enroll Alice", err);
+            // Exit the test script after a failure
+            process.exit(1);
+        }
         alice = user;
         alice.getUserCert(null, function (err, userCert) {
-            if (err) fail(t, "Failed getting Application certificate.");
+            if (err) {
+                fail(t, "Failed getting Application certificate.");
+                // Exit the test script after a failure
+                process.exit(1);
+            }
             alicesCert = userCert;
             pass(t, "enroll Alice");
         })
@@ -126,10 +142,18 @@ test('Enroll Alice', function (t) {
 
 test('Enroll Bob', function (t) {
     getUser('Bob', function (err, user) {
-        if (err) return fail(t, "enroll Bob", err);
+        if (err) {
+            fail(t, "enroll Bob", err);
+            // Exit the test script after a failure
+            process.exit(1);
+        }
         bob = user;
         bob.getUserCert(null, function (err, userCert) {
-            if (err) fail(t, "Failed getting Application certificate.");
+            if (err) {
+                fail(t, "Failed getting Application certificate.");
+                // Exit the test script after a failure
+                process.exit(1);
+            }
             bobAppCert = userCert;
             pass(t, "enroll Bob");
         })
@@ -138,10 +162,18 @@ test('Enroll Bob', function (t) {
 
 test('Enroll Charlie', function (t) {
     getUser('Charlie', function (err, user) {
-        if (err) return fail(t, "enroll Charlie", err);
+        if (err) {
+            fail(t, "enroll Charlie", err);
+            // Exit the test script after a failure
+            process.exit(1);
+        }
         charlie = user;
         charlie.getUserCert(null, function (err, userCert) {
-            if (err) fail(t, "Failed getting Application certificate.");
+            if (err) {
+                fail(t, "Failed getting Application certificate.");
+                // Exit the test script after a failure
+                process.exit(1);
+            }
             charlieAppCert = userCert;
             pass(t, "enroll Charlie");
         })
@@ -188,6 +220,8 @@ test("Alice deploys chaincode", function (t) {
     deployTx.on('error', function(err) {
       // Deploy request failed
       t.fail(util.format("Failed to deploy chaincode: request=%j, error=%j", deployRequest, err));
+      // Exit the test script after a failure
+      process.exit(1);
     });
 });
 
@@ -219,6 +253,8 @@ test("Alice assign ownership", function (t) {
     });
     tx.on('error', function (err) {
         fail(t, "Alice invoke", err);
+        // Exit the test script after a failure
+        process.exit(1);
     });
 });
 
@@ -247,6 +283,8 @@ test("Bob transfers ownership to Charlie", function (t) {
     });
     tx.on('error', function (err) {
         fail(t, "Bob invoke", err);
+        // Exit the test script after a failure
+        process.exit(1);
     });
 });
 
@@ -272,10 +310,14 @@ test("Alice queries chaincode", function (t) {
 
         if (results.result != charlieAppCert.encode().toString('hex')) {
             fail(t, "Charlie is not the owner of the asset.")
+            // Exit the test script after a failure
+            process.exit(1);
         }
         pass(t, "Alice query. Result: " + results);
     });
     tx.on('error', function (err) {
         fail(t, "Alice query", err);
+        // Exit the test script after a failure
+        process.exit(1);
     });
 });

--- a/sdk/node/test/unit/chain-tests.js
+++ b/sdk/node/test/unit/chain-tests.js
@@ -141,9 +141,13 @@ test('Set Invalid security level and hash algorithm.', function (t) {
     try {
         chain.getMemberServices().setSecurityLevel(128);
         t.fail("Setting an invalid security level should fail. Allowed security levels are '256' and '384'.")
+        // Exit the test script after a failure
+        process.exit(1);
     } catch (err) {
         if (securityLevel != chain.getMemberServices().getSecurityLevel()) {
             t.fail("Chain is using an invalid security level.")
+            // Exit the test script after a failure
+            process.exit(1);
         }
 
         t.pass("Setting an invalid security level failed as expected.")
@@ -153,9 +157,13 @@ test('Set Invalid security level and hash algorithm.', function (t) {
     try {
         chain.getMemberServices().setHashAlgorithm('SHA');
         t.fail("Setting an invalid hash algorithm should fail. Allowed hash algorithm are 'SHA2' and 'SHA3'.")
+        // Exit the test script after a failure
+        process.exit(1);
     } catch (err) {
         if (hashAlgorithm != chain.getMemberServices().getHashAlgorithm()) {
             t.fail("Chain is using an invalid hash algorithm.")
+            // Exit the test script after a failure
+            process.exit(1);
         }
 
         t.pass("Setting an invalid hash algorithm failed as expected.")
@@ -177,6 +185,8 @@ test('Enroll WebAppAdmin', function (t) {
         if (err) {
             t.fail("Failed to get WebAppAdmin member " + " ---> " + err);
             t.end(err);
+            // Exit the test script after a failure
+            process.exit(1);
         } else {
             t.pass("Successfully got WebAppAdmin member" /*+ " ---> " + JSON.stringify(crypto)*/);
 
@@ -187,6 +197,8 @@ test('Enroll WebAppAdmin', function (t) {
                 if (err) {
                     t.fail("Failed to enroll WebAppAdmin member " + " ---> " + err);
                     t.end(err);
+                    // Exit the test script after a failure
+                    process.exit(1);
                 } else {
                     t.pass("Successfully enrolled WebAppAdmin member" /*+ " ---> " + JSON.stringify(crypto)*/);
 
@@ -198,6 +210,8 @@ test('Enroll WebAppAdmin', function (t) {
                             t.pass("Successfully stored client token" /*+ " ---> " + WebAppAdmin.getName()*/);
                         } else {
                             t.fail("Failed to store client token for " + WebAppAdmin.getName() + " ---> " + err);
+                            // Exit the test script after a failure
+                            process.exit(1);
                         }
                     });
                 }
@@ -221,6 +235,8 @@ test('Set chain registrar', function (t) {
         if (err) {
             t.fail("Failed to get WebAppAdmin member " + " ---> " + err);
             t.end(err);
+            // Exit the test script after a failure
+            process.exit(1);
         } else {
             t.pass("Successfully got WebAppAdmin member");
 
@@ -245,6 +261,8 @@ test('Register and enroll a new user', function (t) {
     getUser(test_user1.name, function (err, user) {
         if (err) {
             fail(t, "Failed to get " + test_user1.name + " ---> ", err);
+            // Exit the test script after a failure
+            process.exit(1);
         } else {
             test_user_Member1 = user;
 
@@ -255,10 +273,12 @@ test('Register and enroll a new user', function (t) {
             fs.exists(path, function (exists) {
                 if (exists) {
                     t.pass("Successfully stored client token" /*+ " ---> " + test_user1.name*/);
-                    t.end()
+                    t.end();
                 } else {
                     t.fail("Failed to store client token for " + test_user1.name + " ---> " + err);
-                    t.end(err)
+                    t.end(err);
+                    // Exit the test script after a failure
+                    process.exit(1);
                 }
             });
         }
@@ -294,6 +314,8 @@ test('Deploy with missing chaincodeName or chaincodePath', function(t) {
     testChaincodeID = results.chaincodeID;
     console.log("testChaincodeID:" + testChaincodeID);
     t.fail(util.format("Successfully deployed chaincode: request=%j, response=%j", deployRequest, results));
+    // Exit the test script after a failure
+    process.exit(1);
   });
   deployTx.on('error', function(err) {
     // Deploy request failed
@@ -341,6 +363,8 @@ test('Deploy a chaincode by enrolled user', function(t) {
   deployTx.on('error', function(err) {
     // Deploy request failed
     t.fail(util.format("Failed to deploy chaincode: request=%j, error=%j",deployRequest,err));
+    // Exit the test script after a failure
+    process.exit(1);
   });
 });
 
@@ -369,6 +393,8 @@ test('Query with missing chaincodeID', function (t) {
     queryTx.on('complete', function (results) {
         // Query completed successfully
         t.fail(util.format("Successfully queried existing chaincode state: request=%j, response=%j, value=%s", queryRequest, results, results.result.toString()));
+        // Exit the test script after a failure
+        process.exit(1);
     });
     queryTx.on('error', function (err) {
         // Query failed
@@ -407,6 +433,8 @@ test('Query existing chaincode state by enrolled user with batch size of 1', fun
     queryTx.on('error', function (err) {
         // Query failed
         t.fail(util.format("Failed to query existing chaincode state: request=%j, error=%j", queryRequest, err));
+        // Exit the test script after a failure
+        process.exit(1);
     });
 });
 
@@ -441,6 +469,8 @@ test('Query existing chaincode state by enrolled user with batch size of 100', f
     queryTx.on('error', function (err) {
       // Query failed
       t.fail(util.format("Failed to query existing chaincode state: request=%j, error=%j", queryRequest, err));
+      // Exit the test script after a failure
+      process.exit(1);
     });
 });
 
@@ -470,6 +500,8 @@ test('Query non-existing chaincode state by enrolled user', function (t) {
     queryTx.on('complete', function (results) {
         // Query completed successfully
         t.fail(util.format("Successfully queried non-existing chaincode state: request=%j, response=%j, value=%s", queryRequest, results, results.result.toString()));
+        // Exit the test script after a failure
+        process.exit(1);
     });
     queryTx.on('error', function (err) {
         // Query failed
@@ -503,6 +535,8 @@ test('Query non-existing chaincode function by enrolled user', function (t) {
     queryTx.on('complete', function (results) {
         // Query completed successfully
         t.fail(util.format("Successfully queried non-existing chaincode function: request=%j, response=%j, value=%s", queryRequest, results, results.result.toString()));
+        // Exit the test script after a failure
+        process.exit(1);
     });
     queryTx.on('error', function (err) {
         // Query failed
@@ -534,6 +568,8 @@ test('Invoke with missing chaincodeID', function (t) {
     invokeTx.on('submitted', function (results) {
         // Invoke transaction submitted successfully
         t.fail(util.format("Successfully submitted chaincode invoke transaction: request=%j, response=%j", invokeRequest,results));
+        // Exit the test script after a failure
+        process.exit(1);
     });
     invokeTx.on('error', function (err) {
         // Invoke transaction submission failed
@@ -570,5 +606,7 @@ test('Invoke a chaincode by enrolled user', function (t) {
     invokeTx.on('error', function (err) {
         // Invoke transaction submission failed
         t.fail(util.format("Failed to submit chaincode invoke transaction: request=%j, error=%j", invokeRequest, err));
+        // Exit the test script after a failure
+        process.exit(1);
     });
 });

--- a/sdk/node/test/unit/registrar.js
+++ b/sdk/node/test/unit/registrar.js
@@ -31,8 +31,13 @@ var keyValStorePath2 = keyValStorePath + "2";
 //
 test('registrar test', function (t) {
     registrarTest(function(err) {
-        if (err) fail(t, "registrarTest", err);
-        else pass(t, "registrarTest");
+        if (err) {
+          fail(t, "registrarTest", err);
+          // Exit the test script after a failure
+          process.exit(1);
+        } else {
+          pass(t, "registrarTest");
+        }
     });
 });
 
@@ -41,8 +46,13 @@ test('registrar test', function (t) {
 //
 test('enroll again', function (t) {
     enrollAgain(function(err) {
-        if (err) fail(t, "enrollAgain", err);
-        else pass(t, "enrollAgain");
+        if (err) {
+          fail(t, "enrollAgain", err);
+          // Exit the test script after a failure
+          process.exit(1);
+        } else {
+          pass(t, "enrollAgain");
+        }
     });
 });
 
@@ -147,6 +157,6 @@ function pass(t, msg) {
 }
 
 function fail(t, msg, err) {
-    t.pass("Failure: [" + msg + "]: [" + err + "]");
+    t.fail("Failure: [" + msg + "]: [" + err + "]");
     t.end(err);
 }


### PR DESCRIPTION
## Description

I am making some changes to the Node.js UT scripts as well as the .sh script that runs them. These changes are necessary to integrate the Node.js UT scripts into the CI framework.

@rameshthoomu please take a look.
## Motivation and Context

In order to integrated the existing Node.js UT into the CI framework I am making the following changes:

(1) Modifying the existing Node.js UT scrips to report the first failure and exit. We do not want to continue executing the test script, as typically, the operations that follow are dependent on the ones that come before them. For example, if deploy fails there is no point in waiting for invoke/query to finish. Or if enrollment of the test user with the membership service fails, there is no sense to continue the test as all subsequent requests will fail.

(2) Modifying the existing .sh script that is triggered with the `make node-sdk-unit-tests` so it returns a `1` whenever any of the Node scripts fail. This allows the CI scripts to use that output.
## How Has This Been Tested?

I have tested this with the existing UTs. I am not introducing any new functionality. 
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
