### PR TITLE
DEVENV: Provide strong feedback when provisioning fails

### DIFF
--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -34,6 +34,53 @@ set -e
 BASEIMAGE_RELEASE=`cat /etc/hyperledger-baseimage-release`
 DEVENV_REVISION=`(cd /hyperledger/devenv; git rev-parse --short HEAD)`
 
+# Install WARNING before we start provisioning so that it
+# will remain active.  We will remove the warning after
+# success
+cat <<EOF >/etc/motd
+##########################################################
+                       ,.-""``""-.,
+                      /  ,:,;;,;,  \  DANGER DANGER
+                      \  ';';;';'  /   WILL ROBINSON...
+                       `'---;;---'`
+                       <>_==""==_<>
+                       _<<<<<>>>>>_
+                     .'____\==/____'.
+                _____|__   |__|   __|______
+              /C \\\\\\\\  |..|  //////// C\
+              \_C////////  |;;|  \\\\\\\\C_/
+                     |____o|##|o____|
+                      \ ___|~~|___ /
+                       '>--------<'
+                       {==_==_==_=}
+                       {= -=_=-_==}
+                       {=_=-}{=-=_}
+                       {=_==}{-=_=}
+                       }~~~~""~~~~{
+                  jgs  }____::____{
+                      /`    ||    `\
+                      |     ||     |
+                      |     ||     |
+                      |     ||     |
+                      '-----''-----'
+##########################################################
+
+If you see this notice, it means that something is wrong
+with your hyperledger/fabric development environment.
+
+Typically this indicates that something failed during
+provisioning and your environment is incomplete.  Builds,
+execution, etc., may not operate as they were intended.
+Please review the provisioning log and visit:
+
+                https://goo.gl/yqjRC7
+
+for more information on troubleshooting and solutions.
+
+##########################################################
+EOF
+
+
 # Update system
 apt-get update -qq
 
@@ -101,9 +148,6 @@ sudo chown -R vagrant:vagrant $GOPATH
 # Update limits.conf to increase nofiles for RocksDB
 sudo cp /hyperledger/devenv/limits.conf /etc/security/limits.conf
 
-# Set our shell prompt to something less ugly than the default from packer
-echo "PS1=\"\u@hyperledger-devenv:v$BASEIMAGE_RELEASE-$DEVENV_REVISION:\w$ \"" >> /home/vagrant/.bashrc
-
 # configure vagrant specific environment
 cat <<EOF >/etc/profile.d/vagrant-devenv.sh
 # Expose the devenv/tools in the $PATH
@@ -112,3 +156,9 @@ export VAGRANT=1
 export CGO_CFLAGS=" "
 export CGO_LDFLAGS="-lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
 EOF
+
+# Set our shell prompt to something less ugly than the default from packer
+echo "PS1=\"\u@hyperledger-devenv:v$BASEIMAGE_RELEASE-$DEVENV_REVISION:\w$ \"" >> /home/vagrant/.bashrc
+
+# finally, remove our warning so the user knows this was successful
+rm /etc/motd


### PR DESCRIPTION
Fix for Issue #2222
## Description

Introduces a MOTD that will be displayed for environments that have failed to fully provision:

```
##########################################################
 __      __                         .__
/  \    /  \_____   _______   ____  |__|  ____     ____
\   \/\/   /\__  \  \_  __ \ /    \ |  | /    \   / ___\
 \        /  / __ \_ |  | \/|   |  \|  ||   |  \ / /_/  |
  \__/\  /  (____  / |__|   |___|  /|__||___|  / \___  /
       \/        \/              \/          \/ /_____/
##########################################################

If you can see this, something is wrong with your
hyperledger/fabric development env.

Typically this indicates that something failed during
provisioning and your environment is incomplete.  Builds,
execution, etc, may not operate as they were intended.
Please review the provisioning log for more information.

##########################################################
```
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2222
## How Has This Been Tested?

I tested that the message displays when I artificially cause the provisioner script to exit early, and that it is not displayed when thins run properly.  No code changes were introduced, so no UTs were added nor run.  CI should confirm this.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [ ] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Greg Haskins gregory.haskins@gmail.com
