### PR TITLE
Fix #2195 - Add better logging when building flawed chaincode

### DIFF
--- a/core/container/dockercontroller/dockercontroller.go
+++ b/core/container/dockercontroller/dockercontroller.go
@@ -123,7 +123,8 @@ func (vm *DockerVM) deployImage(client *docker.Client, ccid ccintf.CCID, args []
 	}
 
 	if err := client.BuildImage(opts); err != nil {
-		dockerLogger.Error(fmt.Sprintf("Error building images: %s", err))
+		dockerLogger.Errorf("Error building images: %s", err)
+		dockerLogger.Errorf("Image Output:\n********************\n%s\n********************", outputbuf.String())
 		return err
 	}
 
@@ -246,7 +247,7 @@ func (vm *DockerVM) Destroy(ctxt context.Context, ccid ccintf.CCID, force bool, 
 	id, _ := vm.GetVMName(ccid)
 	client, err := cutil.NewDockerClient()
 	if err != nil {
-		dockerLogger.Error(fmt.Sprintf("destroy-cannot create client %s", err))
+		dockerLogger.Errorf("destroy-cannot create client %s", err)
 		return err
 	}
 	id = strings.Replace(id, ":", "_", -1)
@@ -254,7 +255,7 @@ func (vm *DockerVM) Destroy(ctxt context.Context, ccid ccintf.CCID, force bool, 
 	err = client.RemoveImageExtended(id, docker.RemoveImageOptions{Force: force, NoPrune: noprune})
 
 	if err != nil {
-		dockerLogger.Error(fmt.Sprintf("error while destroying image: %s", err))
+		dockerLogger.Errorf("error while destroying image: %s", err)
 	} else {
 		dockerLogger.Debug("Destroyed image %s", id)
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Add logging of the errors when building faulty chaincode.
Also replaced fmt.Sprintf with direct formatting in the logger.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2195
Gives a better understanding of why building failed by embedding the chaincode build log in the peer log.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Brought up a peer and attempted to deploy chaincode with a compile error. The following was output in the peer log:

```
01:12:24.227 [peer] ensureConnected -> INFO 01f Touch service indicates no dropped connections
01:12:29.185 [dockercontroller] deployImage -> ERRO 020 Error building images: The command '/bin/sh -c go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && cp src/github.com/hyperledger/fabric/peer/core.yaml $GOPATH/bin && mv $GOPATH/bin/chaincode_example02 $GOPATH/bin/0cbc73e2e86c98dcfb79243d9761b00af7f882c3c0ac1261f4b4c12956c3015c0f9a79c322447360324045eb6acd961ea3aaa427ba48e2681714bc44d30b2969' returned a non-zero code: 2
01:12:29.186 [dockercontroller] deployImage -> ERRO 021 Image Output:
********************
Step 1 : FROM hyperledger/fabric-baseimage
 ---> 2b5669336d1d
Step 2 : COPY src $GOPATH/src
 ---> Using cache
 ---> 53bdb4e86e2a
Step 3 : WORKDIR $GOPATH
 ---> Using cache
 ---> 12254136b6ec
Step 4 : RUN go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && cp src/github.com/hyperledger/fabric/peer/core.yaml $GOPATH/bin && mv $GOPATH/bin/chaincode_example02 $GOPATH/bin/0cbc73e2e86c98dcfb79243d9761b00af7f882c3c0ac1261f4b4c12956c3015c0f9a79c322447360324045eb6acd961ea3aaa427ba48e2681714bc44d30b2969
 ---> Running in a53e381e3f77
# github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02
src/github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02/chaincode_example02.go:91: syntax error: unexpected HERE at end of statement

********************
01:12:29.186 [chaincode] Launch -> ERRO 022 launchAndWaitForRegister failed Error starting container: The command '/bin/sh -c go install github.com/hyperledger/fabric/examples/chaincode/go/chaincode_example02 && cp src/github.com/hyperledger/fabric/peer/core.yaml $GOPATH/bin && mv $GOPATH/bin/chaincode_example02 $GOPATH/bin/0cbc73e2e86c98dcfb79243d9761b00af7f882c3c0ac1261f4b4c12956c3015c0f9a79c322447360324045eb6acd961ea3aaa427ba48e2681714bc44d30b2969' returned a non-zero code: 2
```
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
