### PR TITLE
Switch to Fast P256 Golang1.6 on z

### DIFF
--- a/devenv/setupRHELonZ.sh
+++ b/devenv/setupRHELonZ.sh
@@ -46,16 +46,17 @@ nohup docker daemon -g /data/docker -H tcp://0.0.0.0:2375 -H unix:///var/run/doc
 cd $HOME
 git clone http://github.com/linux-on-ibm-z/go.git
 cd go
-git checkout release-branch.go1.6
+git checkout release-branch.go1.6-p256
 
 cat > crosscompile.sh <<HEREDOC
+apt-get update -qq
 cd /tmp/home/go/src	
-yum install -y git wget tar gcc bzip2
-export GOROOT_BOOTSTRAP=/usr/local/go
+apt-get install -y golang git wget tar gcc bzip2
+export GOROOT_BOOTSTRAP=/usr/lib/go
 GOOS=linux GOARCH=s390x ./bootstrap.bash
 HEREDOC
 
-docker run --privileged --rm -ti -v $HOME:/tmp/home brunswickheads/openchain-peer /bin/bash /tmp/home/go/crosscompile.sh
+docker run --privileged --rm -ti -v $HOME:/tmp/home s390x/ubuntu /bin/bash /tmp/home/go/crosscompile.sh
 
 export GOROOT_BOOTSTRAP=$HOME/go-linux-s390x-bootstrap
 cd $HOME/go/src

--- a/images/base/scripts/common/setup.sh
+++ b/images/base/scripts/common/setup.sh
@@ -26,7 +26,20 @@ MACHINE=`uname -m`
 if [ x$MACHINE = xs390x ]
 then
    apt-get install --yes golang
-   export GOROOT="/usr/lib/go-1.6"
+   cd /usr/lib
+   git clone http://github.com/linux-on-ibm-z/go.git go-1.6a
+   cd go-1.6a/src
+   git checkout release-branch.go1.6-p256
+   export GOROOT_BOOTSTRAP=/usr/lib/go-1.6
+   ./make.bash
+   export GOROOT="/usr/lib/go-1.6a"
+   cd /usr/lib
+   rm go
+   ln -s go-1.6a go
+   cd /usr/bin/
+   rm go
+   ln ../lib/go-1.6a/bin/go
+
 elif [ x$MACHINE = xppc64 ]
 then
    echo "TODO: Add PPC support"


### PR DESCRIPTION
Golang 1.6 on z got a fast implementation of P256 ECC curve, switch.
## Motivation and Context

P256 curve was really slow, golang compiler got improved, pick the better version.
## How Has This Been Tested?

Ran behave tests
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [ ] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Volodymyr Paprotski vpaprots@ca.ibm.com
