### PR TITLE
Fix excessive logging of touch service

### DIFF
--- a/core/peer/peer.go
+++ b/core/peer/peer.go
@@ -537,7 +537,7 @@ func (p *PeerImpl) ensureConnected() {
 			}
 			p.chatWithSomePeers(delta)
 		} else {
-			peerLogger.Info("Touch service indicates no dropped connections")
+			peerLogger.Debug("Touch service indicates no dropped connections")
 		}
 		peerLogger.Debugf("Connected to: %v", getPeerAddresses(peersMsg))
 		peerLogger.Debugf("Discovery knows about: %v", allNodes)


### PR DESCRIPTION
## Description

Log level for touch service in the normal case (no dropped connections) was set to INFO, resulting in excessive logging. This PR switches it to the DEBUG level.
## Motivation and Context

Fixes #2277.
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Kostas Christidis kchristidis@us.ibm.com
