### PR TITLE
Nominate Chris Ferris as a maintainer

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -3,5 +3,6 @@ Maintainers
 Binh Nguyen binhn binhn@us.ibm.com
 Sheehan Anderson srderson sheehan@us.ibm.com
 Tamas Blummer tamasblummer tamas@digitalasset.com
-Robert Fajta rfajta robert@digitalasset.com 
+Robert Fajta rfajta robert@digitalasset.com
 Greg Haskins ghaskins ghaskins@lseg.com
+Chris Ferris christo4ferris chrisfer@us.ibm.com


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

Nominate Chris Ferris @christo4ferris as a maintainer of Hyperledger Fabric. See http://lists.hyperledger.org/pipermail/hyperledger-fabric/2016-July/000160.html for details.

Based on the rules described under the “Becoming a maintainer” section in the [CONTRIBUTING document](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md), existing maintainers should add a comment indicating if they agree with Chris's addition as a new maintainer on the project.

Signed-off-by: Sheehan Anderson sheehan@us.ibm.com
