### PR TITLE
Use linux-on-ibm-z/protobuf to allow compiling of protobuf on zLinux

### DIFF
--- a/images/base/scripts/common/setup.sh
+++ b/images/base/scripts/common/setup.sh
@@ -83,7 +83,12 @@ fi
 
 # First install protoc
 cd /tmp
-git clone https://github.com/google/protobuf.git
+if [ x$MACHINE = xs390x ]
+then
+    git clone https://github.com/linux-on-ibm-z/protobuf.git
+else
+    git clone https://github.com/google/protobuf.git
+fi
 cd protobuf
 git checkout v3.0.0-beta-3
 #unzip needed for ./autogen.sh
@@ -100,15 +105,9 @@ apt-get install -y build-essential libtool
 #
 #./configure
 ./configure --prefix=/usr
-
-if [ x$MACHINE = xs390x ]
-then
-    echo FIXME: protobufs wont compile on 390, missing atomic call
-else
-    make
-    make check
-    make install
-fi
+make
+make check
+make install
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 cd ~/
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

A patched version of protobuf that compiles on zLinux is hosted on github in the linux-on-ibm-z repo. images/base/scripts/common/setup.sh is modified to use it for building base image on zLinux.

Note that the maintainer of hyperledger/fabric-baseimage:s390x-0.0.10 still needs to update the image so that it has protoc installed.
## Motivation and Context

protobuf is required in hyperledger base image. This enables compiling protobuf on zLinux.
## How Has This Been Tested?

I manually tested the command sequence in setup.sh for the protoc installation on zLinux.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Gong Su gongsugongsu@gmail.com
