### PR TITLE
Fixes issue 2278

### DIFF
--- a/tools/busywork/bin/checkAgreement
+++ b/tools/busywork/bin/checkAgreement
@@ -245,7 +245,7 @@ foreach peer [parms peers] file [parms files] {
 }
 
 waitPIDs $pids digest
-foreach pid $pids {
+foreach pid $pids peer [parms peers] file [parms files] {
     if {$digest($pid.ok)} {
         lappend goodPeers $peer
         lappend goodFiles $file
@@ -267,6 +267,8 @@ for {set i 0; set j 1} {$j < [llength $goodPeers]} {incr i; incr j} {
             "Peers [lindex $goodPeers $i] and [lindex $goodPeers $j] " \
             "disagree."
         incr errors
+    } else {
+        note {} "Peers [lindex $goodPeers $i] and [lindex $goodPeers $j] agree"
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

Supplied missing arguments to iteration over files to 'diff', and added a logging statement to make it clear what is being compared.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #2278
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Tested interactively
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Bishop Brock bcbrock@us.ibm.com
