### PR TITLE
Fix issue 2044: support docker api 1.24+

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -102,7 +102,7 @@ func getDockerHostConfig() *docker.HostConfig {
 
 func (vm *DockerVM) createContainer(ctxt context.Context, client *docker.Client, imageID string, containerID string, args []string, env []string, attachstdin bool, attachstdout bool) error {
 	config := docker.Config{Cmd: args, Image: imageID, Env: env, AttachStdin: attachstdin, AttachStdout: attachstdout}
-	copts := docker.CreateContainerOptions{Name: containerID, Config: &config}
+	copts := docker.CreateContainerOptions{Name: containerID, Config: &config, HostConfig: getDockerHostConfig()}
 	dockerLogger.Debugf("Create container: %s", containerID)
 	_, err := client.CreateContainer(copts)
 	if err != nil {
@@ -190,6 +190,9 @@ func (vm *DockerVM) Start(ctxt context.Context, ccid ccintf.CCID, args []string,
 		}
 	}
 
+	// Baohua: getDockerHostConfig() will be ignored when communicating with docker API 1.24+.
+	// I keep it here for a short-term compatibility.
+	// See https://goo.gl/ZvtkKm for more details.
 	err = client.StartContainer(containerID, getDockerHostConfig())
 	if err != nil {
 		dockerLogger.Errorf("start-could not start container %s", err)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Add HostConfig option in Docker create call, to support Docker API 1.24+.
## Description

<!-- Describe your changes in detail. -->

Since Docker API 1.24+, the HostConfig option is only supported in docker create call. This patch will add the option in docker create call, while still keeps the HostConfig option in docker start call, for compatibility. Finally, we can safe remove the HostConfig option in docker start call.

See [here](https://docs.docker.com/engine/reference/api/docker_remote_api/#/v1-24-api-changes) for more details about the API changes.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2044 
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

No new test case is required, and all container related test cases are passed.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Baohua Yang baohyang@cn.ibm.com
