### PR TITLE
enable node-sdk unit-tests and publish npm packages (jenkins) in CI for node sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ services:
  - docker
 env:
     - TEST_TARGET=unit-test
+    - TEST_TARGET=node-sdk-unit-tests 
     - TEST_TARGET=behave
+
 
 before_install:
 

--- a/sdk/node/Makefile
+++ b/sdk/node/Makefile
@@ -26,7 +26,9 @@ all: hfc
 hfc:
 	cp ../../protos/*.proto ./lib/protos
 	cp ../../membersrvc/protos/*.proto ./lib/protos
-	npm install && sudo npm install -g typescript && sudo npm install typings --global && typings install
+	npm ls -g | grep 'typings' || sudo npm install -g typings
+	npm ls -g | grep 'typescript' || sudo npm install -g typescript
+	npm install && typings install 
 	tsc
 	./makedoc.sh
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description

<!-- Describe your changes in detail. -->

This PR enables node sdk unit tests in CI process (Jenkins and Travis) and publishes npm packages after perform npm check on production package.json and PR's package.json version change.  Publishing npm packages to npm repo (https://www.npmjs.com/package/hfc) If any files changed in sdk/node directory or proto files changed in protos directory.  

Executing npm publish command only in jenkins x86 build merge jobs. This is to avoid duplicate attempts to npm repo from different CI machines.

Check has been added in sdk/node/Makefile to verify whether `typings` and `typescripts` packages are installed in local machine or not. If the above said packages are not installed, script installs using sudo permissions otherwise it skips (Jenkins doesn't run in sudo mode but travis require sudo permissions to install softwares)

@bramwelt @angrbrd @smithbk  please review configuration files modified in Jenkins jobs for npm node sdk. Below is the reference link: https://gerrit.hyperledger.org/r/#/c/241/
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #
#2066
## How Has This Been Tested?

<!-- If this PR does not contain a new test case, explain why. -->

<!-- Describe in detail how you tested your changes. -->

Tested these changes in Travis ans observed these changes are working as expected. Below is the reference link:
https://travis-ci.org/rameshthoomu/fabric/builds/146739863
Configuration has been added in jenkins job setup and tested this by adding a PR https://github.com/hyperledger/fabric/pull/2264

Below is the test result from Jenkins console output:

```
20:41:50 Jenkins CI node setup
20:41:51 protos/chaincode.proto
20:41:51 protos/transaction.go
20:41:51 pull request commit 959e9a3b5131e93d545351fc5c6b4b0148090871
20:41:51 Target Branch master
20:41:51 Number of files changed in sdk/node directory: 0
20:41:51 Number of Proto files changed are: 2
20:41:51   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
20:41:51                                  Dload  Upload   Total   Spent    Left  Speed
20:41:51 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   788  100   788    0     0   1477      0 --:--:-- --:--:-- --:--:--  1478
20:41:51 Version Number in Production is: 0.0.2
20:41:51 Version number in PR is: 0.0.2
20:41:51 Package Version has to change, Please run npm version <major> <minor> <patch>
```
## Checklist:

<!-- To check a box, and an 'x': [x] -->

<!-- To uncheck box, add a space: [ ] -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:thoomu@us.ibm.com
