### PR TITLE
Change APT to use mirror protocol

### DIFF
--- a/scripts/provision/common.sh
+++ b/scripts/provision/common.sh
@@ -2,6 +2,16 @@
 
 # Add any logic that is common to both the peer and docker environments here
 
+# Use the mirror protocol for apt so that geographically close mirrors are automatically chosen
+source /etc/lsb-release
+
+cat <<EOF > /etc/apt/sources.list
+deb mirror://mirrors.ubuntu.com/mirrors.txt $DISTRIB_CODENAME main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt $DISTRIB_CODENAME-updates main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt $DISTRIB_CODENAME-backports main restricted universe multiverse
+deb mirror://mirrors.ubuntu.com/mirrors.txt $DISTRIB_CODENAME-security main restricted universe multiverse
+EOF
+
 apt-get update -qq
 
 # Used by CHAINTOOL


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

As part of the setup script, set APT to use the mirror protocol so that no matter where you are in the world, the closest mirror to you will be chosen.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

If you don't reside in the US it can be slow to download all the packages when building images. This will mean the best mirrors will be chosen regardless of the developer's location.
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

I have rebuilt all the docker images and they finish successfully.
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by: Julian Carrivick cjulian@au1.ibm.com
