### PR TITLE
Nominate Gabor Hosszu as a maintainer

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -5,4 +5,5 @@ Sheehan Anderson srderson sheehan@us.ibm.com
 Tamas Blummer tamasblummer tamas@digitalasset.com
 Robert Fajta rfajta robert@digitalasset.com
 Greg Haskins ghaskins ghaskins@lseg.com
+Jonathan Levi JonathanLevi jonathan@levi.name
 Gabor Hosszu gabre gabor@digitalasset.com

--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -3,5 +3,6 @@ Maintainers
 Binh Nguyen binhn binhn@us.ibm.com
 Sheehan Anderson srderson sheehan@us.ibm.com
 Tamas Blummer tamasblummer tamas@digitalasset.com
-Robert Fajta rfajta robert@digitalasset.com 
+Robert Fajta rfajta robert@digitalasset.com
 Greg Haskins ghaskins ghaskins@lseg.com
+Gabor Hosszu gabre gabor@digitalasset.com


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Nominate Gabor Hosszu @gabre as a maintainer of Hyperledger Fabric. See http://lists.hyperledger.org/pipermail/hyperledger-fabric/2016-July/000160.html for details.

Based on the rules described under the “Becoming a maintainer” section in the [CONTRIBUTING document](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md), existing maintainers should add a comment indicating if they agree with Gabor's addition as a new maintainer on the project.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
