### PR TITLE
Use pip install docker-compose

### DIFF
--- a/scripts/provision/host.sh
+++ b/scripts/provision/host.sh
@@ -4,11 +4,7 @@ CURDIR=`dirname $0`
 
 $CURDIR/common.sh
 
-# Install docker-compose
-curl -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
-# Install Python, pip, behave, nose
+# Install Python, pip, behave, nose, docker-compose
 #
 # install python-dev and libyaml-dev to get compiled speedups
 apt-get install --yes python-dev
@@ -18,6 +14,7 @@ apt-get install --yes python-setuptools
 apt-get install --yes python-pip
 pip install behave
 pip install nose
+pip install docker-compose
 
 # updater-server, update-engine, and update-service-common dependencies (for running locally)
 pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couchdb==1.0 flask-cors==2.0.1 requests==2.4.3


### PR DESCRIPTION
## Description

Update host.sh, use pip install docker-compose instead of curl
## Motivation and Context

1.More consistent with setupRHELonZ.sh
2.It is faster than docker-compose official site for people network not good.
## How Has This Been Tested?

no test
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:Kai Chen ckaiwh@cn.ibm.com
