### PR TITLE
Fix issue 2120

### DIFF
--- a/membersrvc/ca/aca.go
+++ b/membersrvc/ca/aca.go
@@ -300,8 +300,8 @@ func (aca *ACA) populateAttributes(attrs []*AttributePair) error {
 func (aca *ACA) populateAttribute(tx *sql.Tx, attr *AttributePair) error {
 	fmt.Printf("*********************** ATTR %v %v %v\n", attr.GetID(), attr.attributeName, string(attr.attributeValue))
 
-	mutex.RLock()
-	defer mutex.RUnlock()
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	var count int
 	err := tx.QueryRow("SELECT count(row) AS cant FROM Attributes WHERE id=? AND affiliation =? AND attributeName =?",

--- a/membersrvc/ca/aca.go
+++ b/membersrvc/ca/aca.go
@@ -300,9 +300,6 @@ func (aca *ACA) populateAttributes(attrs []*AttributePair) error {
 func (aca *ACA) populateAttribute(tx *sql.Tx, attr *AttributePair) error {
 	fmt.Printf("*********************** ATTR %v %v %v\n", attr.GetID(), attr.attributeName, string(attr.attributeValue))
 
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	var count int
 	err := tx.QueryRow("SELECT count(row) AS cant FROM Attributes WHERE id=? AND affiliation =? AND attributeName =?",
 		attr.GetID(), attr.GetAffiliation(), attr.GetAttributeName()).Scan(&count)

--- a/membersrvc/ca/aca.go
+++ b/membersrvc/ca/aca.go
@@ -300,6 +300,9 @@ func (aca *ACA) populateAttributes(attrs []*AttributePair) error {
 func (aca *ACA) populateAttribute(tx *sql.Tx, attr *AttributePair) error {
 	fmt.Printf("*********************** ATTR %v %v %v\n", attr.GetID(), attr.attributeName, string(attr.attributeValue))
 
+	mutex.RLock()
+	defer mutex.RUnlock()
+
 	var count int
 	err := tx.QueryRow("SELECT count(row) AS cant FROM Attributes WHERE id=? AND affiliation =? AND attributeName =?",
 		attr.GetID(), attr.GetAffiliation(), attr.GetAttributeName()).Scan(&count)
@@ -339,6 +342,9 @@ func (aca *ACA) fetchAndPopulateAttributes(id, affiliation string) error {
 
 func (aca *ACA) findAttribute(owner *AttributeOwner, attributeName string) (*AttributePair, error) {
 	var count int
+
+	mutex.RLock()
+	defer mutex.RUnlock()
 
 	err := aca.db.QueryRow("SELECT count(row) AS cant FROM Attributes WHERE id=? AND affiliation =? AND attributeName =?",
 		owner.GetID(), owner.GetAffiliation(), attributeName).Scan(&count)

--- a/membersrvc/ca/ecap.go
+++ b/membersrvc/ca/ecap.go
@@ -106,6 +106,7 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 
 	id := in.Id.Id
 	err := ecap.eca.readUser(id).Scan(&role, &tok, &state, &prev, &enrollID)
+
 	if err != nil {
 		errMsg := "Identity lookup error: " + err.Error()
 		Trace.Println(errMsg)
@@ -127,7 +128,10 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 		// initial request, create encryption challenge
 		tok = []byte(randomString(12))
 
+		mutex.Lock()
 		_, err = ecap.eca.db.Exec("UPDATE Users SET token=?, state=?, key=? WHERE id=?", tok, 1, in.Enc.Key, id)
+		mutex.Unlock()
+
 		if err != nil {
 			Error.Println(err)
 			return nil, err
@@ -190,14 +194,20 @@ func (ecap *ECAP) CreateCertificatePair(ctx context.Context, in *pb.ECertCreateR
 		spec = NewDefaultCertificateSpecWithCommonName(id, enrollID, ekey.(*ecdsa.PublicKey), x509.KeyUsageDataEncipherment, pkix.Extension{Id: ECertSubjectRole, Critical: true, Value: []byte(strconv.Itoa(ecap.eca.readRole(id)))})
 		eraw, err := ecap.eca.createCertificateFromSpec(spec, ts, nil, true)
 		if err != nil {
+			mutex.Lock()
 			ecap.eca.db.Exec("DELETE FROM Certificates Where id=?", id)
+			mutex.Unlock()
 			Error.Println(err)
 			return nil, err
 		}
 
+		mutex.Lock()
 		_, err = ecap.eca.db.Exec("UPDATE Users SET state=? WHERE id=?", 2, id)
+		mutex.Unlock()
 		if err != nil {
+			mutex.Lock()
 			ecap.eca.db.Exec("DELETE FROM Certificates Where id=?", id)
+			mutex.Unlock()
 			Error.Println(err)
 			return nil, err
 		}

--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -240,8 +240,8 @@ func (tca *TCA) startTCAA(srv *grpc.Server) {
 }
 
 func (tca *TCA) getCertificateSets(enrollmentID string) ([]*TCertSet, error) {
-	mutex.Lock()
-	defer mutex.Unlock()
+	mutex.RLock()
+	defer mutex.RUnlock()
 
 	var sets = []*TCertSet{}
 	var err error

--- a/membersrvc/ca/tca.go
+++ b/membersrvc/ca/tca.go
@@ -240,6 +240,9 @@ func (tca *TCA) startTCAA(srv *grpc.Server) {
 }
 
 func (tca *TCA) getCertificateSets(enrollmentID string) ([]*TCertSet, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	var sets = []*TCertSet{}
 	var err error
 
@@ -269,6 +272,9 @@ func (tca *TCA) getCertificateSets(enrollmentID string) ([]*TCertSet, error) {
 }
 
 func (tca *TCA) persistCertificateSet(enrollmentID string, timestamp int64, nonce []byte, kdfKey []byte) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	var err error
 
 	if _, err = tca.db.Exec("INSERT INTO TCertificateSets (enrollmentID, timestamp, nonce, kdfkey) VALUES (?, ?, ?, ?)", enrollmentID, timestamp, nonce, kdfKey); err != nil {


### PR DESCRIPTION
Member services fails under load with "database is locked" error

"Database is locked" error could be easily reproduced when no sync mechanism is present. See original gist https://gist.github.com/mrnugget/0eda3b2b53a70fa4a894 and its fork: https://gist.github.com/jeronimoirazabal/cbe014eb22333cc3b6b56aa66379e933
## Description

Mutex variable has been changed to RWMutex type in order to allow simultaneous reads and exclusive writes to sqlite3 db. Synchronization has been taken into account in all db access within the scope of Membership Services.
## Motivation and Context

Fixes #2120 
## How Has This Been Tested?

This PR does not require additional test cases as no new functionality was introduced.

Unit tests have been run without errors.
Behave tests have been run without errors.
Node.js tests have been run without errors. Even under heavy load (i.e. 1000 users, 1000 iterations)
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] This change requires no new documentation.
- [x] This change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified.

Signed-off-by: Jeronimo Irazabal jeronimo.irazabal@gmail.com / iraza@ar.ibm.com
