### PR TITLE
Removing /typings/ directory from .npmignore file

### DIFF
--- a/sdk/node/.npmignore
+++ b/sdk/node/.npmignore
@@ -2,4 +2,3 @@
 node_modules/*
 /.idea/
 /node.iml
-/typings/


### PR DESCRIPTION
## Description

This is a one line change to remove the `/typings/` directory from the .npmignore file. This change is necessary in order to have that directory and its contents published to NPM with the  `npm publish` command.
## How Has This Been Tested?

This change does not introduce any code changes.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
