### PR TITLE
Re-establish the correct function of filterError

### DIFF
--- a/core/chaincode/handler.go
+++ b/core/chaincode/handler.go
@@ -1441,18 +1441,17 @@ func filterError(errFromFSMEvent error) error {
 	if errFromFSMEvent != nil {
 		if noTransitionErr, ok := errFromFSMEvent.(*fsm.NoTransitionError); ok {
 			if noTransitionErr.Err != nil {
-				// Only allow NoTransitionError's, all others are considered true error.
+				// Squash the NoTransitionError
 				return errFromFSMEvent
 			}
-			chaincodeLogger.Warningf("Ignoring NoTransitionError: %s", noTransitionErr)
+			chaincodeLogger.Debugf("Ignoring NoTransitionError: %s", noTransitionErr)
 		}
 		if canceledErr, ok := errFromFSMEvent.(*fsm.CanceledError); ok {
 			if canceledErr.Err != nil {
-				// Only allow NoTransitionError's, all others are considered true error.
+				// Squash the CanceledError
 				return canceledErr
-				//t.Error("expected only 'NoTransitionError'")
 			}
-			chaincodeLogger.Warningf("Ignoring CanceledError: %s", canceledErr)
+			chaincodeLogger.Debugf("Ignoring CanceledError: %s", canceledErr)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

A recent PR from @juliancarrivick-ibm ( #2177 ) inadvertently defeated the intended function of the filterError() function, which was to avoid error logging for benign conditions in certain cases. Unlike many other situations the PR fixed, these messages were correctly intended to be at the debug level only. This PR re-establishes the correct function (and eliminates tens of thousands of WARN messages from busywork logs), corrects the inline documentation and removes dead code that has been commented out.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Corrects a nit in PR #2177
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I have observed that the warnings no longer appear in interactive runs. This is a minor fix; I assume it will pass CI tests.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
