### PR TITLE
Get docker client from Docker Env

### DIFF
--- a/core/container/util/dockerutil.go
+++ b/core/container/util/dockerutil.go
@@ -24,6 +24,10 @@ import (
 //NewDockerClient creates a docker client
 func NewDockerClient() (client *docker.Client, err error) {
 	endpoint := viper.GetString("vm.endpoint")
+	if endpoint == "" {
+		return docker.NewClientFromEnv()
+	}
+
 	tlsenabled := viper.GetBool("vm.docker.tls.enabled")
 	if tlsenabled {
 		cert := viper.GetString("vm.docker.tls.cert.file")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

 Get a docker client from docker Env on host when `vm.endpoint` is not set.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Docker support environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_CERT_PATH. It's convenient to reuse these variables when connect to docker daemon.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

It's a small change with a standard docker api calling. No test.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:  Yaoguo Jiang  jiangyaoguo@gmail.com
