### PR TITLE
New header for outdated doc repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,11 @@
-## Hyperledger Fabric Documentation
+# THIS REPO IS ARCHIVE AND NO LONGER VALID!!! PLEASE SEE CURRENT DOCUMENTATION AT
+ http://hyperledger-fabric.readthedocs.io/en/stable/index.html
+
+# THIS REPO IS ARCHIVE AND NO LONGER VALID!!!
+# THIS REPO IS ARCHIVE AND NO LONGER VALID!!!
+# THIS REPO IS ARCHIVE AND NO LONGER VALID!!! 
+
+Hyperledger Fabric Documentation
 The Hyperledger [fabric](https://github.com/hyperledger/fabric) is an implementation of blockchain technology, that has been collaboratively developed under the Linux Foundation's [Hyperledger Project](http://hyperledger.org). It leverages familiar and proven technologies, and offers a modular architecture that allows pluggable implementations of various function including membership services, consensus, and smart contracts (Chaincode) execution. It features powerful container technology to host any mainstream language for smart contracts development.
 
 To contribute to this documentation, create an issue for any requests for clarification or to highlight any errors, or you may fork and update the [source](https://github.com/hyperledger/fabric), and submit a pull request.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Hyperledger Fabric
-site_url: http://hyperledger-fabric.readthedocs.io
+site_url: http://openblockchain.readthedocs.io
 theme: readthedocs
-repo_url: https://github.com/hyperledger/fabric
+repo_url: https://github.com/hyperledger-archives/fabric
 site_description: 'Welcome to the Hyperledger fabric documentation'
 
 pages:


### PR DESCRIPTION
Note that archive doc repo should no longer be used

## Description
We've come across an interesting problem. Someone created a RTD site for the now defunct https://github.com/openblockchain/peer project (which is no longer a thing) but that org now redirects to github.com/hyperledger-archives/fabric and so the RTD build picks up the old archive of fabric and publishes what looks like the Fabric docs (sigh) complete will all kinds of bad, misleading and dated information.
 
While we can try to remove the redirect, the fact is that the RTD site will still stand and confuse people https://openblockchain.readthedocs.io/en/latest/
 
What I would like to do is make a pull request against the hyperledger-archives/fabric repo to update the "home page" of the docs https://github.com/hyperledger-archives/fabric/blob/master/docs/index.md to say that these docs are DEFUNCT, built from an (OLD) archive of the Hyperledger Fabric repository and to redirect to the current stable release http://hyperledger-fabric.readthedocs.io/en/stable/index.html

## Motivation and Context
Misleading cusotmers
Fixes #

## How Has This Been Tested?
Simple doc change

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:
